### PR TITLE
Feat/#20 payment entity repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### AI Agents & Prompts
 .claude/
 260413_*.md
+
+### Local environment (contains credentials)
+src/main/resources/application-local.yml

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/AutoChargeSetting.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/AutoChargeSetting.java
@@ -1,0 +1,59 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "auto_charge_settings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE auto_charge_settings SET deleted_at = current_timestamp WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class AutoChargeSetting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "billing_key_id", nullable = false)
+    private BillingKey billingKey;
+
+    @Column(nullable = false)
+    private Integer jellyAmount; // 자동충전 젤리 수량
+
+    @Column(nullable = false)
+    private Integer thresholdBalance; // 잔액이 이 값 이하로 떨어지면 자동충전 트리거
+
+    @Column(nullable = false)
+    private boolean enabled; // 자동충전 활성 여부
+
+    @Builder
+    public AutoChargeSetting(Long userId, BillingKey billingKey,
+                             Integer jellyAmount, Integer thresholdBalance) {
+        this.userId = userId;
+        this.billingKey = billingKey;
+        this.jellyAmount = jellyAmount;
+        this.thresholdBalance = thresholdBalance;
+        this.enabled = true;
+    }
+
+    public void update(BillingKey billingKey, Integer jellyAmount, Integer thresholdBalance) {
+        this.billingKey = billingKey;
+        this.jellyAmount = jellyAmount;
+        this.thresholdBalance = thresholdBalance;
+    }
+
+    public void disable() {
+        this.enabled = false;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/BillingKey.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/BillingKey.java
@@ -1,0 +1,52 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "billing_keys")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE billing_keys SET deleted_at = current_timestamp WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class BillingKey extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String billingKey; // PortOne에서 발급된 빌링키
+
+    @Column(nullable = false, length = 20)
+    private String cardName; // 카드사명 (예: 신한, 국민)
+
+    @Column(nullable = false, length = 10)
+    private String cardLast4; // 카드 끝 4자리
+
+    @Column(nullable = false)
+    private boolean defaultCard; // 대표 카드 여부
+
+    @Builder
+    public BillingKey(Long userId, String billingKey,
+                      String cardName, String cardLast4, boolean defaultCard) {
+        this.userId = userId;
+        this.billingKey = billingKey;
+        this.cardName = cardName;
+        this.cardLast4 = cardLast4;
+        this.defaultCard = defaultCard;
+    }
+
+    public void setDefault(boolean defaultCard) {
+        this.defaultCard = defaultCard;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/DmSubscription.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/DmSubscription.java
@@ -1,0 +1,64 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.domain.Payment.Enums.SubscriptionStatus;
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "dm_subscriptions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE dm_subscriptions SET deleted_at = current_timestamp WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class DmSubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long artistId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SubscriptionStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Builder
+    public DmSubscription(Long userId, Long artistId, LocalDateTime startedAt, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.artistId = artistId;
+        this.status = SubscriptionStatus.ACTIVE;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+    }
+
+    public void cancel() {
+        this.status = SubscriptionStatus.CANCELLED;
+    }
+
+    public boolean isActive() {
+        return this.status == SubscriptionStatus.ACTIVE
+                && LocalDateTime.now().isBefore(this.expiredAt);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/JellyTransaction.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/JellyTransaction.java
@@ -1,0 +1,52 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.domain.Payment.Enums.ReferenceType;
+import com.example.infinite.domain.Payment.Enums.TransactionType;
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "jelly_transactions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JellyTransaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReferenceType referenceType;
+
+    private Long relatedId; // 관련 엔티티 ID (결제ID, 구독ID 등)
+
+    @Column(nullable = false)
+    private Integer amount; // 항상 양수, 방향은 type으로 구분
+
+    @Column(nullable = false)
+    private Integer balanceAfter; // 거래 후 잔액 스냅샷
+
+    @Builder
+    public JellyTransaction(Long userId, TransactionType type,
+                            ReferenceType referenceType, Long relatedId,
+                            Integer amount, Integer balanceAfter) {
+        this.userId = userId;
+        this.type = type;
+        this.referenceType = referenceType;
+        this.relatedId = relatedId;
+        this.amount = amount;
+        this.balanceAfter = balanceAfter;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/UserJellyBalance.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/UserJellyBalance.java
@@ -1,0 +1,41 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_jelly_balances")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserJellyBalance {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer currentBalance;
+
+    public UserJellyBalance(Long userId) {
+        this.userId = userId;
+        this.currentBalance = 0;
+    }
+
+    public void charge(int amount) {
+        this.currentBalance += amount;
+    }
+
+    public void use(int amount) {
+        if (this.currentBalance < amount) {
+            throw new PaymentException(ErrorCode.JELLY_INSUFFICIENT_BALANCE);
+        }
+        this.currentBalance -= amount;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Enums/ReferenceType.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Enums/ReferenceType.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.Payment.Enums;
+
+public enum ReferenceType {
+    PAYMENT,      // PortOne 결제
+    DM_SUB,       // DM 구독권
+    MEMBERSHIP    // 팬 멤버십
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Enums/SubscriptionStatus.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Enums/SubscriptionStatus.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.Payment.Enums;
+
+public enum SubscriptionStatus {
+    ACTIVE,       // 구독 활성
+    EXPIRED,      // 기간 만료
+    CANCELLED     // 유저 해지
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Enums/TransactionType.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Enums/TransactionType.java
@@ -1,0 +1,9 @@
+package com.example.infinite.domain.Payment.Enums;
+
+public enum TransactionType {
+    CHARGE,       // 젤리 충전 (결제)
+    USE,          // 젤리 사용 (구독/멤버십 등)
+    REWARD,       // 젤리 지급 (이벤트/보상)
+    REFUND,       // 환불로 인한 젤리 반환
+    EXPIRED       // 유효기간 만료 소멸
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/AutoChargeSettingRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/AutoChargeSettingRepository.java
@@ -1,0 +1,11 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.AutoChargeSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AutoChargeSettingRepository extends JpaRepository<AutoChargeSetting, Long> {
+
+    Optional<AutoChargeSetting> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/BillingKeyRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/BillingKeyRepository.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.BillingKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BillingKeyRepository extends JpaRepository<BillingKey, Long> {
+
+    List<BillingKey> findByUserId(Long userId);
+
+    Optional<BillingKey> findByUserIdAndDefaultCardTrue(Long userId);
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/DmSubscriptionRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/DmSubscriptionRepository.java
@@ -1,0 +1,16 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.DmSubscription;
+import com.example.infinite.domain.Payment.Enums.SubscriptionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DmSubscriptionRepository extends JpaRepository<DmSubscription, Long> {
+
+    Optional<DmSubscription> findByUserIdAndArtistIdAndStatus(Long userId, Long artistId, SubscriptionStatus status);
+
+    Page<DmSubscription> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/JellyTransactionRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/JellyTransactionRepository.java
@@ -1,0 +1,11 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.JellyTransaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JellyTransactionRepository extends JpaRepository<JellyTransaction, Long> {
+
+    Page<JellyTransaction> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/UserJellyBalanceRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/UserJellyBalanceRepository.java
@@ -1,0 +1,17 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.UserJellyBalance;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserJellyBalanceRepository extends JpaRepository<UserJellyBalance, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM UserJellyBalance b WHERE b.userId = :userId")
+    Optional<UserJellyBalance> findByUserIdForUpdate(@Param("userId") Long userId);
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/infineat?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: Alsry921!@
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    open-in-view: false
+
+  security:
+    user:
+      name: test
+      password: test


### PR DESCRIPTION
  ## 💡 기능 상세 내용                                                                                                                                           
  젤리(Jelly) 충전·사용·구독·환불 흐름에 필요한 결제 도메인의 Entity, Enum, Repository를 구현합니다.                                                             
                                                                                                                                                                 
  - [x] `TransactionType` Enum 생성 (CHARGE, USE, REWARD, REFUND, EXPIRED)
  - [x] `ReferenceType` Enum 생성 (PAYMENT, DM_SUB, MEMBERSHIP)
  - [x] `SubscriptionStatus` Enum 생성 (ACTIVE, EXPIRED, CANCELLED)
  - [x] `JellyTransaction` 엔티티 생성 (거래 원장)
  - [x] `UserJellyBalance` 엔티티 생성 (잔액 캐시 테이블, 비관적 락 쿼리 포함)
  - [x] `BillingKey` 엔티티 생성 (PortOne 정기결제 카드 정보)
  - [x] `AutoChargeSetting` 엔티티 생성 (자동충전 플랜 설정)
  - [x] `DmSubscription` 엔티티 생성 (DM 구독권)
  - [ ] `FanMembership` 엔티티 생성 - 후속 PR 예정
  - [x] 각 엔티티에 대응하는 Repository 생성
  - [x] application-local.yml .gitignore 추가 (보안)

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] 모든 Entity가 `BaseEntity`를 상속하고 `@SQLDelete` / `@SQLRestriction` soft delete 적용됨
  - [x] `UserJellyBalanceRepository`에 `@Lock(PESSIMISTIC_WRITE)` 쿼리 메서드 포함
  - [ ] `FanMembership` 포함 전체 기동 확인 - 후속 PR 예정

  ## 🔗 기타 참고 사항
  - 패키지 경로: `com.example.infinite.domain.Payment`
  - 비관적 락 전략 적용 대상: `UserJellyBalance` 잔액 조작 한정
  - `FanMembership`은 팀원 이슈로 인해 다음 PR에서 완료 예정