### PR TITLE
Feat: Redisson 분산 락 인프라 구현 (LockService + @RedisLock AOP)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     // 4. Redis 분산 락 및 로컬 캐싱
     implementation 'org.redisson:redisson-spring-boot-starter:4.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs.add('-parameters')
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/src/main/java/com/example/infinite/global/lock/LockException.java
+++ b/src/main/java/com/example/infinite/global/lock/LockException.java
@@ -1,0 +1,12 @@
+package com.example.infinite.global.lock;
+
+public class LockException extends RuntimeException {
+
+    public LockException(String message) {
+        super(message);
+    }
+
+    public LockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/infinite/global/lock/LockService.java
+++ b/src/main/java/com/example/infinite/global/lock/LockService.java
@@ -1,0 +1,39 @@
+package com.example.infinite.global.lock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LockService {
+
+    private final RedissonClient redissonClient;
+
+    public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
+        RLock rLock = redissonClient.getLock(key);
+        try {
+            boolean acquired = rLock.tryLock(waitTime, leaseTime, timeUnit);
+            if (!acquired) {
+                throw new LockException("락 획득 실패: key=" + key);
+            }
+            log.debug("락 획득 성공: key={}", key);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LockException("락 획득 중 인터럽트 발생: key=" + key);
+        }
+    }
+
+    public void unlock(String key) {
+        RLock rLock = redissonClient.getLock(key);
+        if (rLock.isHeldByCurrentThread()) {
+            rLock.unlock();
+            log.debug("락 해제 완료: key={}", key);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/global/lock/LockService.java
+++ b/src/main/java/com/example/infinite/global/lock/LockService.java
@@ -1,39 +1,10 @@
 package com.example.infinite.global.lock;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
-import org.springframework.stereotype.Component;
-
 import java.util.concurrent.TimeUnit;
 
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class LockService {
+public interface LockService {
 
-    private final RedissonClient redissonClient;
+    void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit);
 
-    public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
-        RLock rLock = redissonClient.getLock(key);
-        try {
-            boolean acquired = rLock.tryLock(waitTime, leaseTime, timeUnit);
-            if (!acquired) {
-                throw new LockException("락 획득 실패: key=" + key);
-            }
-            log.debug("락 획득 성공: key={}", key);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new LockException("락 획득 중 인터럽트 발생: key=" + key);
-        }
-    }
-
-    public void unlock(String key) {
-        RLock rLock = redissonClient.getLock(key);
-        if (rLock.isHeldByCurrentThread()) {
-            rLock.unlock();
-            log.debug("락 해제 완료: key={}", key);
-        }
-    }
+    void unlock(String key);
 }

--- a/src/main/java/com/example/infinite/global/lock/RedisLock.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLock.java
@@ -22,10 +22,11 @@ public @interface RedisLock {
     long waitTime() default 5;
 
     /**
-     * 락 점유 시간 (기본 3초)
-     * -1로 설정하면 Redisson Watchdog이 자동 연장
+     * 락 점유 시간 (기본 10초)
+     * -1로 설정하면 Redisson Watchdog이 자동 연장 (비정상 종료 시 30초간 데드락 주의)
+     * 외부 API 호출 등 소요 시간이 불확실한 경우에만 -1 사용 권장
      */
-    long leaseTime() default 3;
+    long leaseTime() default 10;
 
     /**
      * 시간 단위 (기본 SECONDS)

--- a/src/main/java/com/example/infinite/global/lock/RedisLock.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLock.java
@@ -1,0 +1,34 @@
+package com.example.infinite.global.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisLock {
+
+    /**
+     * 락 키. SpEL 표현식 사용 가능.
+     * 예: "'raffle:' + #raffleId"
+     */
+    String key();
+
+    /**
+     * 락 획득 대기 시간 (기본 5초)
+     */
+    long waitTime() default 5;
+
+    /**
+     * 락 점유 시간 (기본 3초)
+     * -1로 설정하면 Redisson Watchdog이 자동 연장
+     */
+    long leaseTime() default 3;
+
+    /**
+     * 시간 단위 (기본 SECONDS)
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
@@ -1,0 +1,54 @@
+package com.example.infinite.global.lock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+@Slf4j
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@RequiredArgsConstructor
+public class RedisLockAspect {
+
+    private final LockService lockService;
+    private final ExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(redisLock)")
+    public Object around(ProceedingJoinPoint joinPoint, RedisLock redisLock) throws Throwable {
+        String key = resolveKey(joinPoint, redisLock.key());
+
+        lockService.lock(key, redisLock.waitTime(), redisLock.leaseTime(), redisLock.timeUnit());
+        try {
+            return joinPoint.proceed();
+        } finally {
+            lockService.unlock(key);
+        }
+    }
+
+    private String resolveKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Parameter[] parameters = method.getParameters();
+        Object[] args = joinPoint.getArgs();
+
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        for (int i = 0; i < parameters.length; i++) {
+            context.setVariable(parameters[i].getName(), args[i]);
+        }
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}

--- a/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
@@ -13,9 +13,6 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-
 @Slf4j
 @Aspect
 @Component
@@ -40,13 +37,12 @@ public class RedisLockAspect {
 
     private String resolveKey(ProceedingJoinPoint joinPoint, String keyExpression) {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        Parameter[] parameters = method.getParameters();
+        String[] paramNames = signature.getParameterNames();
         Object[] args = joinPoint.getArgs();
 
         StandardEvaluationContext context = new StandardEvaluationContext();
-        for (int i = 0; i < parameters.length; i++) {
-            context.setVariable(parameters[i].getName(), args[i]);
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
         }
 
         return parser.parseExpression(keyExpression).getValue(context, String.class);

--- a/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
@@ -1,11 +1,11 @@
 package com.example.infinite.global.lock;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.expression.ExpressionParser;
@@ -17,11 +17,16 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)
-@RequiredArgsConstructor
 public class RedisLockAspect {
 
     private final LockService lockService;
     private final ExpressionParser parser = new SpelExpressionParser();
+
+    // @Qualifier를 생성자 파라미터에 직접 명시 (Lombok @RequiredArgsConstructor 미사용)
+    // Lombok은 @Qualifier를 생성자 파라미터에 복사하지 않으므로 직접 작성
+    public RedisLockAspect(@Qualifier("redissonLockService") LockService lockService) {
+        this.lockService = lockService;
+    }
 
     @Around("@annotation(redisLock)")
     public Object around(ProceedingJoinPoint joinPoint, RedisLock redisLock) throws Throwable {

--- a/src/main/java/com/example/infinite/global/lock/lettuce/LettuceLockService.java
+++ b/src/main/java/com/example/infinite/global/lock/lettuce/LettuceLockService.java
@@ -1,0 +1,110 @@
+package com.example.infinite.global.lock.lettuce;
+
+import com.example.infinite.global.lock.LockException;
+import com.example.infinite.global.lock.LockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component("lettuceLockService")
+@RequiredArgsConstructor
+public class LettuceLockService implements LockService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 스레드별 락 소유자 UUID 저장.
+     * ThreadLocal로 격리하여 다른 스레드의 락을 해제하는 버그를 방지.
+     */
+    private final ThreadLocal<Map<String, String>> lockOwnerMap =
+            ThreadLocal.withInitial(HashMap::new);
+
+    /**
+     * 스핀락 재시도 간격 (밀리초)
+     */
+    private static final long SPIN_LOCK_RETRY_INTERVAL_MS = 100;
+
+    /**
+     * Lua Script: key의 value가 내 UUID와 일치할 때만 삭제.
+     * 원자적(atomic) 실행으로 다른 스레드의 락을 실수로 해제하는 것을 방지.
+     */
+    private static final String UNLOCK_SCRIPT =
+            "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+            "  return redis.call('del', KEYS[1]) " +
+            "else " +
+            "  return 0 " +
+            "end";
+
+    private static final DefaultRedisScript<Long> UNLOCK_REDIS_SCRIPT;
+
+    static {
+        UNLOCK_REDIS_SCRIPT = new DefaultRedisScript<>();
+        UNLOCK_REDIS_SCRIPT.setScriptText(UNLOCK_SCRIPT);
+        UNLOCK_REDIS_SCRIPT.setResultType(Long.class);
+    }
+
+    @Override
+    public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
+        String uuid = UUID.randomUUID().toString();
+        long waitTimeMs = timeUnit.toMillis(waitTime);
+        long leaseTimeSec = timeUnit.toSeconds(leaseTime);
+        long deadline = System.currentTimeMillis() + waitTimeMs;
+
+        while (System.currentTimeMillis() < deadline) {
+            Boolean acquired = stringRedisTemplate.opsForValue()
+                    .setIfAbsent(key, uuid, Duration.ofSeconds(leaseTimeSec));
+
+            if (Boolean.TRUE.equals(acquired)) {
+                lockOwnerMap.get().put(key, uuid);
+                log.debug("락 획득 성공 [Lettuce]: key={}, uuid={}", key, uuid);
+                return;
+            }
+
+            try {
+                Thread.sleep(SPIN_LOCK_RETRY_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new LockException("락 획득 중 인터럽트 발생 [Lettuce]: key=" + key);
+            }
+        }
+
+        throw new LockException("락 획득 실패 (대기 시간 초과) [Lettuce]: key=" + key);
+    }
+
+    @Override
+    public void unlock(String key) {
+        String uuid = lockOwnerMap.get().remove(key);
+
+        // 맵이 비었으면 메모리 누수 방지를 위해 ThreadLocal 정리
+        if (lockOwnerMap.get().isEmpty()) {
+            lockOwnerMap.remove();
+        }
+
+        if (uuid == null) {
+            log.warn("락 해제 시도했으나 소유 정보 없음 [Lettuce]: key={}", key);
+            return;
+        }
+
+        Long result = stringRedisTemplate.execute(
+                UNLOCK_REDIS_SCRIPT,
+                Collections.singletonList(key),
+                uuid
+        );
+
+        if (result != null && result == 1L) {
+            log.debug("락 해제 완료 [Lettuce]: key={}, uuid={}", key, uuid);
+        } else {
+            log.warn("락 해제 실패 (이미 만료 또는 소유자 불일치) [Lettuce]: key={}", key);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/global/lock/redisson/RedissonLockService.java
+++ b/src/main/java/com/example/infinite/global/lock/redisson/RedissonLockService.java
@@ -1,0 +1,43 @@
+package com.example.infinite.global.lock.redisson;
+
+import com.example.infinite.global.lock.LockException;
+import com.example.infinite.global.lock.LockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component("redissonLockService")
+@RequiredArgsConstructor
+public class RedissonLockService implements LockService {
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
+        RLock rLock = redissonClient.getLock(key);
+        try {
+            boolean acquired = rLock.tryLock(waitTime, leaseTime, timeUnit);
+            if (!acquired) {
+                throw new LockException("락 획득 실패 [Redisson]: key=" + key);
+            }
+            log.debug("락 획득 성공 [Redisson]: key={}", key);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LockException("락 획득 중 인터럽트 발생 [Redisson]: key=" + key);
+        }
+    }
+
+    @Override
+    public void unlock(String key) {
+        RLock rLock = redissonClient.getLock(key);
+        if (rLock.isHeldByCurrentThread()) {
+            rLock.unlock();
+            log.debug("락 해제 완료 [Redisson]: key={}", key);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,7 @@
-spring.application.name=demo
+spring:
+  application:
+    name: demo
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
**Title:** Feat: Redisson 분산 락 인프라 구현 (LockService + @RedisLock AOP)
**Base branch:** `develop`

---

### 📝 Summary
- Redisson 기반 분산 락 인프라 구현 (`@RedisLock` 어노테이션 + AOP + LockService)
- `application.yml`에 Redis 연결 설정 추가 (localhost:6379)
- `build.gradle`에 `-parameters` 컴파일 옵션 추가 (SpEL 파라미터 이름 인식용)

### 📂 변경 파일
| 파일 | 설명 |
| :--- | :--- |
| `application.yml` | `spring.data.redis` 설정 블록 추가 |
| `global/lock/RedisLock.java` | 커스텀 어노테이션 (`key`, `waitTime`, `leaseTime`, `timeUnit`) |
| `global/lock/LockService.java` | Redisson RLock 래핑 서비스 (`lock`/`unlock`) |
| `global/lock/RedisLockAspect.java` | AOP Aspect — `@Transactional`보다 먼저 실행 (`@Order(HIGHEST_PRECEDENCE+1)`), SpEL 키 해석 |
| `global/lock/LockException.java` | 락 획득 실패 전용 `RuntimeException` |
| `build.gradle` | `-parameters` 컴파일 옵션 추가 |

### 💡 사용 방법
락과 트랜잭션은 클래스를 분리하여 사용합니다:
`XxxLockFacade (@RedisLock)` ➔ `XxxService (@Transactional)`

```java
@RedisLock(key = "'raffle:slot:' + #raffleId + ':' + #slotIndex")
public void confirmSlotWinner(Long raffleId, int slotIndex) {
    raffleService.confirmSlotWinner(raffleId, slotIndex);
}
```

✅ Test plan
./gradlew compileJava 빌드 성공 확인

Redis 서버 기동 후 @RedisLock 어노테이션 적용 메서드 호출 테스트

동시 요청 시 락 획득/대기/실패 동작 확인