### PR TITLE
Feat: Payment 도메인 Entity 설계 변경 반영 및 AutoChargeHistory 추가 (#24)

### DIFF
--- a/src/main/java/com/example/infinite/domain/Payment/Entity/AutoChargeHistory.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/AutoChargeHistory.java
@@ -1,0 +1,49 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "auto_charge_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE auto_charge_histories SET deleted_at = current_timestamp WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class AutoChargeHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "billing_key_id", nullable = false)
+    private BillingKey billingKey; // 자동충전에 사용된 카드
+
+    @Column(nullable = false)
+    private Integer jellyAmount; // 충전된 젤리 수량
+
+    @Column(nullable = false)
+    private boolean success; // 자동충전 성공 여부
+
+    @Column
+    private String failReason; // 실패 사유 (성공 시 null)
+
+    @Builder
+    public AutoChargeHistory(Long userId, BillingKey billingKey,
+                             Integer jellyAmount, boolean success, String failReason) {
+        this.userId = userId;
+        this.billingKey = billingKey;
+        this.jellyAmount = jellyAmount;
+        this.success = success;
+        this.failReason = failReason;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/FanMembership.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/FanMembership.java
@@ -1,0 +1,66 @@
+package com.example.infinite.domain.Payment.Entity;
+
+import com.example.infinite.domain.Payment.Enums.SubscriptionStatus;
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "fan_memberships")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE fan_memberships SET deleted_at = current_timestamp WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class FanMembership extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long artistId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SubscriptionStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Builder
+    public FanMembership(Long userId, Long artistId,
+                         LocalDateTime startedAt, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.artistId = artistId;
+        this.status = SubscriptionStatus.ACTIVE;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+    }
+
+    public void cancel() {
+        this.status = SubscriptionStatus.CANCELLED;
+    }
+
+    public boolean isActive() {
+        // 상태가 ACTIVE이고 만료일이 지나지 않은 경우에만 유효
+        return this.status == SubscriptionStatus.ACTIVE
+                && LocalDateTime.now().isBefore(this.expiredAt);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Entity/UserJellyBalance.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Entity/UserJellyBalance.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "user_jelly_balances")
+@Table(name = "user_jelly_wallet")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserJellyBalance {
 

--- a/src/main/java/com/example/infinite/domain/Payment/Enums/TransactionType.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Enums/TransactionType.java
@@ -1,9 +1,8 @@
 package com.example.infinite.domain.Payment.Enums;
 
 public enum TransactionType {
-    CHARGE,       // 젤리 충전 (결제)
-    USE,          // 젤리 사용 (구독/멤버십 등)
-    REWARD,       // 젤리 지급 (이벤트/보상)
-    REFUND,       // 환불로 인한 젤리 반환
-    EXPIRED       // 유효기간 만료 소멸
+    CHARGE,   // 젤리 충전 (결제)
+    USE,      // 젤리 사용 (구독/멤버십 등)
+    REFUND    // 환불로 인한 젤리 반환
+    // REWARD, EXPIRED 는 추후 래플/소멸 기능 추가 시 팀장 확인 후 반영 예정
 }

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/AutoChargeHistoryRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/AutoChargeHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.AutoChargeHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AutoChargeHistoryRepository extends JpaRepository<AutoChargeHistory, Long> {
+
+    // 유저의 자동충전 실행 이력 페이징 조회
+    Page<AutoChargeHistory> findByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Repository/FanMembershipRepository.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Repository/FanMembershipRepository.java
@@ -1,0 +1,18 @@
+package com.example.infinite.domain.Payment.Repository;
+
+import com.example.infinite.domain.Payment.Entity.FanMembership;
+import com.example.infinite.domain.Payment.Enums.SubscriptionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FanMembershipRepository extends JpaRepository<FanMembership, Long> {
+
+    // 특정 아티스트에 대한 유저의 활성 멤버십 조회
+    Optional<FanMembership> findByUserIdAndArtistIdAndStatus(Long userId, Long artistId, SubscriptionStatus status);
+
+    // 유저의 멤버십 전체 이력 페이징 조회
+    Page<FanMembership> findByUserId(Long userId, Pageable pageable);
+}


### PR DESCRIPTION
  ## 💡 기능 상세 내용
  팀 설계 변경사항 및 누락된 Entity를 반영합니다.

  - [x] `UserJellyBalance` 테이블명 변경 (`user_jelly_balances` → `jelly_wallet`)
  - [x] `TransactionType` Enum 축소 (REWARD, EXPIRED 제거 → CHARGE, USE, REFUND 3개)
  - [x] `AutoChargeHistory` 엔티티 생성 (자동충전 실행 이력)
  - [x] `AutoChargeHistoryRepository` 생성
  - [x] `FanMembership` 엔티티 및 Repository 생성 (이전 PR 미완료 항목)

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] 변경된 테이블명으로 애플리케이션 정상 기동 확인
  - [x] TransactionType이 3개로 정리됨
  - [x] AutoChargeHistory 테이블 정상 생성 확인

  ## 🔗 기타 참고 사항
  - #20 PR 머지 후 설계 변경사항 반영
  - REWARD, EXPIRED 추후 추가 여부는 팀장 확인 필요
  - close #24