### PR TITLE
Feat/#16 raffle reservoir sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### AI Agents & Prompts
+.claude/
+260413_*.md

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:4.2.2'
+
+    // Testcontainers (Redis 통합 테스트용)
+    testImplementation 'org.testcontainers:testcontainers:1.20.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // 프로메테우스

--- a/src/main/java/com/example/infinite/domain/Raffle/Service/ReservoirSampler.java
+++ b/src/main/java/com/example/infinite/domain/Raffle/Service/ReservoirSampler.java
@@ -1,0 +1,198 @@
+package com.example.infinite.domain.Raffle.Service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservoirSampler {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // TTL: 현재 하드코딩 24시간. Phase 2에서 래플 duration 기반 동적 TTL로 교체 예정.
+    private static final Duration DEFAULT_KEY_TTL = Duration.ofDays(1);
+
+    // 중복 응모 방지 키
+    private static final String USER_ENTRY_KEY_FORMAT = "raffle:%d:user:%d";
+
+    // 슬롯별 키 (Hash Tag 적용 — Redis Cluster 대비)
+    private static final String CLOSED_KEY_FORMAT = "{raffle:%d:slot:%d}:closed";
+    private static final String COUNT_KEY_FORMAT = "{raffle:%d:slot:%d}:count";
+    private static final String CANDIDATE_KEY_FORMAT = "{raffle:%d:slot:%d}:candidate";
+
+    // Lua Script
+    private DefaultRedisScript<List> entryScript;
+    private DefaultRedisScript<List> closeSlotScript;
+
+    @PostConstruct
+    void initScripts() {
+        entryScript = new DefaultRedisScript<>();
+        entryScript.setScriptSource(new ResourceScriptSource(new ClassPathResource("redis/entry.lua")));
+        entryScript.setResultType(List.class);
+
+        closeSlotScript = new DefaultRedisScript<>();
+        closeSlotScript.setScriptSource(new ResourceScriptSource(new ClassPathResource("redis/close_slot.lua")));
+        closeSlotScript.setResultType(List.class);
+    }
+
+    /**
+     * 응모 결과를 담는 record.
+     * @param success     응모 성공 여부
+     * @param entryOrder  순번 (-1이면 슬롯 마감)
+     * @param replaced    candidate가 교체되었는지 여부
+     * @param reason      실패 사유 (성공 시 null)
+     */
+    public record EntryResult(boolean success, int entryOrder, boolean replaced, String reason) {
+        public static EntryResult rejected(String reason) {
+            return new EntryResult(false, -1, false, reason);
+        }
+        public static EntryResult entered(int order, boolean replaced) {
+            return new EntryResult(true, order, replaced, null);
+        }
+    }
+
+    /**
+     * 응모 처리.
+     * 1. 중복 응모 체크 (SETNX + TTL)
+     * 2. entry.lua 실행 (closed 확인 + INCR + 확률 판정 + 조건부 candidate SET)
+     */
+    public EntryResult enter(long raffleId, int slotIndex, long userId) {
+        // 1. 중복 응모 방지
+        String userEntryKey = String.format(USER_ENTRY_KEY_FORMAT, raffleId, userId);
+        Boolean isFirstEntry = stringRedisTemplate.opsForValue()
+                .setIfAbsent(userEntryKey, String.valueOf(slotIndex), DEFAULT_KEY_TTL);
+
+        if (Boolean.FALSE.equals(isFirstEntry)) {
+            log.debug("중복 응모 차단: raffleId={}, userId={}", raffleId, userId);
+            return EntryResult.rejected("ALREADY_ENTERED");
+        }
+
+        // 2. Lua Script 실행 (원자적)
+        String closedKey = String.format(CLOSED_KEY_FORMAT, raffleId, slotIndex);
+        String countKey = String.format(COUNT_KEY_FORMAT, raffleId, slotIndex);
+        String candidateKey = String.format(CANDIDATE_KEY_FORMAT, raffleId, slotIndex);
+
+        double rand = ThreadLocalRandom.current().nextDouble(); // 0.0 ~ 1.0
+
+        List<Long> result = stringRedisTemplate.execute(
+                entryScript,
+                Arrays.asList(closedKey, countKey, candidateKey),
+                String.valueOf(userId),
+                String.valueOf(rand)
+        );
+
+        if (result == null || result.isEmpty()) {
+            log.error("entry.lua 실행 실패: raffleId={}, slotIndex={}", raffleId, slotIndex);
+            // 중복 응모 키 롤백
+            stringRedisTemplate.delete(userEntryKey);
+            return EntryResult.rejected("SCRIPT_ERROR");
+        }
+
+        int entryOrder = result.get(0).intValue();
+        boolean replaced = result.get(1).intValue() == 1;
+
+        // 슬롯 마감으로 거절된 경우
+        if (entryOrder == -1) {
+            // 중복 응모 키 롤백 (이 슬롯에서 거절되었으므로 다음 슬롯에서 재시도 가능해야 함)
+            stringRedisTemplate.delete(userEntryKey);
+            log.debug("슬롯 마감으로 응모 거절: raffleId={}, slotIndex={}, userId={}",
+                    raffleId, slotIndex, userId);
+            return EntryResult.rejected("SLOT_CLOSED");
+        }
+
+        // count 키에 첫 생성 시 TTL 설정
+        if (entryOrder == 1) {
+            stringRedisTemplate.expire(countKey, DEFAULT_KEY_TTL);
+            stringRedisTemplate.expire(candidateKey, DEFAULT_KEY_TTL);
+        }
+
+        log.debug("응모 성공: raffleId={}, slotIndex={}, userId={}, order={}, replaced={}",
+                raffleId, slotIndex, userId, entryOrder, replaced);
+        return EntryResult.entered(entryOrder, replaced);
+    }
+
+    /**
+     * 슬롯 종료 처리 (스케줄러 호출).
+     * close_slot.lua를 실행하여 원자적으로 슬롯을 닫고 최종 후보/참여자 수를 읽는다.
+     */
+    public SlotCloseResult closeSlot(long raffleId, int slotIndex) {
+        String closedKey = String.format(CLOSED_KEY_FORMAT, raffleId, slotIndex);
+        String candidateKey = String.format(CANDIDATE_KEY_FORMAT, raffleId, slotIndex);
+        String countKey = String.format(COUNT_KEY_FORMAT, raffleId, slotIndex);
+
+        List<Object> result = stringRedisTemplate.execute(
+                closeSlotScript,
+                Arrays.asList(closedKey, candidateKey, countKey)
+        );
+
+        if (result == null || result.isEmpty()) {
+            log.error("close_slot.lua 실행 실패: raffleId={}, slotIndex={}", raffleId, slotIndex);
+            return new SlotCloseResult(null, 0);
+        }
+
+        String candidate = result.get(0) instanceof String s && !s.isEmpty() ? s : null;
+        int count = result.get(1) instanceof Long l ? l.intValue() : 0;
+
+        log.info("슬롯 종료: raffleId={}, slotIndex={}, candidate={}, count={}",
+                raffleId, slotIndex, candidate, count);
+        return new SlotCloseResult(candidate, count);
+    }
+
+    /**
+     * 슬롯 종료 결과.
+     * @param candidateUserId 최종 당첨 후보 userId (참여자 없으면 null)
+     * @param totalEntries    총 참여자 수
+     */
+    public record SlotCloseResult(String candidateUserId, int totalEntries) {
+        public boolean isEmpty() {
+            return candidateUserId == null || totalEntries == 0;
+        }
+    }
+
+    /**
+     * 슬롯 관련 Redis 키 정리 (슬롯 종료 후 호출).
+     * 스케줄러가 DB 쓰기 완료 후 호출한다.
+     * TTL이 보험으로 걸려 있으므로, 이 메서드가 호출되지 않아도 키는 만료된다.
+     */
+    public void cleanupSlotKeys(long raffleId, int slotIndex) {
+        String closedKey = String.format(CLOSED_KEY_FORMAT, raffleId, slotIndex);
+        String countKey = String.format(COUNT_KEY_FORMAT, raffleId, slotIndex);
+        String candidateKey = String.format(CANDIDATE_KEY_FORMAT, raffleId, slotIndex);
+
+        stringRedisTemplate.unlink(Arrays.asList(closedKey, countKey, candidateKey));
+        log.debug("슬롯 키 정리 완료: raffleId={}, slotIndex={}", raffleId, slotIndex);
+    }
+
+    /**
+     * Reservoir Sampling 확률 판정 (k=1) — 단위 테스트 전용 순수 함수.
+     *
+     * 실제 응모 경로에서는 이 메서드를 사용하지 않는다.
+     * entry.lua 내부에서 동일한 로직이 원자적으로 실행된다.
+     *
+     * 이 메서드가 존재하는 이유:
+     * - Lua Script 내부의 확률 로직을 Java로 미러링하여 Redis 없이 10만 회 시뮬레이션으로
+     *   1/n 균등 분포 수렴을 통계적으로 검증하기 위함.
+     * - Lua 코드의 수학적 정확성에 대한 신뢰 근거를 제공한다.
+     */
+    boolean shouldReplace(int count) {
+        if (count <= 0) {
+            throw new IllegalArgumentException("count는 1 이상이어야 합니다: " + count);
+        }
+        if (count == 1) {
+            return true;
+        }
+        return ThreadLocalRandom.current().nextInt(count) == 0;
+    }
+}

--- a/src/main/resources/redis/close_slot.lua
+++ b/src/main/resources/redis/close_slot.lua
@@ -10,7 +10,7 @@
 -- 반환값: {candidate(string), count(int)}
 --   candidate가 없으면 빈 문자열 ''
 
-redis.call('SET', KEYS[1], 1)
+redis.call('SET', KEYS[1], 1, 'EX', 86400)
 
 local candidate = redis.call('GET', KEYS[2])
 local count = redis.call('GET', KEYS[3])

--- a/src/main/resources/redis/close_slot.lua
+++ b/src/main/resources/redis/close_slot.lua
@@ -1,0 +1,18 @@
+-- close_slot.lua
+-- 슬롯 종료: closed 플래그 세우기 + candidate/count 최종 읽기
+-- 응모 Lua(entry.lua)와 이 스크립트는 Redis 명령 큐에서 반드시 직렬화된다.
+-- 네트워크 역전과 무관하게 정합성이 보장된다.
+--
+-- KEYS[1] = {raffle:{id}:slot:{index}}:closed
+-- KEYS[2] = {raffle:{id}:slot:{index}}:candidate
+-- KEYS[3] = {raffle:{id}:slot:{index}}:count
+--
+-- 반환값: {candidate(string), count(int)}
+--   candidate가 없으면 빈 문자열 ''
+
+redis.call('SET', KEYS[1], 1)
+
+local candidate = redis.call('GET', KEYS[2])
+local count = redis.call('GET', KEYS[3])
+
+return {candidate or '', tonumber(count) or 0}

--- a/src/main/resources/redis/entry.lua
+++ b/src/main/resources/redis/entry.lua
@@ -1,0 +1,30 @@
+-- entry.lua
+-- 응모 처리: closed 확인 + INCR + Reservoir Sampling 확률 판정 + 조건부 candidate SET
+-- 이 스크립트가 실행되는 동안 Redis는 다른 명령을 처리하지 않는다 (원자적).
+--
+-- KEYS[1] = {raffle:{id}:slot:{index}}:closed
+-- KEYS[2] = {raffle:{id}:slot:{index}}:count
+-- KEYS[3] = {raffle:{id}:slot:{index}}:candidate
+-- ARGV[1] = userId (문자열)
+-- ARGV[2] = JVM에서 생성한 0.0~1.0 사이의 난수 (문자열)
+--
+-- 반환값: {순번(int), candidate갱신여부(0or1)}
+--   순번 = -1 이면 슬롯 마감으로 응모 거절
+
+-- 1. 슬롯 마감 여부 확인
+local closed = redis.call('GET', KEYS[1])
+if closed then
+    return {-1, 0}
+end
+
+-- 2. 순번 획득 (원자적 증가)
+local i = redis.call('INCR', KEYS[2])
+
+-- 3. Reservoir Sampling 확률 판정 (1/i 확률로 교체)
+local rand = tonumber(ARGV[2])
+if rand < (1 / i) then
+    redis.call('SET', KEYS[3], ARGV[1])
+    return {i, 1}
+end
+
+return {i, 0}

--- a/src/main/resources/redis/entry.lua
+++ b/src/main/resources/redis/entry.lua
@@ -23,7 +23,7 @@ local i = redis.call('INCR', KEYS[2])
 -- 3. Reservoir Sampling 확률 판정 (1/i 확률로 교체)
 local rand = tonumber(ARGV[2])
 if rand < (1 / i) then
-    redis.call('SET', KEYS[3], ARGV[1])
+    redis.call('SET', KEYS[3], ARGV[1], 'KEEPTTL')
     return {i, 1}
 end
 

--- a/src/test/java/com/example/infinite/domain/Raffle/ReservoirSamplerIntegrationTest.java
+++ b/src/test/java/com/example/infinite/domain/Raffle/ReservoirSamplerIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.example.infinite.domain.Raffle;
+
+import com.example.infinite.domain.Raffle.Service.ReservoirSampler;
+import com.example.infinite.domain.Raffle.Service.ReservoirSampler.EntryResult;
+import com.example.infinite.domain.Raffle.Service.ReservoirSampler.SlotCloseResult;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Testcontainers
+class ReservoirSamplerIntegrationTest {
+
+    @Container
+    static GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Autowired
+    private ReservoirSampler sampler;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    // ──────────── 단일 스레드 기본 동작 ────────────
+
+    @Test
+    @DisplayName("응모 시 순번이 순차 증가하고 후보가 존재한다")
+    void singleThreadEntry() {
+        long raffleId = 1L;
+        int slotIndex = 0;
+
+        for (long userId = 1; userId <= 10; userId++) {
+            EntryResult result = sampler.enter(raffleId, slotIndex, userId);
+            assertThat(result.success()).isTrue();
+            assertThat(result.entryOrder()).isEqualTo((int) userId);
+        }
+
+        SlotCloseResult closeResult = sampler.closeSlot(raffleId, slotIndex);
+        assertThat(closeResult.totalEntries()).isEqualTo(10);
+        assertThat(closeResult.candidateUserId()).isNotNull();
+        long candidateId = Long.parseLong(closeResult.candidateUserId());
+        assertThat(candidateId).isBetween(1L, 10L);
+    }
+
+    @Test
+    @DisplayName("중복 응모 시 ALREADY_ENTERED로 거절된다")
+    void duplicateEntryBlocked() {
+        long raffleId = 2L;
+        int slotIndex = 0;
+        long userId = 100L;
+
+        EntryResult first = sampler.enter(raffleId, slotIndex, userId);
+        EntryResult second = sampler.enter(raffleId, slotIndex, userId);
+
+        assertThat(first.success()).isTrue();
+        assertThat(second.success()).isFalse();
+        assertThat(second.reason()).isEqualTo("ALREADY_ENTERED");
+    }
+
+    // ──────────── 슬롯 마감 원자성 ────────────
+
+    @Test
+    @DisplayName("슬롯 마감 후 응모 요청은 SLOT_CLOSED로 거절된다")
+    void entryAfterSlotClosed() {
+        long raffleId = 3L;
+        int slotIndex = 0;
+
+        sampler.enter(raffleId, slotIndex, 1L);
+        sampler.enter(raffleId, slotIndex, 2L);
+
+        // 슬롯 마감
+        SlotCloseResult closeResult = sampler.closeSlot(raffleId, slotIndex);
+        assertThat(closeResult.totalEntries()).isEqualTo(2);
+
+        // 마감 후 응모 시도
+        EntryResult late = sampler.enter(raffleId, slotIndex, 3L);
+        assertThat(late.success()).isFalse();
+        assertThat(late.reason()).isEqualTo("SLOT_CLOSED");
+    }
+
+    @Test
+    @DisplayName("빈 슬롯 마감 시 후보가 없고 참여자 수가 0이다")
+    void emptySlotClose() {
+        long raffleId = 4L;
+        int slotIndex = 0;
+
+        SlotCloseResult result = sampler.closeSlot(raffleId, slotIndex);
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.candidateUserId()).isNull();
+        assertThat(result.totalEntries()).isEqualTo(0);
+    }
+
+    // ──────────── 동시성 검증 ────────────
+
+    @Test
+    @DisplayName("100개 스레드 동시 응모 시 카운터 정합성이 유지된다")
+    void concurrentEntries() throws InterruptedException {
+        long raffleId = 5L;
+        int slotIndex = 0;
+        int threadCount = 100;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i + 1;
+            executor.submit(() -> {
+                try {
+                    barrier.await();
+                    EntryResult result = sampler.enter(raffleId, slotIndex, userId);
+                    if (result.success()) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        executor.shutdown();
+        assertThat(executor.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+        // 모든 유저가 서로 다른 userId이므로 전원 응모 성공
+        assertThat(successCount.get()).isEqualTo(threadCount);
+
+        // Lua INCR은 원자적이므로 카운터는 정확히 threadCount
+        SlotCloseResult closeResult = sampler.closeSlot(raffleId, slotIndex);
+        assertThat(closeResult.totalEntries()).isEqualTo(threadCount);
+        assertThat(closeResult.candidateUserId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("동일 유저가 여러 스레드에서 동시 응모해도 1회만 성공한다")
+    void concurrentDuplicateEntry() throws InterruptedException {
+        long raffleId = 6L;
+        int slotIndex = 0;
+        long userId = 999L;
+        int threadCount = 50;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    barrier.await();
+                    EntryResult result = sampler.enter(raffleId, slotIndex, userId);
+                    if (result.success()) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        // SETNX 원자성에 의해 정확히 1회만 성공
+        assertThat(successCount.get()).isEqualTo(1);
+    }
+
+    // ──────────── 키 정리 ────────────
+
+    @Test
+    @DisplayName("cleanupSlotKeys 호출 후 슬롯 관련 키가 삭제된다")
+    void cleanupSlotKeys() {
+        long raffleId = 7L;
+        int slotIndex = 0;
+
+        sampler.enter(raffleId, slotIndex, 1L);
+        sampler.closeSlot(raffleId, slotIndex);
+
+        // 정리 전: 키 존재
+        assertThat(stringRedisTemplate.hasKey("{raffle:7:slot:0}:closed")).isTrue();
+
+        // 정리
+        sampler.cleanupSlotKeys(raffleId, slotIndex);
+
+        // 정리 후: 키 삭제됨
+        assertThat(stringRedisTemplate.hasKey("{raffle:7:slot:0}:closed")).isFalse();
+        assertThat(stringRedisTemplate.hasKey("{raffle:7:slot:0}:count")).isFalse();
+        assertThat(stringRedisTemplate.hasKey("{raffle:7:slot:0}:candidate")).isFalse();
+    }
+}

--- a/src/test/java/com/example/infinite/domain/Raffle/Service/ReservoirSamplerUnitTest.java
+++ b/src/test/java/com/example/infinite/domain/Raffle/Service/ReservoirSamplerUnitTest.java
@@ -1,0 +1,86 @@
+package com.example.infinite.domain.Raffle.Service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ReservoirSamplerUnitTest {
+
+    // Redis 의존성 없이 순수 로직만 테스트
+    private final ReservoirSampler sampler = new ReservoirSampler(null);
+
+    @Test
+    @DisplayName("첫 번째 참여자는 무조건 후보로 선정된다")
+    void firstParticipantAlwaysSelected() {
+        for (int i = 0; i < 1_000; i++) {
+            assertThat(sampler.shouldReplace(1)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("count가 0 이하이면 예외가 발생한다")
+    void invalidCountThrowsException() {
+        assertThatThrownBy(() -> sampler.shouldReplace(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> sampler.shouldReplace(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Reservoir Sampling은 모든 참여자에게 균등한 확률(1/n)을 보장한다 (n=100)")
+    void uniformDistribution_n100() {
+        int n = 100;
+        int simulations = 100_000;
+        int[] selectionCount = new int[n];
+
+        for (int sim = 0; sim < simulations; sim++) {
+            int candidate = 0;
+            for (int i = 1; i < n; i++) {
+                if (sampler.shouldReplace(i + 1)) {
+                    candidate = i;
+                }
+            }
+            selectionCount[candidate]++;
+        }
+
+        double expected = 1.0 / n;
+        double tolerance = 0.02;
+
+        for (int i = 0; i < n; i++) {
+            double actual = (double) selectionCount[i] / simulations;
+            assertThat(actual)
+                    .as("참여자 %d의 선정 확률: 기대=%.4f, 실제=%.4f", i, expected, actual)
+                    .isBetween(expected - tolerance, expected + tolerance);
+        }
+    }
+
+    @Test
+    @DisplayName("참여자 수가 늘어나도 균등 분포가 유지된다 (n=1000)")
+    void uniformDistribution_n1000() {
+        int n = 1_000;
+        int simulations = 100_000;
+        int[] selectionCount = new int[n];
+
+        for (int sim = 0; sim < simulations; sim++) {
+            int candidate = 0;
+            for (int i = 1; i < n; i++) {
+                if (sampler.shouldReplace(i + 1)) {
+                    candidate = i;
+                }
+            }
+            selectionCount[candidate]++;
+        }
+
+        double expected = 1.0 / n;
+        double tolerance = 0.005;
+
+        int[] sampleIndices = {0, 99, 250, 499, 500, 750, 900, 950, 998, 999};
+        for (int idx : sampleIndices) {
+            double actual = (double) selectionCount[idx] / simulations;
+            assertThat(actual)
+                    .as("참여자 %d의 선정 확률 (n=%d)", idx, n)
+                    .isBetween(expected - tolerance, expected + tolerance);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
Closes #16 

래플 응모의 핵심 연산을 Redis Lua Script로 원자화하여 구현하고,
확률 분포 검증(단위) + 동시성 검증(통합) 테스트를 작성했습니다.

## 변경 사항
### 신규 파일
- `src/main/resources/redis/entry.lua` — 응모 Lua Script
- `src/main/resources/redis/close_slot.lua` — 슬롯 종료 Lua Script
- `domain/Raffle/Service/ReservoirSampler.java` — Lua Script 호출 서비스
- `test/.../ReservoirSamplerUnitTest.java` — 확률 분포 검증 (Redis 불필요)
- `test/.../ReservoirSamplerIntegrationTest.java` — Lua + 동시성 검증 (Testcontainers)

### 수정 파일
- `build.gradle` — Testcontainers 의존성 추가

## 핵심 설계
1. **Lua Script 원자화**: closed 확인 + INCR + 확률 판정 + SET candidate를 하나의 EVAL로 실행.
   Java 별개 호출 시 스케줄러와 네트워크 역전으로 정합성 붕괴 가능 → Lua로 구조적 차단.
2. **SETNX 분리**: 중복 응모 키와 슬롯 키의 Hash Tag가 달라 CROSSSLOT 방지를 위해 Java 영역에서 처리.
   슬롯 마감 거절 시 중복 응모 키 롤백 (Saga 패턴).
3. **KEEPTTL**: candidate 교체 시 기존 TTL 소멸 방어.
4. **JVM 난수 생성**: Redis 복제 정합성 보장 + 테스트 시 결정적 값 주입 가능.

## 테스트 전략
- **단위 테스트 (A)**: shouldReplace()의 수학적 정확성을 10만 회 시뮬레이션으로 통계 검증.
  Lua 내부 확률 로직의 정확성에 대한 간접 근거. Redis 불필요하므로 CI에서 빠르게 실행.
- **통합 테스트 (B)**: Testcontainers Redis에서 Lua Script 실행 + ExecutorService/CyclicBarrier로
  동시성 시나리오 검증. 실패 시 원인이 알고리즘이 아닌 Redis 연동 문제임을 특정 가능.