### PR TITLE
feat#19 : ì인증/인가 구현 ; AccessToken 발급, EntryPoint, DeniedHandler 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,13 @@ SPRING_PROFILES_ACTIVE=local
 # Database (local 프로파일은 H2 사용, prod는 MySQL 사용)
 # =============================
 DB_URL=jdbc:mysql://localhost:3306/instagram_clone
-DB_USERNAME=your_username
-DB_PASSWORD=your_password
+DB_USERNAME=root
+DB_PASSWORD=12345678
 
 # =============================
 # JWT
 # =============================
 # 256비트(32바이트) 이상의 랜덤 시크릿 키를 사용하세요.
 # 생성 예시: openssl rand -base64 32
-JWT_SECRET_KEY=your-secret-key-here
+JWT_SECRET_KEY=gAiWPV0y28qhA2XXdGufyYKwAsXgxqWYrvOrrkYO6oQ=
+JWT_EXPIRATION=1800000

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 
 ### Local environment (contains credentials)
 src/main/resources/application-local.yml
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+
+    //env 설정
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/com/example/infinite/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/infinite/domain/user/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.example.infinite.domain.user.controller;
+
+
+import com.example.infinite.domain.user.service.AuthService;
+import com.example.infinite.domain.user.dto.LoginRequest;
+import com.example.infinite.domain.user.dto.SignUpRequest;
+import com.example.infinite.domain.user.dto.TokenResponse;
+import com.example.infinite.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/v1")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ApiResponse<Void> signUp(@RequestBody SignUpRequest request) {
+        authService.signUp(request);
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<TokenResponse> login(@RequestBody LoginRequest request) {
+        TokenResponse response = authService.login(request);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/example/infinite/domain/user/dto/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.example.infinite.domain.user.dto;
+
+public record LoginRequest(String email, String password) {}

--- a/src/main/java/com/example/infinite/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/com/example/infinite/domain/user/dto/SignUpRequest.java
@@ -1,0 +1,3 @@
+package com.example.infinite.domain.user.dto;
+
+public record SignUpRequest(String email, String password, String phoneNumber, String nickname) {}

--- a/src/main/java/com/example/infinite/domain/user/dto/TokenResponse.java
+++ b/src/main/java/com/example/infinite/domain/user/dto/TokenResponse.java
@@ -1,0 +1,3 @@
+package com.example.infinite.domain.user.dto;
+
+public record TokenResponse(String accessToken, String grantType) {}

--- a/src/main/java/com/example/infinite/domain/user/entity/User.java
+++ b/src/main/java/com/example/infinite/domain/user/entity/User.java
@@ -1,8 +1,7 @@
 package com.example.infinite.domain.user.entity;
 
 import com.example.infinite.global.common.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +15,60 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLDelete(sql = "UPDATE users SET deleted_at = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String subscriptionStatus;
+
+    private User(String email, String password, String phoneNumber, UserRole role,
+                 String status, String nickname, String subscriptionStatus) {
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+        this.status = status;
+        this.nickname = nickname;
+        this.subscriptionStatus = subscriptionStatus;
+    }
+
+    // 2. 정적 팩토리 메서드 (회원가입 등 객체 생성 시 사용)
+    public static User createNewUser(String email, String password, String phoneNumber, String nickname) {
+        return new User(
+                email,
+                password,
+                phoneNumber,
+                UserRole.USER,      // 초기 가입 시 기본 권한 설정
+                "ACTIVE",           // 초기 상태
+                nickname,
+                "NONE"              // 초기 구독 상태
+        );
+    }
 }
+
+
+
+
 
 

--- a/src/main/java/com/example/infinite/domain/user/entity/UserRole.java
+++ b/src/main/java/com/example/infinite/domain/user/entity/UserRole.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 서비스 권한 체계
+ * 1. SUPER_ADMIN: 시스템 전체 관리
+ * 2. ARTIST_ADMIN: 아티스트 페이지 관리 및 아티스트 본인
+ * 3. SUBSCRIBER: 유료 구독 팬 (팬레터, DM 가능)
+ * 4. USER: 일반 팬 (멤버십 미가입자 포함)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    SUPER_ADMIN("ROLE_SUPER_ADMIN", "시스템 관리자"),
+    ARTIST_ADMIN("ROLE_ARTIST_ADMIN", "아티스트 및 멤버"),
+    SUBSCRIBER("ROLE_SUBSCRIBER", "유료 구독 팬"),
+    USER("ROLE_USER", "일반 팬");
+
+    private final String authority; // 시큐리티 인증용 (ROLE_ 접두사 포함)
+    private final String description; // 설명용
+}

--- a/src/main/java/com/example/infinite/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/infinite/domain/user/repository/UserRepository.java
@@ -1,6 +1,15 @@
 package com.example.infinite.domain.user.repository;
 
-public class UserRepository {
+
+import com.example.infinite.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }
 
 

--- a/src/main/java/com/example/infinite/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/infinite/domain/user/service/AuthService.java
@@ -1,0 +1,55 @@
+package com.example.infinite.domain.user.service;
+
+
+import com.example.infinite.domain.user.dto.LoginRequest;
+import com.example.infinite.domain.user.dto.SignUpRequest;
+import com.example.infinite.domain.user.dto.TokenResponse;
+import com.example.infinite.domain.user.entity.User;
+import com.example.infinite.domain.user.repository.UserRepository;
+import com.example.infinite.global.auth.JwtTokenProvider;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 💡 회원가입
+    public void signUp(SignUpRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL); // 이미 있는 이메일 체크
+        }
+
+        User user = User.createNewUser(
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.phoneNumber(),
+                request.nickname()
+        );
+        userRepository.save(user);
+    }
+
+    // 💡 로그인
+    @Transactional(readOnly = true)
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 토큰 생성 (Subject로 이메일 사용)
+        String accessToken = jwtTokenProvider.createToken(user.getEmail(), user.getRole().name());
+        return new TokenResponse(accessToken, "Bearer");
+    }
+}

--- a/src/main/java/com/example/infinite/global/auth/AccessDeniedHandler.java
+++ b/src/main/java/com/example/infinite/global/auth/AccessDeniedHandler.java
@@ -1,4 +1,0 @@
-package com.example.infinite.global.auth;
-
-public class AccessDeniedHandler {
-}

--- a/src/main/java/com/example/infinite/global/auth/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/infinite/global/auth/JwtAccessDeniedHandler.java
@@ -1,0 +1,56 @@
+package com.example.infinite.global.auth;
+
+
+import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.error.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+/**
+ * 인가(Authorization) 실패 시 실행되는 핸들러 (403 Forbidden)
+ * 인증은 되었으나 해당 자원에 접근할 권한(Role)이 없을 때 호출됩니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        log.warn("권한 없는 사용자의 접근: {}", accessDeniedException.getMessage());
+
+
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+
+        // 1. 응답 설정 (JSON, 403 Forbidden)
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        // errorCode.getStatus().value()를 통해 403
+        response.setStatus(errorCode.getStatus().value());
+
+        // 2. 프로젝트 표준 에러 응답 생성
+        ApiResponse<Void> errorResponse = ApiResponse.fail(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+
+        // 3. JSON 변환 후 출력
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/example/infinite/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/infinite/global/auth/JwtAuthenticationFilter.java
@@ -1,10 +1,14 @@
 package com.example.infinite.global.auth;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -17,6 +21,7 @@ import java.io.IOException;
  * 모든 요청에서 JWT 유효성을 검사하는 필터
  * OncePerRequestFilter를 상속받아 한 요청당 딱 한 번만 실행됨을 보장합니다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -33,20 +38,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 1. 요청 헤더에서 토큰 추출
         String jwt = resolveToken(request);
 
-        // 2. 토큰 유효성 검사 (validateToken 활용)
-        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
-            // 3. 유효시 인증 객체 생성
-            Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
-            // 4. SecurityContext에 인증 정보 저장 (이게 되어야 '로그인 상태'로 인정됨)
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 2. 토큰 유효성 검사 및 인증 처리
+        if (StringUtils.hasText(jwt)) {
+            try {
+                // [수정 포인트] 이제 boolean 리턴이 아니라 Claims를 가져오거나 예외가 터집니다.
+                Claims claims = jwtTokenProvider.validateToken(jwt);
+
+                // 3. 유효시 인증 객체 생성 (이미 검증된 claims가 있다면 더 효율적입니다)
+                Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+
+                // 4. SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (ExpiredJwtException e) {
+                log.warn("만료된 토큰 요청입니다: {}", e.getMessage());
+                // TODO : 필요 시 request.setAttribute("exception", ErrorCode.TOKEN_EXPIRED); 추가
+            } catch (JwtException | IllegalArgumentException e) {
+                log.warn("유효하지 않은 토큰 요청입니다: {}", e.getMessage());
+                // TODO : 필요 시 request.setAttribute("exception", ErrorCode.INVALID_TOKEN); 추가
+            }
         }
 
-        // 5. 필터 진행
+        // 5. 다음 필터로 진행
         filterChain.doFilter(request, response);
     }
 
-    // 헤더에서 "Bearer "를 제외한 순수 토큰 문자열만 꺼내오는 로직
-    private String resolveToken(HttpServletRequest request) {
+
+        // 헤더에서 "Bearer "를 제외한 순수 토큰 문자열만 꺼내오는 로직
+        private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);

--- a/src/main/java/com/example/infinite/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/infinite/global/auth/JwtTokenProvider.java
@@ -6,11 +6,14 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.util.Collections;
@@ -19,7 +22,12 @@ import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
+
+    private final UserDetailsService userDetailsService;
+
+
     @Value("${JWT_SECRET_KEY}")
     private String secretKey;
 
@@ -32,6 +40,13 @@ public class JwtTokenProvider {
     protected void init() {
         // 보안상 문자열 키를 바이트 배열로 변환하여 HMAC-SHA 알고리즘 키로 로딩합니다.
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+
+        // 키 길이 검증 (HS256을 위해 최소 256비트/32바이트 확보)
+        if (keyBytes.length < 32) {
+            log.error("JWT 시크릿 키가 너무 짧습니다. 최소 32바이트(256비트)가 필요합니다.");
+            throw new IllegalArgumentException("JWT 시크릿 키의 길이가 부족합니다. 현재 길이: " + keyBytes.length);
+        }
+
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
@@ -40,39 +55,66 @@ public class JwtTokenProvider {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
+        //TODO : 프로젝트 윤곽이 나왔을때 issuer와 Audience 설정
         return Jwts.builder()
                 .subject(userEmail)
                 .claim("role", role)
+                .claim("type", "ACCESS")
                 .issuedAt(now)
                 .expiration(validity)
                 .signWith(key, Jwts.SIG.HS256) // 알고리즘 명시로 혼동 공격 방어
                 .compact();
     }
 
-    // 2. 토큰 파싱 및 검증
-    public boolean validateToken(String token) {
+    // 2. 토큰 파싱 및 검증 // TODO : 검증 역시 issuer와 Audience 추가 예정
+    public Claims validateToken(String token) {
         try {
-            Jwts.parser()
+            Claims claims = Jwts.parser()
                     .verifyWith(key)
                     .build()
-                    .parseSignedClaims(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("JWT 검증 실패: {}", e.getMessage());
-            return false;
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            // 토큰 타입 검증 (ACCESS 타입이 아니면 예외를 던짐)
+            String type = claims.get("type", String.class);
+            if (!"ACCESS".equals(type)) {
+                log.warn("잘못된 토큰 타입입니다. 기대값: ACCESS, 실제값: {}", type);
+                throw new JwtException("Invalid token type");
+            }
+
+            return claims; // 검증 성공 시 Claims 반환
+        }
+        catch (io.jsonwebtoken.security.SignatureException e) {
+            log.warn("잘못된 JWT 서명입니다: {}", e.getMessage());
+            throw e;
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+            throw e;
+        } catch (io.jsonwebtoken.UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+            throw e;
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있거나 잘못되었습니다: {}", e.getMessage());
+            throw e;
+        } catch (JwtException e) {
+            log.error("JWT 검증 중 예상치 못한 오류 발생: {}", e.getMessage());
+            throw e;
         }
     }
 
     // 3. 인증 객체 생성
+
+
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
 
         // 토큰에 담긴 role을 꺼내서 시큐리티 권한 객체로 변환
         String role = claims.get("role", String.class);
         List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
 
-        // Principal에 이메일을 넣고, 권한 리스트를 부여합니다.
-        return new UsernamePasswordAuthenticationToken(claims.getSubject(), "", authorities);
+        // Principal에 이메일을 넣고, 권한 리스트를 부여
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
     private Claims getClaims(String token) {
@@ -82,4 +124,6 @@ public class JwtTokenProvider {
                 .parseSignedClaims(token)
                 .getPayload();
     }
+
+
 }

--- a/src/main/java/com/example/infinite/global/auth/UserDetailsImpl.java
+++ b/src/main/java/com/example/infinite/global/auth/UserDetailsImpl.java
@@ -1,0 +1,58 @@
+package com.example.infinite.global.auth;
+
+
+import com.example.infinite.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * 시큐리티 인증 객체 내부에서 사용자 정보를 담는 구현체
+ */
+@Getter
+@RequiredArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(user.getRole().getAuthority())
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    /**
+     * 계정 만료, 잠금, 활성화 여부 등은
+     * 우선 true로 설정하고 나중에 User 엔티티의 status 필드와 연동 가능합니다.
+     */
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() {
+        // 예: status가 "ACTIVE"인 경우에만 true를 반환하게 설계 가능
+        return "ACTIVE".equals(user.getStatus());
+    }
+}

--- a/src/main/java/com/example/infinite/global/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/infinite/global/auth/UserDetailsServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.infinite.global.auth;
+
+
+import com.example.infinite.domain.user.entity.User;
+import com.example.infinite.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * DB에서 사용자 정보를 조회하여 시큐리티 인증 객체로 변환하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        log.info("사용자 인증 정보 조회 시작: {}", email);
+
+        // 1. DB에서 이메일로 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("인증 실패 - 존재하지 않는 사용자: {}", email);
+                    return new UsernameNotFoundException("해당 이메일의 사용자를 찾을 수 없습니다: " + email);
+                });
+
+        // 2. 조회된 엔티티를 신분증(UserDetailsImpl)에 담아 반환
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/example/infinite/global/cofig/Config.java
+++ b/src/main/java/com/example/infinite/global/cofig/Config.java
@@ -1,0 +1,18 @@
+package com.example.infinite.global.cofig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        // 날짜 관련 라이브러리 연동 (성실한 설계)
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -1,14 +1,18 @@
 package com.example.infinite.global.common.config;
 
+import com.example.infinite.global.auth.JwtAccessDeniedHandler;
 import com.example.infinite.global.auth.JwtAuthenticationEntryPoint;
 import com.example.infinite.global.auth.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -17,29 +21,70 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    //TODO : 극 초안임
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                // 에러 핸들링 : EntryPoint 연결
-                .exceptionHandling(exception ->
-                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
-                // API 접근 권한 설정
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**", "/api/v1/users/signup", "/api/v1/users/login").permitAll()
-                        // 스웨거 관련 경로
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
-                        // 그 외 모든 요청은 인증이 필요함
-                        .anyRequest().authenticated()
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
 
-                // JWT 필터 배치
+                // 2. 요청 권한 설정 (화이트리스트 운영)
+                // TODO : 너무 초안이라 반드시 수정해야함
+                .authorizeHttpRequests(auth -> auth
+                                // 1. 전체 공개 (인증 없이 접근 가능)
+                                .requestMatchers("/api/auth/v1/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/post/v1/fan-posts/**", "/api/post/v1/artist-posts/**").permitAll() // 게시글 조회는 비로그인도 가능할 경우
+
+                                // 2. 슈퍼 어드민 전용 (전체 관리)
+                                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                                .requestMatchers("/api/payment/v1/charge/settings/**").hasRole("ADMIN")
+
+                                // 3. 아티스트 및 어드민 (콘텐츠 생성 및 라이브 관리)
+                                .requestMatchers("/api/post/v1/artist-posts").hasAnyRole("ARTIST", "ADMIN")
+                                .requestMatchers("/api/v1/admin/lives/**", "/api/v1/admin/raffles/**").hasAnyRole("ARTIST", "ADMIN")
+
+                                // 4. 구독팬 전용 (팬레터 작성, DM 등 유료 서비스)
+                                .requestMatchers("/api/post/v1/fan-letters/**").hasAnyRole("SUBSCRIBER", "ARTIST", "ADMIN")
+                                .requestMatchers("/api/payment/v1/subscription/**").hasRole("SUBSCRIBER")
+
+                                // 5. 일반 팬 (멤버십 가입자 및 미가입자 공통 - 포스트 작성, 댓글, 좋아요)
+                                .requestMatchers("/api/post/v1/fan-posts").hasAnyRole("USER", "SUBSCRIBER", "ARTIST", "ADMIN")
+                                .requestMatchers("/api/post/v1/comments/**", "/api/post/v1/*/likes/toggle").authenticated()
+                                .requestMatchers("/api/myinfo/v1/**", "/api/payment/v1/jelly/**").authenticated()
+
+                                // 미디어 조회는 전체 공개 (또는 로그인 유저 전체)
+                                .requestMatchers(HttpMethod.GET, "/api/media/v1/**").permitAll()
+
+                                // 유튜브 연동 및 미디어 관리 (아티스트/어드민 전용)
+                                .requestMatchers("/api/media/v1/media/import-youtube").hasAnyRole("ARTIST", "ADMIN")
+                                .requestMatchers(HttpMethod.POST, "/api/media/v1/**").hasAnyRole("ARTIST", "ADMIN")
+                                .requestMatchers(HttpMethod.DELETE, "/api/media/v1/**").hasAnyRole("ARTIST", "ADMIN")
+
+                                // 구독 관련 정보 및 이력 조회 (구독팬 전용)
+                                .requestMatchers("/api/payment/v1/subscription/**").hasAnyRole("SUBSCRIBER", "ARTIST", "ADMIN")
+
+                                // 알림 및 소켓 연결 권한
+                                .requestMatchers("/sub/user/{userId}/notifications").authenticated() // 본인 알림은 본인만
+                                .anyRequest().authenticated()
+                )
+
+                // 3. 예외 핸들링 (EntryPoint, DeniedHandler 운영)
+                .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint) // 401 Unauthorized
+                        .accessDeniedHandler(jwtAccessDeniedHandler)           // 403 Forbidden
+                )
+
+                // 4. JWT 필터 추가 (UsernamePasswordAuthenticationFilter 앞단에 배치)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/infinite/global/error/ErrorCode.java
+++ b/src/main/java/com/example/infinite/global/error/ErrorCode.java
@@ -53,7 +53,15 @@ public enum ErrorCode implements ErrorCodeType {
     // 7. LiveStreaming (라이브)
     LIVE_STREAM_NOT_FOUND(HttpStatus.NOT_FOUND, "L001", "진행 중인 라이브 방송 정보를 찾을 수 없습니다."),
     LIVE_THUMBNAIL_REQUIRED(HttpStatus.BAD_REQUEST, "L002", "라이브 송출을 위해 썸네일 등록이 필수입니다."),
-    LIVE_CHAT_NOT_READY(HttpStatus.INTERNAL_SERVER_ERROR, "L003", "라이브 채팅 서버와의 연결에 실패했습니다.");
+    LIVE_CHAT_NOT_READY(HttpStatus.INTERNAL_SERVER_ERROR, "L003", "라이브 채팅 서버와의 연결에 실패했습니다."),
+
+    // 8. User (사용자) 너무 귀찮아서 나중에 쪼개갰습니다 아효
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "해당 사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "U002", "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "비밀번호가 일치하지 않습니다."),
+    USER_ALREADY_LOGOUT(HttpStatus.BAD_REQUEST, "U004", "이미 로그아웃된 사용자입니다."),
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "U005", "비활성화된 계정입니다. 관리자에게 문의하세요.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/infinite/global/exception/BusinessException.java
+++ b/src/main/java/com/example/infinite/global/exception/BusinessException.java
@@ -1,0 +1,24 @@
+package com.example.infinite.global.exception;
+
+import com.example.infinite.global.error.ErrorCode;
+import lombok.Getter;
+
+/**
+ * 8팀 프로젝트의 공통 비즈니스 예외 클래스
+ * ErrorCode를 필드로 가져서 어떤 에러인지 명확하게 전달합니다.
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage()); // 부모 생성자에 메시지 전달
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/infineat?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/infinite_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
     username: root
-    password: Alsry921!@
+    password: 12345678
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -18,3 +18,7 @@ spring:
     user:
       name: test
       password: test
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  expiration: ${JWT_EXPIRATION}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,5 +8,5 @@ spring:
 
 # JWT
 jwt:
-  secret: 
+  secret: ${JWT_SECRET_KEY}
   expiration: 3600000


### PR DESCRIPTION
#23 

🚀 [PR] Stateless JWT 기반 보안 인프라 및 유저 도메인 구축
1. 개요
Spring Security와 JWT를 결합하여 확장성 있는 무상태(Stateless) 인증 시스템을 구축했습니다. 대규모 트래픽을 고려하여 세션을 사용하지 않는 토큰 기반 방식을 채택하였으며, 역할 기반 접근 제어(RBAC)를 통해 보안성을 강화했습니다.

2. 주요 구현 사항
🛡️ 보안 인프라 (global.auth)
[] JwtTokenProvider: JWT 생성, 검증 및 클레임 추출 로직 구현. (보안을 위해 Secret Key는 .env로 관리)
[] JwtAuthenticationFilter: 모든 요청을 가로채 토큰을 검증하는 커스텀 필터 구현.
[] UserDetails / UserDetailsServiceImpl: DB 유저 정보를 SecurityContext에 연동하는 가교 역할 구현.
[] EntryPoint & AccessDeniedHandler: 401(인증 실패), 403(권한 부족) 예외 상황에 대한 일관된 커스텀 응답 처리.

🏗️ 유저 및 권한 설계 (domain.user)
[] User Entity: Soft Delete(@SQLDelete) 및 정적 팩토리 메서드 패턴 적용.
[] UserRole Enum: SUPER_ADMIN, ARTIST_ADMIN, SUBSCRIBER, USER의 4단계 권한 체계 확립.
[] Static Factory Method: 팀 컨벤션에 따라 Builder를 지양하고, 목적이 명확한 생성 메서드(createNewUser) 사용.

🔑 인증 API 구현
AuthController & AuthService: BCrypt를 이용한 비밀번호 암호화 기반의 회원가입 및 로그인 로직 완공.

3. 기술적 의사결정
[] Global Error Handling: BusinessException과 ErrorCode Enum을 통해 도메인 전반의 에러 응답 규격 통일.
