### PR TITLE
Feat: BillingService 구현 (PortOne 정기결제 카드 등록/조회/삭제) (#35) 

### DIFF
--- a/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
+++ b/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
@@ -2,6 +2,7 @@ package com.example.infinite.domain.payment.client;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -10,13 +11,23 @@ import org.springframework.web.client.RestClient;
 public class PortOneClient {
 
     private final RestClient restClient;
+    private final String apiSecret; // [수정] final 추가 - 불변성 보장
 
-    @Value("${portone.api-secret}")
-    private String apiSecret;
+    // [수정] 필드 주입(@Value) → 생성자 주입으로 변경
+    // 불변성 보장, 테스트 용이성, Spring 공식 권장 방식
+    // [추가] connectTimeout/readTimeout 설정 - PortOne API 무응답 시 스레드 무한 대기 방지
+    // connectTimeout: 서버 연결까지 대기 시간 (3초)
+    // readTimeout: 응답 데이터 수신까지 대기 시간 (10초)
+    public PortOneClient(@Value("${portone.api-secret}") String apiSecret) {
+        this.apiSecret = apiSecret;
 
-    public PortOneClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);  // 연결 타임아웃 3초
+        factory.setReadTimeout(10000);    // 읽기 타임아웃 10초
+
         this.restClient = RestClient.builder()
                 .baseUrl("https://api.portone.io")
+                .requestFactory(factory)
                 .build();
     }
 

--- a/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
+++ b/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
@@ -1,0 +1,36 @@
+package com.example.infinite.domain.payment.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class PortOneClient {
+
+    private final RestClient restClient;
+
+    @Value("${portone.api-secret}")
+    private String apiSecret;
+
+    public PortOneClient() {
+        this.restClient = RestClient.builder()
+                .baseUrl("https://api.portone.io")
+                .build();
+    }
+
+    // PortOne 빌링키 삭제 (카드 등록 해제)
+    public void deleteBillingKey(String billingKey) {
+        try {
+            restClient.delete()
+                    .uri("/billing-keys/{billingKey}", billingKey)
+                    .header("Authorization", "PortOne " + apiSecret)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.error("PortOne 빌링키 삭제 실패: billingKey={}, error={}", billingKey, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/controller/BillingController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/BillingController.java
@@ -1,0 +1,43 @@
+package com.example.infinite.domain.payment.controller;
+
+import com.example.infinite.domain.payment.dto.request.BillingKeyRequest;
+import com.example.infinite.domain.payment.dto.response.BillingKeyResponse;
+import com.example.infinite.domain.payment.service.BillingService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payment/v1/billings")
+public class BillingController {
+
+    private final BillingService billingService;
+
+    // 카드 등록
+    @PostMapping
+    public ApiResponse<BillingKeyResponse> register(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody @Valid BillingKeyRequest request) {
+        return ApiResponse.success(billingService.register(userId, request));
+    }
+
+    // 카드 목록 조회
+    @GetMapping
+    public ApiResponse<List<BillingKeyResponse>> getList(
+            @RequestHeader("X-User-Id") Long userId) {
+        return ApiResponse.success(billingService.getList(userId));
+    }
+
+    // 카드 삭제
+    @DeleteMapping("/{billingId}")
+    public ApiResponse<Void> delete(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long billingId) {
+        billingService.delete(userId, billingId);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/dto/PaymentDto.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/PaymentDto.java
@@ -1,4 +1,0 @@
-package com.example.infinite.domain.payment.dto;
-
-public class PaymentDto {
-}

--- a/src/main/java/com/example/infinite/domain/payment/dto/request/BillingKeyRequest.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/request/BillingKeyRequest.java
@@ -1,0 +1,18 @@
+package com.example.infinite.domain.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BillingKeyRequest(
+
+        @NotBlank(message = "PortOne 빌링키는 필수입니다.")
+        String billingKey,   // PortOne에서 프론트가 발급받은 빌링키
+
+        @NotBlank(message = "카드사명은 필수입니다.")
+        String cardName,     // 카드사명 (예: 신한, 국민)
+
+        @NotBlank(message = "카드 끝 4자리는 필수입니다.")
+        String cardLast4,    // 카드 끝 4자리
+
+        boolean defaultCard  // 대표 카드 등록 여부
+) {
+}

--- a/src/main/java/com/example/infinite/domain/payment/dto/response/BillingKeyResponse.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/response/BillingKeyResponse.java
@@ -1,0 +1,23 @@
+package com.example.infinite.domain.payment.dto.response;
+
+import com.example.infinite.domain.payment.entity.BillingKey;
+
+import java.time.LocalDateTime;
+
+public record BillingKeyResponse(
+        Long id,
+        String cardName,       // 카드사명
+        String cardLast4,      // 카드 끝 4자리
+        boolean defaultCard,   // 대표 카드 여부
+        LocalDateTime createdAt
+) {
+    public static BillingKeyResponse from(BillingKey billingKey) {
+        return new BillingKeyResponse(
+                billingKey.getId(),
+                billingKey.getCardName(),
+                billingKey.getCardLast4(),
+                billingKey.isDefaultCard(),
+                billingKey.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/entity/BillingKey.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/BillingKey.java
@@ -46,7 +46,13 @@ public class BillingKey extends BaseEntity {
         this.defaultCard = defaultCard;
     }
 
-    public void setDefault(boolean defaultCard) {
-        this.defaultCard = defaultCard;
+    // [추가] 대표 카드 설정 - 의도를 명확히 표현하는 메서드명 사용 (@Setter 지양 컨벤션 준수)
+    public void markAsDefault() {
+        this.defaultCard = true;
+    }
+
+    // [추가] 대표 카드 해제 - setDefault(false) 대신 의도 명확한 메서드로 분리
+    public void unsetDefault() {
+        this.defaultCard = false;
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/service/BillingService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/BillingService.java
@@ -7,9 +7,12 @@ import com.example.infinite.domain.payment.entity.BillingKey;
 import com.example.infinite.domain.payment.repository.BillingKeyRepository;
 import com.example.infinite.global.error.ErrorCode;
 import com.example.infinite.global.error.PaymentException;
+import com.example.infinite.global.lock.RedisLock; // [추가] 대표 카드 동시 등록 방지용 분산락 import
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -21,12 +24,14 @@ public class BillingService {
     private final PortOneClient portOneClient;
 
     // 카드 등록
+    // [수정] @RedisLock 추가 - 동일 유저가 두 창에서 동시에 대표 카드 등록 시 대표 카드가 2개 생기는 문제 방지
+    @RedisLock(key = "'billing:default:' + #userId", waitTime = 3, leaseTime = 10)
     @Transactional
     public BillingKeyResponse register(Long userId, BillingKeyRequest request) {
         // 대표 카드 등록 시 기존 대표 카드 해제
         if (request.defaultCard()) {
             billingKeyRepository.findByUserIdAndDefaultCardTrue(userId)
-                    .ifPresent(existing -> existing.setDefault(false));
+                    .ifPresent(existing -> existing.unsetDefault()); // [수정] setDefault(false) → unsetDefault() (의도 명확한 메서드명)
         }
 
         BillingKey billingKey = BillingKey.builder()
@@ -49,20 +54,34 @@ public class BillingService {
     }
 
     // 카드 삭제 (soft delete + PortOne 빌링키 해제)
+    // [수정] PortOne API 호출을 트랜잭션 커밋 후로 분리 (부분 반영)
+    // 이유: @Transactional 안에 외부 API 호출이 있으면 두 가지 문제가 생김
+    //   1) PortOne API가 느릴 경우 DB 커넥션이 계속 점유되어 커넥션 풀 고갈 위험
+    //   2) PortOne 성공 → DB 실패 시 외부는 삭제됐는데 DB엔 남는 데이터 불일치 발생
+    // afterCommit 훅으로 DB 커밋 이후에 PortOne API를 호출해 위 문제를 해결함
+    // 완전한 해결(PortOne 실패 시 보상 로직)은 Saga 패턴이지만 현재 팀 규모에서 과한 구현이라 판단해 부분 반영
     @Transactional
     public void delete(Long userId, Long billingId) {
         BillingKey billingKey = billingKeyRepository.findById(billingId)
-                .orElseThrow(() -> new PaymentException(ErrorCode.RESOURCE_NOT_FOUND));
+                .orElseThrow(() -> new PaymentException(ErrorCode.BILLING_KEY_NOT_FOUND)); // [수정] RESOURCE_NOT_FOUND → BILLING_KEY_NOT_FOUND
 
         // 본인 카드인지 검증
         if (!billingKey.getUserId().equals(userId)) {
             throw new PaymentException(ErrorCode.ACCESS_DENIED);
         }
 
-        // PortOne 빌링키 삭제
-        portOneClient.deleteBillingKey(billingKey.getBillingKey());
-
-        // soft delete
+        // DB soft delete (트랜잭션 커밋 시 반영)
         billingKey.delete();
+
+        // [수정] DB 커밋 후 PortOne API 호출 - afterCommit 훅 사용
+        // 이렇게 하면 DB 커밋이 완료된 이후에만 외부 API가 호출되어
+        // DB 커넥션 점유 시간을 최소화하고 트랜잭션 범위를 DB 작업만으로 한정함
+        String portOneBillingKey = billingKey.getBillingKey();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                portOneClient.deleteBillingKey(portOneBillingKey);
+            }
+        });
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/service/BillingService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/BillingService.java
@@ -1,0 +1,68 @@
+package com.example.infinite.domain.payment.service;
+
+import com.example.infinite.domain.payment.client.PortOneClient;
+import com.example.infinite.domain.payment.dto.request.BillingKeyRequest;
+import com.example.infinite.domain.payment.dto.response.BillingKeyResponse;
+import com.example.infinite.domain.payment.entity.BillingKey;
+import com.example.infinite.domain.payment.repository.BillingKeyRepository;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BillingService {
+
+    private final BillingKeyRepository billingKeyRepository;
+    private final PortOneClient portOneClient;
+
+    // 카드 등록
+    @Transactional
+    public BillingKeyResponse register(Long userId, BillingKeyRequest request) {
+        // 대표 카드 등록 시 기존 대표 카드 해제
+        if (request.defaultCard()) {
+            billingKeyRepository.findByUserIdAndDefaultCardTrue(userId)
+                    .ifPresent(existing -> existing.setDefault(false));
+        }
+
+        BillingKey billingKey = BillingKey.builder()
+                .userId(userId)
+                .billingKey(request.billingKey())
+                .cardName(request.cardName())
+                .cardLast4(request.cardLast4())
+                .defaultCard(request.defaultCard())
+                .build();
+
+        return BillingKeyResponse.from(billingKeyRepository.save(billingKey));
+    }
+
+    // 카드 목록 조회
+    @Transactional(readOnly = true)
+    public List<BillingKeyResponse> getList(Long userId) {
+        return billingKeyRepository.findByUserId(userId).stream()
+                .map(BillingKeyResponse::from)
+                .toList();
+    }
+
+    // 카드 삭제 (soft delete + PortOne 빌링키 해제)
+    @Transactional
+    public void delete(Long userId, Long billingId) {
+        BillingKey billingKey = billingKeyRepository.findById(billingId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        // 본인 카드인지 검증
+        if (!billingKey.getUserId().equals(userId)) {
+            throw new PaymentException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // PortOne 빌링키 삭제
+        portOneClient.deleteBillingKey(billingKey.getBillingKey());
+
+        // soft delete
+        billingKey.delete();
+    }
+}

--- a/src/main/java/com/example/infinite/global/error/ErrorCode.java
+++ b/src/main/java/com/example/infinite/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode implements ErrorCodeType {
     PAYMENT_AUTO_CHARGING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "P003", "월 단위 정기 결제 처리 중 오류가 발생했습니다."),
     JELLY_WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "P004", "사용자의 젤리 지갑 정보를 찾을 수 없습니다."),
     REFUND_NOT_ELIGIBLE(HttpStatus.BAD_REQUEST, "P005", "환불 정책 조건을 충족하지 않습니다."),
+    BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "P006", "등록된 카드 정보를 찾을 수 없습니다."), // [추가] 빌링키 도메인 특화 에러코드 - 운영 로그에서 원인 파악 용이
 
     // 3. DM (Direct Message)
     DM_SUBSCRIPTION_REQUIRED(HttpStatus.FORBIDDEN, "D001", "DM 구독 상태인 유저만 이용 가능합니다."),


### PR DESCRIPTION
  ## 💡 기능 상세 내용                                                                                                                                           
  PortOne 빌링키 기반 정기결제 카드 관리 기능을 구현합니다.                                                                                                    

  - [x] `PortOneClient` 구현 (RestClient 기반 PortOne API 연동)
  - [x] `BillingKeyRequest` DTO 생성
  - [x] `BillingKeyResponse` DTO 생성
  - [x] `BillingService` 구현 (카드 등록/목록조회/삭제/대표카드 변경)
  - [x] `BillingController` 구현
    - `POST /api/payment/v1/billings` 카드 등록
    - `GET /api/payment/v1/billings` 카드 목록 조회
    - `DELETE /api/payment/v1/billings/{billingId}` 카드 삭제

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] PortOne API 호출로 빌링키 삭제 연동
  - [x] 카드 삭제 시 soft delete 처리
  - [x] 대표 카드 등록 시 기존 대표 카드 자동 해제
  - [x] 본인 카드 여부 검증 포함

  ## 🔗 기타 참고 사항
  - PortOne API Secret은 `application-local.yml`에서 관리 (git 제외)
  - userId는 `@RequestHeader("X-User-Id")` 임시 처리
  - close #35