### PR TITLE
Feat: JellyService 구현 (젤리 충전/사용/환불/잔액조회/이력조회) (#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // 4. Redis 분산 락 및 로컬 캐싱
     implementation 'org.redisson:redisson-spring-boot-starter:4.0.0'

--- a/src/main/java/com/example/infinite/DemoApplication.java
+++ b/src/main/java/com/example/infinite/DemoApplication.java
@@ -2,8 +2,10 @@ package com.example.infinite;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class DemoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/infinite/domain/Payment/Config/JellyProperties.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Config/JellyProperties.java
@@ -1,0 +1,11 @@
+package com.example.infinite.domain.Payment.Config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jelly")
+public record JellyProperties(
+        int pricePerUnit,       // 1젤리 = 300원
+        int fanMembershipCost,  // 팬 멤버십 = 9젤리
+        int dmSubscriptionCost  // DM 구독권 = 15젤리
+) {
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Controller/JellyController.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Controller/JellyController.java
@@ -1,0 +1,40 @@
+package com.example.infinite.domain.Payment.Controller;
+
+import com.example.infinite.domain.Payment.Dto.Response.JellyBalance;
+import com.example.infinite.domain.Payment.Dto.Response.JellyHistory;
+import com.example.infinite.domain.Payment.Service.JellyService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.common.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payment/v1/jelly")
+public class JellyController {
+
+    private final JellyService jellyService;
+
+    // 젤리 잔액 조회
+    @GetMapping("/balance")
+    public ApiResponse<JellyBalance> getBalance(
+            @RequestHeader("X-User-Id") Long userId) {
+        return ApiResponse.success(jellyService.getBalance(userId));
+    }
+
+    // 젤리 거래 이력 조회 (최신순, 기본 20개)
+    @GetMapping("/histories")
+    public ApiResponse<PageResponse<JellyHistory>> getHistories(
+            @RequestHeader("X-User-Id") Long userId,
+            @PageableDefault(size = 20, sort = "createdAt",
+                    direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.success(
+                new PageResponse<>(jellyService.getHistory(userId, pageable)));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Controller/PaymentController.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Controller/PaymentController.java
@@ -1,4 +1,0 @@
-package com.example.infinite.domain.Payment.Controller;
-
-public class PaymentController {
-}

--- a/src/main/java/com/example/infinite/domain/Payment/Dto/Response/JellyBalance.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Dto/Response/JellyBalance.java
@@ -1,0 +1,15 @@
+package com.example.infinite.domain.Payment.Dto.Response;
+
+import com.example.infinite.domain.Payment.Entity.UserJellyBalance;
+
+public record JellyBalance(
+        Long userId,
+        Integer currentBalance
+) {
+    public static JellyBalance from(UserJellyBalance balance) {
+        return new JellyBalance(
+                balance.getUserId(),
+                balance.getCurrentBalance()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Dto/Response/JellyHistory.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Dto/Response/JellyHistory.java
@@ -1,0 +1,27 @@
+package com.example.infinite.domain.Payment.Dto.Response;
+
+import com.example.infinite.domain.Payment.Entity.JellyTransaction;
+import com.example.infinite.domain.Payment.Enums.ReferenceType;
+import com.example.infinite.domain.Payment.Enums.TransactionType;
+
+import java.time.LocalDateTime;
+
+public record JellyHistory(
+        Long id,
+        TransactionType type,       // 거래 유형 (CHARGE, USE, REFUND 등)
+        ReferenceType referenceType, // 거래 발생 출처 (PAYMENT, DM_SUB, MEMBERSHIP)
+        Integer amount,             // 거래 젤리 수량 (항상 양수)
+        Integer balanceAfter,       // 거래 후 잔액 스냅샷
+        LocalDateTime createdAt
+) {
+    public static JellyHistory from(JellyTransaction tx) {
+        return new JellyHistory(
+                tx.getId(),
+                tx.getType(),
+                tx.getReferenceType(),
+                tx.getAmount(),
+                tx.getBalanceAfter(),
+                tx.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/Payment/Service/JellyService.java
+++ b/src/main/java/com/example/infinite/domain/Payment/Service/JellyService.java
@@ -1,0 +1,99 @@
+package com.example.infinite.domain.Payment.Service;
+
+import com.example.infinite.domain.Payment.Dto.Response.JellyBalance;
+import com.example.infinite.domain.Payment.Dto.Response.JellyHistory;
+import com.example.infinite.domain.Payment.Entity.JellyTransaction;
+import com.example.infinite.domain.Payment.Entity.UserJellyBalance;
+import com.example.infinite.domain.Payment.Enums.ReferenceType;
+import com.example.infinite.domain.Payment.Enums.TransactionType;
+import com.example.infinite.domain.Payment.Repository.JellyTransactionRepository;
+import com.example.infinite.domain.Payment.Repository.UserJellyBalanceRepository;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class JellyService {
+
+    private final UserJellyBalanceRepository jellyWalletRepository;
+    private final JellyTransactionRepository jellyTransactionRepository;
+
+    // 잔액 조회 (읽기 전용)
+    @Transactional(readOnly = true)
+    public JellyBalance getBalance(Long userId) {
+        UserJellyBalance wallet = jellyWalletRepository.findById(userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.JELLY_WALLET_NOT_FOUND));
+        return JellyBalance.from(wallet);
+    }
+
+    // 거래 이력 페이징 조회 (읽기 전용)
+    @Transactional(readOnly = true)
+    public Page<JellyHistory> getHistory(Long userId, Pageable pageable) {
+        return jellyTransactionRepository.findByUserId(userId, pageable)
+                .map(JellyHistory::from);
+    }
+
+    // 젤리 충전 - 비관적 락 적용 (외부: Webhook, 내부: 자동충전)
+    @Transactional
+    public void charge(Long userId, int amount, ReferenceType referenceType, Long relatedId) {
+        UserJellyBalance wallet = findWalletForUpdate(userId);
+        wallet.charge(amount);
+
+        saveTransaction(userId, TransactionType.CHARGE, referenceType, relatedId,
+                amount, wallet.getCurrentBalance());
+    }
+
+    // 젤리 사용 - 비관적 락 적용 (내부: 구독/멤버십 결제 시 호출)
+    @Transactional
+    public void use(Long userId, int amount, ReferenceType referenceType, Long relatedId) {
+        UserJellyBalance wallet = findWalletForUpdate(userId);
+        wallet.use(amount); // 잔액 부족 시 PaymentException(JELLY_INSUFFICIENT_BALANCE) 발생
+
+        saveTransaction(userId, TransactionType.USE, referenceType, relatedId,
+                amount, wallet.getCurrentBalance());
+    }
+
+    // 젤리 환불 - 비관적 락 적용 (내부: 환불 서비스에서 호출)
+    @Transactional
+    public void refund(Long userId, int amount, ReferenceType referenceType, Long relatedId) {
+        UserJellyBalance wallet = findWalletForUpdate(userId);
+        wallet.charge(amount); // 환불은 잔액 재충전
+
+        saveTransaction(userId, TransactionType.REFUND, referenceType, relatedId,
+                amount, wallet.getCurrentBalance());
+    }
+
+    // 신규 유저 지갑 생성 (회원가입 시 호출)
+    @Transactional
+    public void createWallet(Long userId) {
+        if (jellyWalletRepository.existsById(userId)) {
+            return; // 이미 지갑이 있으면 생성하지 않음
+        }
+        jellyWalletRepository.save(new UserJellyBalance(userId));
+    }
+
+    // 비관적 락으로 지갑 조회 (공통 메서드)
+    private UserJellyBalance findWalletForUpdate(Long userId) {
+        return jellyWalletRepository.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.JELLY_WALLET_NOT_FOUND));
+    }
+
+    // 거래 이력 저장 (공통 메서드)
+    private void saveTransaction(Long userId, TransactionType type,
+                                 ReferenceType referenceType, Long relatedId,
+                                 int amount, int balanceAfter) {
+        jellyTransactionRepository.save(JellyTransaction.builder()
+                .userId(userId)
+                .type(type)
+                .referenceType(referenceType)
+                .relatedId(relatedId)
+                .amount(amount)
+                .balanceAfter(balanceAfter)
+                .build());
+    }
+}


### PR DESCRIPTION
  ## 💡 기능 상세 내용
  젤리 핵심 비즈니스 로직을 담당하는 JellyService와 Controller를 구현합니다.

  - [x] `JellyBalance` Response DTO 생성
  - [x] `JellyHistory` Response DTO 생성
  - [x] `JellyService` 구현 (충전/사용/환불/잔액조회/이력조회)
  - [x] `JellyController` 구현 (`GET /api/payment/v1/jelly/balance`, `GET /api/payment/v1/jelly/histories`)
  - [x] `JellyProperties` 설정 추가 (1젤리=300원, 팬멤버십=9젤리, DM구독권=15젤리)
  - [x] `build.gradle` configuration-processor 추가
  - [x] `DemoApplication` @ConfigurationPropertiesScan 추가

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] 비관적 락으로 잔액 정합성 보장
  - [x] 잔액 부족 시 `PaymentException(JELLY_INSUFFICIENT_BALANCE)` 발생
  - [x] 모든 거래마다 `JellyTransaction` 이력 기록

  ## 🔗 기타 참고 사항
  - userId는 `@RequestHeader("X-User-Id")`로 임시 처리 (인증 도메인 완성 후 교체 예정)
  - 기동 테스트는 팀장 JWT PR 머지 후 진행 예정
  - close #28