### PR TITLE
fix : CommonError

### DIFF
--- a/src/main/java/com/example/infinite/global/error/CommonError.java
+++ b/src/main/java/com/example/infinite/global/error/CommonError.java
@@ -15,6 +15,8 @@ public enum CommonError {
     COMMON_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "요청한 리소스를 찾을 수 없습니다."),
     COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C005", "서버 내부 오류가 발생했습니다."),
     COMMON_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "C006", "도배 방지를 위해 요청 횟수가 제한되었습니다."),
+    COMMON_INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C007", "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C008", "서버 내부 오류입니다."),
 
     // 2. Auth (인증/인가)
     AUTH_DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "A001", "이미 가입된 이메일 주소입니다."),


### PR DESCRIPTION
#3 



💡 기능 상세 내용
프로젝트 초기 환경 설정 및 공통 예외 처리 시스템 구축

[x] Java 21 가상 스레드(Virtual Threads) 활성화 및 컴파일 옵션 설정

[x] Spring Boot 4.0.0 기반의 멀티 모듈 및 의존성 환경 구축

[x] QueryDSL 5.1.0(Jakarta) 및 JPA 인프라 설정

[x] CommonError Enum을 활용한 공통 에러 코드 체계 정의

[x] GlobalExceptionHandler를 통한 전역 예외 처리 로직 구현

✅ 완료 조건 (Acceptance Criteria)
[x] ./gradlew clean build 실행 시 에러 없이 빌드 성공

[x] CommonError 내 status 필드를 HttpStatus 타입으로 적용하여 타입 안정성 확보

[x] API 호출 실패 시 ApiResponse를 통해 규격화된 에러 메시지가 반환되는지 확인

[x] GitHub develop 브랜치에 초기 설정 코드 반영 완료

🔗 기타 참고 사항
주의: Java 21 Preview 기능을 사용하므로 팀원들의 로컬 IDE SDK 설정 확인이 필요함.

CommonError에 도메인별(Auth, Chat, etc.) 에러 코드를 추가할 수 있는 구조로 설계함.

💬 커밋 메시지 예시 (이 규칙대로 날리시면 됩니다!)
Chore: 프로젝트 초기 인프라 및 Java 21 가상 스레드 설정을 완료했습니다.

Feat: GlobalExceptionHandler 및 CommonError 체계를 구축했습니다.

Fix: CommonError의 status 타입을 HttpStatus로 수정하여 빨간 줄을 해결했습니다.