### PR TITLE
Feat: Redis Streams 감사 로그 및 Reservoir Sampling 감사 연동

### DIFF
--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleAuditConsumer.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleAuditConsumer.java
@@ -1,0 +1,82 @@
+package com.example.infinite.domain.raffle.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RaffleAuditConsumer {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String CONSUMER_GROUP = "raffle-audit-group";
+    private static final String CONSUMER_NAME = "consumer-1"; // Scale-out 시 서버 ID로 변경
+    private static final int BATCH_SIZE = 500;
+
+    public void createConsumerGroupIfNotExists(String streamKey) {
+        try {
+            stringRedisTemplate.opsForStream().createGroup(streamKey, ReadOffset.from("0"), CONSUMER_GROUP);
+            log.info("Consumer Group 생성: streamKey={}, group={}", streamKey, CONSUMER_GROUP);
+        } catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().contains("BUSYGROUP")) {
+                log.debug("Consumer Group 이미 존재: streamKey={}", streamKey);
+            } else {
+                log.warn("Consumer Group 생성 실패: streamKey={}, error={}", streamKey, e.getMessage());
+            }
+        }
+    }
+
+    public int consume(String streamKey) {
+        List<MapRecord<String, Object, Object>> records;
+
+        try {
+            records = stringRedisTemplate.opsForStream().read(
+                    Consumer.from(CONSUMER_GROUP, CONSUMER_NAME),
+                    StreamReadOptions.empty().count(BATCH_SIZE).block(Duration.ofMillis(500)),
+                    StreamOffset.create(streamKey, ReadOffset.lastConsumed())
+            );
+        } catch (Exception e) {
+            log.warn("스트림 읽기 실패: streamKey={}, error={}", streamKey, e.getMessage());
+            return 0;
+        }
+
+        if (records == null || records.isEmpty()) {
+            return 0;
+        }
+
+        // ──────────────────────────────────────────
+        // TODO [Phase 1]: 여기에 DB Batch INSERT 구현
+        // JPA 엔티티 확정 후 JdbcTemplate.batchUpdate()로 교체
+        // ──────────────────────────────────────────
+
+        for (MapRecord<String, Object, Object> record : records) {
+            Map<Object, Object> fields = record.getValue();
+            log.info("감사 로그 소비: raffleId={}, userId={}, slotIndex={}, order={}, replaced={}",
+                    fields.get("raffleId"),
+                    fields.get("userId"),
+                    fields.get("slotIndex"),
+                    fields.get("entryOrder"),
+                    fields.get("replaced"));
+        }
+
+        records.forEach(record ->
+                stringRedisTemplate.opsForStream().acknowledge(streamKey, CONSUMER_GROUP, record.getId()));
+
+        log.debug("감사 로그 {} 건 소비 완료: streamKey={}", records.size(), streamKey);
+        return records.size();
+    }
+
+    public void deleteStream(long raffleId) {
+        String streamKey = String.format("raffle:%d:audit-log", raffleId);
+        stringRedisTemplate.delete(streamKey);
+        log.info("감사 로그 스트림 삭제: raffleId={}", raffleId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleAuditLogger.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleAuditLogger.java
@@ -1,0 +1,47 @@
+package com.example.infinite.domain.raffle.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RaffleAuditLogger {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String STREAM_KEY_FORMAT = "raffle:%d:audit-log";
+    private static final long MAX_STREAM_LENGTH = 100_000;
+
+    public void log(long raffleId, int slotIndex, long userId, int entryOrder, boolean replaced) {
+        String streamKey = String.format(STREAM_KEY_FORMAT, raffleId);
+
+        Map<String, String> fields = Map.of(
+                "raffleId", String.valueOf(raffleId),
+                "slotIndex", String.valueOf(slotIndex),
+                "userId", String.valueOf(userId),
+                "entryOrder", String.valueOf(entryOrder),
+                "replaced", String.valueOf(replaced),
+                "timestamp", Instant.now().toString()
+        );
+
+        MapRecord<String, String, String> record = StreamRecords.newRecord()
+                .in(streamKey)
+                .ofMap(fields);
+
+        try {
+            stringRedisTemplate.opsForStream().add(record);
+            stringRedisTemplate.opsForStream().trim(streamKey, MAX_STREAM_LENGTH, true);
+            log.debug("감사 로그 발행: raffleId={}, userId={}, order={}", raffleId, userId, entryOrder);
+        } catch (Exception e) {
+            log.warn("감사 로그 발행 실패: raffleId={}, userId={}, error={}", raffleId, userId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/raffle/service/ReservoirSampler.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/ReservoirSampler.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class ReservoirSampler {
 
     private final StringRedisTemplate stringRedisTemplate;
+    private final RaffleAuditLogger auditLogger;
 
     // TTL: 현재 하드코딩 24시간. Phase 2에서 래플 duration 기반 동적 TTL로 교체 예정.
     private static final Duration DEFAULT_KEY_TTL = Duration.ofDays(1);
@@ -117,6 +118,9 @@ public class ReservoirSampler {
             stringRedisTemplate.expire(countKey, DEFAULT_KEY_TTL);
             stringRedisTemplate.expire(candidateKey, DEFAULT_KEY_TTL);
         }
+
+        // 감사 로그 발행 (비동기 Batch INSERT의 원천 데이터)
+        auditLogger.log(raffleId, slotIndex, userId, entryOrder, replaced);
 
         log.debug("응모 성공: raffleId={}, slotIndex={}, userId={}, order={}, replaced={}",
                 raffleId, slotIndex, userId, entryOrder, replaced);

--- a/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
+++ b/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
@@ -12,8 +12,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
-import static com.example.infinite.domain.member.entity.QMember.member;
-
 /**
  * Spring Security 인증 객체 내부에서 멤버 정보를 담는 구현체입니다.
  * 리더님의 설계에 따라 DB 조회 기반 생성과 토큰 정보 기반 생성을 모두 지원합니다.

--- a/src/test/java/com/example/infinite/domain/raffle/RaffleAuditStreamIntegrationTest.java
+++ b/src/test/java/com/example/infinite/domain/raffle/RaffleAuditStreamIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.example.infinite.domain.raffle;
+
+import com.example.infinite.domain.raffle.service.RaffleAuditConsumer;
+import com.example.infinite.domain.raffle.service.RaffleAuditLogger;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Testcontainers
+class RaffleAuditStreamIntegrationTest {
+
+    @Container
+    static GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @Autowired
+    private RaffleAuditLogger auditLogger;
+
+    @Autowired
+    private RaffleAuditConsumer auditConsumer;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @Test
+    @DisplayName("XADD로 발행한 감사 로그를 Consumer가 읽어온다")
+    void publishAndConsume() {
+        long raffleId = 1L;
+        String streamKey = "raffle:1:audit-log";
+
+        auditLogger.log(raffleId, 0, 100L, 1, true);
+        auditConsumer.createConsumerGroupIfNotExists(streamKey);
+
+        auditLogger.log(raffleId, 0, 101L, 2, false);
+        auditLogger.log(raffleId, 0, 102L, 3, true);
+
+        int consumed = auditConsumer.consume(streamKey);
+        assertThat(consumed).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("Consumer Group이 이미 존재해도 에러 없이 무시된다")
+    void duplicateConsumerGroupCreation() {
+        long raffleId = 2L;
+        String streamKey = "raffle:2:audit-log";
+
+        auditLogger.log(raffleId, 0, 200L, 1, false);
+
+        auditConsumer.createConsumerGroupIfNotExists(streamKey);
+        auditConsumer.createConsumerGroupIfNotExists(streamKey);
+    }
+
+    @Test
+    @DisplayName("소비한 메시지는 재소비되지 않는다 (ACK 확인)")
+    void acknowledgedMessagesNotReconsumed() {
+        long raffleId = 3L;
+        String streamKey = "raffle:3:audit-log";
+
+        auditLogger.log(raffleId, 0, 300L, 1, false);
+        auditConsumer.createConsumerGroupIfNotExists(streamKey);
+
+        int first = auditConsumer.consume(streamKey);
+        assertThat(first).isEqualTo(1);
+
+        int second = auditConsumer.consume(streamKey);
+        assertThat(second).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("스트림 삭제 후 키가 존재하지 않는다")
+    void deleteStream() {
+        long raffleId = 4L;
+        String streamKey = "raffle:4:audit-log";
+
+        auditLogger.log(raffleId, 0, 400L, 1, false);
+        assertThat(stringRedisTemplate.hasKey(streamKey)).isTrue();
+
+        auditConsumer.deleteStream(raffleId);
+        assertThat(stringRedisTemplate.hasKey(streamKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("감사 로그 발행 실패가 예외를 던지지 않는다")
+    void logFailureDoesNotThrow() {
+        assertThatCode(() -> auditLogger.log(-1L, -1, -1L, -1, false))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/example/infinite/domain/raffle/ReservoirSamplerIntegrationTest.java
+++ b/src/test/java/com/example/infinite/domain/raffle/ReservoirSamplerIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.example.infinite.domain.raffle;
 
 import com.example.infinite.domain.raffle.service.ReservoirSampler;
-import com.example.infinite.domain.raffle.service.reservoirsampler.EntryResult;
-import com.example.infinite.domain.raffle.service.reservoirsampler.SlotCloseResult;
+import com.example.infinite.domain.raffle.service.ReservoirSampler.EntryResult;
+import com.example.infinite.domain.raffle.service.ReservoirSampler.SlotCloseResult;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/example/infinite/domain/raffle/service/ReservoirSamplerUnitTest.java
+++ b/src/test/java/com/example/infinite/domain/raffle/service/ReservoirSamplerUnitTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.*;
 class ReservoirSamplerUnitTest {
 
     // Redis 의존성 없이 순수 로직만 테스트
-    private final ReservoirSampler sampler = new ReservoirSampler(null);
+    private final ReservoirSampler sampler = new ReservoirSampler(null, null);
 
     @Test
     @DisplayName("첫 번째 참여자는 무조건 후보로 선정된다")


### PR DESCRIPTION
## Summary                                                                                                                                       
  - **RaffleAuditLogger**: Redis Streams XADD 기반 응모 감사 로그 발행 (MAXLEN ~100K 자동 트림)
  - **RaffleAuditConsumer**: XREADGROUP Consumer Group 기반 감사 로그 소비 및 ACK 처리 (Phase 1 DB Batch INSERT 연동 지점 마련)                    
  - **ReservoirSampler 감사 연동**: 응모 성공 시 auditLogger.log() 호출하여 raffleId, slotIndex, userId, 순번, 교체 여부를 스트림에 기록           
  - **Gemini CLI 사고 복구**: ReservoirSamplerIntegrationTest의 inner record import 경로 수정, MemberDetailsImpl의 미사용 QMember static import    
  제거                                                                                                                                             
                                                                                                                                                   
  ## 변경 파일
  | 파일 | 변경 |
  |------|------|
  | RaffleAuditLogger.java | 신규 — XADD + MAXLEN trim |
  | RaffleAuditConsumer.java | 신규 — XREADGROUP + ACK |
  | ReservoirSampler.java | auditLogger 필드 추가, enter() 감사 로그 발행 |
  | MemberDetailsImpl.java | 미사용 QMember static import 제거 |
  | ReservoirSamplerIntegrationTest.java | EntryResult/SlotCloseResult import 경로 수정 |
  | ReservoirSamplerUnitTest.java | 생성자 인자 호환 수정 |
  | RaffleAuditStreamIntegrationTest.java | 신규 — Testcontainers 통합 테스트 5건 |

  ## Test plan
  - [x] compileJava + compileTestJava 전체 컴파일 통과
  - [x] ReservoirSamplerUnitTest 단위 테스트 통과 (10만 회 시뮬레이션 균등 분포 검증)
  - [ ] ReservoirSamplerIntegrationTest 통합 테스트 (Docker 필요)
  - [ ] RaffleAuditStreamIntegrationTest 통합 테스트 (Docker 필요)
  
  
  ---
  예전에 있던 파일 경로 리팩터링 중 유실되었던 파일과 정리 덜 된 것들 다시 정리한겁니다!
