### PR TITLE
Chore: MemberRole 회귀 수정 + SecurityConfig 재정비 + 래플 사용자 식별 전환     

### DIFF
--- a/src/main/java/com/example/infinite/domain/member/artist/service/ArtistMemberService.java
+++ b/src/main/java/com/example/infinite/domain/member/artist/service/ArtistMemberService.java
@@ -105,7 +105,7 @@ public class ArtistMemberService {
     }
 
     private void validateCreatableMember(Member targetMember) {
-        if (targetMember.getRole() != MemberRole.ARTIST_ADMIN) {
+        if (targetMember.getRole() != MemberRole.ARTIST) {
             throw new ArtistException(ArtistErrorCode.ARTIST_MEMBER_ROLE_REQUIRED);
         }
 

--- a/src/main/java/com/example/infinite/domain/member/artist/service/ArtistService.java
+++ b/src/main/java/com/example/infinite/domain/member/artist/service/ArtistService.java
@@ -158,7 +158,7 @@ public class ArtistService {
     }
 
     private void validateCreatePermission(Member member) {
-        if (member.getRole() != MemberRole.ARTIST_ADMIN) {
+        if (member.getRole() != MemberRole.ARTIST) {
             throw new ArtistException(ArtistErrorCode.ARTIST_CREATE_ROLE_REQUIRED);
         }
 

--- a/src/main/java/com/example/infinite/domain/member/member/controller/AdminMemberController.java
+++ b/src/main/java/com/example/infinite/domain/member/member/controller/AdminMemberController.java
@@ -22,7 +22,7 @@ public class AdminMemberController {
     private final MemberService memberService;
 
     // admin 경로는 SecurityConfig에서 hasRole("ADMIN")으로 보호되므로 SUPER_ADMIN만 접근한다.
-    // 현재 과제 규칙상 USER를 ARTIST_ADMIN 또는 SUPER_ADMIN으로만 승격시킨다.
+    // 현재 과제 규칙상 MEMBER를 ARTIST 또는 SUPER_ADMIN으로만 승격시킨다.
     @PatchMapping("v1/members/{memberId}/role")
     public ResponseEntity<ApiResponse<AdminMemberResponse>> changeRole(
             @PathVariable Long memberId,

--- a/src/main/java/com/example/infinite/domain/member/member/entity/Member.java
+++ b/src/main/java/com/example/infinite/domain/member/member/entity/Member.java
@@ -54,7 +54,7 @@ public class Member extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
-        this.role = MemberRole.USER;
+        this.role = MemberRole.MEMBER;
         this.status = MemberStatus.ACTIVE;
     }
 

--- a/src/main/java/com/example/infinite/domain/member/member/service/AuthService.java
+++ b/src/main/java/com/example/infinite/domain/member/member/service/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
         }
 
         // 토큰 생성 (Subject로 이메일 사용)
-        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().getSecurityName());
+        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name());
         return new TokenResponse(accessToken, "Bearer");
     }
 }

--- a/src/main/java/com/example/infinite/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/example/infinite/domain/member/member/service/MemberService.java
@@ -78,14 +78,14 @@ public class MemberService {
         member.changeEmail(nextEmail);
 
         // JWT subject가 email이므로 이메일 변경 직후 새 토큰을 재발급한다.
-        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().getSecurityName());
+        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name());
         return new TokenResponse(accessToken, "Bearer");
     }
 
     public AdminMemberResponse changeRole(Long memberId, UpdateMemberRoleRequest request) {
         Member member = memberReader.findByIdOrThrow(memberId);
         // 역할 승격은 SUPER_ADMIN 전용 admin 경로에서만 호출되며,
-        // 현재 정책상 USER -> ARTIST_ADMIN / USER -> SUPER_ADMIN 두 경우만 허용한다.
+        // 현재 정책상 MEMBER -> ARTIST / MEMBER -> SUPER_ADMIN 두 경우만 허용한다.
         validateRoleChange(member.getRole(), request.role());
         member.changeRole(request.role());
         return AdminMemberResponse.from(member);
@@ -111,11 +111,11 @@ public class MemberService {
 
 
     private void validateRoleChange(MemberRole currentRole, MemberRole nextRole) {
-        if (currentRole != MemberRole.USER) {
+        if (currentRole != MemberRole.MEMBER) {
             throw new MemberException(MemberErrorCode.MEMBER_INVALID_ROLE_CHANGE);
         }
 
-        if (nextRole != MemberRole.ARTIST_ADMIN && nextRole != MemberRole.SUPER_ADMIN) {
+        if (nextRole != MemberRole.ARTIST && nextRole != MemberRole.SUPER_ADMIN) {
             throw new MemberException(MemberErrorCode.MEMBER_INVALID_ROLE_CHANGE);
         }
     }

--- a/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
+++ b/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
@@ -1,5 +1,7 @@
 package com.example.infinite.domain.raffle.controller;
 
+import com.example.infinite.domain.member.member.support.MemberInputSupport;
+import com.example.infinite.domain.member.member.support.MemberReader;
 import com.example.infinite.domain.raffle.dto.EntryResponse;
 import com.example.infinite.domain.raffle.dto.MyEntryResultResponse;
 import com.example.infinite.domain.raffle.dto.MyRaffleEntryResponse;
@@ -7,10 +9,12 @@ import com.example.infinite.domain.raffle.dto.RaffleDetailResponse;
 import com.example.infinite.domain.raffle.dto.RaffleResponse;
 import com.example.infinite.domain.raffle.service.RaffleEntryService;
 import com.example.infinite.domain.raffle.service.RaffleService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,12 +25,14 @@ public class RaffleController {
 
     private final RaffleEntryService raffleEntryService;
     private final RaffleService raffleService;
+    private final MemberReader memberReader;
 
     @PostMapping("/api/v1/artists/{artistId}/raffles/{raffleId}/entries")
     public ResponseEntity<ApiResponse<EntryResponse>> enter(
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
         EntryResponse response = raffleEntryService.enter(artistId, raffleId, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -42,7 +48,8 @@ public class RaffleController {
     public ResponseEntity<ApiResponse<RaffleDetailResponse>> getRaffleDetail(
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
         RaffleDetailResponse response = raffleService.getRaffleDetail(artistId, raffleId, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -51,14 +58,16 @@ public class RaffleController {
     public ResponseEntity<ApiResponse<MyEntryResultResponse>> getMyResult(
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
         MyEntryResultResponse response = raffleService.getMyResult(artistId, raffleId, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/api/v1/users/me/raffle-entries")
     public ResponseEntity<ApiResponse<List<MyRaffleEntryResponse>>> getMyEntries(
-            @RequestHeader("X-User-Id") Long userId) {
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
         List<MyRaffleEntryResponse> response = raffleService.getMyEntries(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
+++ b/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
@@ -25,7 +25,7 @@ public class MemberDetailsImpl implements UserDetails {
     // 1. DB 엔티티 기반 생성자
     public MemberDetailsImpl(Member member) {
         this.email = member.getEmail();
-        this.role = "ROLE_" + member.getRole().getSecurityName();
+        this.role = "ROLE_" + member.getRole().name();
         this.status = member.getStatus().name();
     }
 

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -38,39 +38,72 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
 
-                // 2. 요청 권한 설정 (화이트리스트 운영)
-                // TODO : 너무 초안이라 반드시 수정해야함
                 .authorizeHttpRequests(auth -> auth
-                                // 1. 전체 공개
-                                .requestMatchers("/api/auth/v1/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/post/v1/fan-posts/**", "/api/post/v1/artists/*/fan-posts/**", "/api/post/v1/hashtags/**", "/api/post/v1/artist-posts/**", "/api/media/v1/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/member/v1/artists/{artistId}").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/member/v2/artists/{artistId}").permitAll()
+                        // ── 1. 전체 공개 ──
+                        .requestMatchers(
+                                "/api/auth/v1/**",
+                                "/h2-console/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
 
-                                // 2. 어드민 및 관리자 전용
-                                // ADMIN 권한은 현재 MemberRole.SUPER_ADMIN만 가지므로
-                                // `/api/{server}/admin/{version}/...` 경로는 SUPER_ADMIN 전용이다.
-                                .requestMatchers("/api/member/admin/v1/**", "/api/payment/v1/charge/settings/**").hasRole("ADMIN")
-                                .requestMatchers("/api/post/v1/artist-posts").hasAnyRole("ARTIST", "ADMIN")
-                                .requestMatchers(HttpMethod.PATCH, "/api/post/v1/artists/*/fan-posts/*").hasAnyRole("USER", "SUBSCRIBER", "ARTIST", "ADMIN")
-                                .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/fan-posts/*").hasAnyRole("USER", "SUBSCRIBER", "ARTIST", "ADMIN")
-                                .requestMatchers("/api/media/v1/media/import-youtube").hasAnyRole("ARTIST", "ADMIN")
-                                .requestMatchers(HttpMethod.POST, "/api/media/v1/**").hasAnyRole("ARTIST", "ADMIN")
-                                .requestMatchers(HttpMethod.DELETE, "/api/media/v1/**").hasAnyRole("ARTIST", "ADMIN")
+                        // 공개 GET: 팬포스트, 해시태그, 아티스트 포스트, 미디어, 아티스트 상세
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/post/v1/fan-posts/**",
+                                "/api/post/v1/artists/*/fan-posts/**",
+                                "/api/post/v1/hashtags/**",
+                                "/api/post/v1/artist-posts/**",
+                                "/api/media/v1/**",
+                                "/api/member/v1/artists/{artistId}",
+                                "/api/member/v2/artists/{artistId}"
+                        ).permitAll()
 
-                                // 3. 유료 서비스 (구독팬 전용)
-                                .requestMatchers("/api/post/v1/fan-letters/**", "/api/payment/v1/subscription/**").hasAnyRole("SUBSCRIBER", "ARTIST", "ADMIN")
+                        // 공개 GET: 래플/라이브 목록 및 상세 (비회원도 조회 가능)
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/artists/*/raffles",
+                                "/api/v1/artists/*/raffles/*",
+                                "/api/v1/artists/*/lives",
+                                "/api/v1/artists/*/lives/*",
+                                "/api/v1/artists/*/lives/*/chat/messages"
+                        ).permitAll()
 
-                                // 4. 일반 사용자 및 공통 인증
-                                .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts").hasAnyRole("USER", "SUBSCRIBER", "ARTIST", "ADMIN")
-                                .requestMatchers("/api/post/v1/fan-posts").hasAnyRole("USER", "SUBSCRIBER", "ARTIST", "ADMIN")
-                                .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts/*/likes/toggle").authenticated()
-                                .requestMatchers("/api/post/v1/comments/**", "/api/post/v1/*/likes/toggle").authenticated()
-                                .requestMatchers("/api/member/v1/**", "/api/payment/v1/jelly/**").authenticated()
-                                .requestMatchers("/sub/user/{userId}/notifications").authenticated()
+                        // WebSocket 핸드쉐이크 (STOMP 연결은 ChannelInterceptor에서 JWT 검증)
+                        .requestMatchers("/ws-stomp/**").permitAll()
 
-                                // 5. 핸드쉐이크만 허용
-                                .requestMatchers("/ws-stomp/**").permitAll()
+                        // ── 2. SUPER_ADMIN 전용 ──
+                        .requestMatchers("/api/member/admin/v1/**").hasRole("SUPER_ADMIN")
+
+
+                        // ── 3. ARTIST + SUPER_ADMIN (관리자) ──
+                        .requestMatchers("/api/v1/admin/artists/*/raffles/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/artists/*/lives/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers("/api/post/v1/artist-posts").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers("/api/media/v1/media/import-youtube").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/media/v1/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/media/v1/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
+
+                        // ── 4. 인증된 사용자 (로그인 필수) ──
+                        // 래플 응모 및 내 응모 내역
+                        .requestMatchers("/api/v1/artists/*/raffles/*/entries/**").authenticated()
+                        .requestMatchers("/api/v1/users/me/raffle-entries").authenticated()
+
+                        // 팬포스트 CRUD (작성/수정/삭제)
+                        .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/post/v1/artists/*/fan-posts/*").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/fan-posts/*").authenticated()
+                        .requestMatchers("/api/post/v1/fan-posts").authenticated()
+
+                        // 좋아요, 댓글
+                        .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts/*/likes/toggle").authenticated()
+                        .requestMatchers("/api/post/v1/comments/**", "/api/post/v1/*/likes/toggle").authenticated()
+
+                        // 팬레터 (구독 검증은 서비스 레이어에서 수행)
+                        .requestMatchers("/api/post/v1/fan-letters/**").authenticated()
+
+                        // 회원, 결제, 구독, 알림
+                        .requestMatchers("/api/member/v1/**").authenticated()
+                        .requestMatchers("/api/payment/v1/**").authenticated()
+                        .requestMatchers("/sub/user/{userId}/notifications").authenticated()
                 )
 
                 // 3. 예외 핸들링 (EntryPoint, DeniedHandler 운영)


### PR DESCRIPTION
## 배경                                                                                                                                          
  4/18 MemberRole Chore 수정사항 복구. 아래 3건을 한 번에 정리.                                                         
                                                                                                                                                   
  ## 변경 사항

  ### 1. MemberRole 회귀 수정 (커밋 f1bfdcf)
  - `MemberRole.USER` → `MemberRole.MEMBER` (Member.java, MemberService.java)
  - `MemberRole.ARTIST_ADMIN` → `MemberRole.ARTIST` (MemberService.java, ArtistService.java, ArtistMemberService.java)
  - `getRole().getSecurityName()` → `getRole().name()` (MemberDetailsImpl.java, AuthService.java, MemberService.java)
  - 주석 문구도 현행 Role 표기로 갱신 (MemberService.java, AdminMemberController.java)

  ### 2. SecurityConfig 재정비 (커밋 8bd5583)
  - `hasRole("ADMIN")` → `hasRole("SUPER_ADMIN")` — ADMIN Role은 존재하지 않음
  - `hasAnyRole("USER", "SUBSCRIBER", ...)` → `authenticated()` — USER/SUBSCRIBER Role은 존재하지 않음. 구독 검증은 서비스 레이어에서 수행하는 것이
   확정 정책
  - 래플/라이브 관리자 매처 추가: `/api/v1/admin/artists/*/raffles/**`, `/api/v1/admin/artists/*/lives/**` (`ARTIST` + `SUPER_ADMIN`)
  - 래플 사용자 매처 추가: `/api/v1/artists/*/raffles/*/entries/**`, `/api/v1/users/me/raffle-entries`
  - 래플/라이브 공개 GET 매처 추가 (목록/상세/채팅 메시지 비회원 조회 허용)
  - 결제 경로 통합: `/api/payment/v1/**` 단일 매처로 통합
  - TODO 주석 제거

  ### 3. 래플 컨트롤러 사용자 식별 전환 (커밋 1214e9c)
  - `@RequestHeader("X-User-Id")` → `@AuthenticationPrincipal MemberDetailsImpl`
  - userId는 `MemberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId()`로 조회
  - 적용 엔드포인트 4개: `enter`, `getRaffleDetail`, `getMyResult`, `getMyEntries`
  - 헤더 위조에 의한 인증 우회 가능성 차단

  ## 검증
  - `grep ARTIST_ADMIN|MemberRole.USER|getSecurityName` → 0건
  - `grep X-User-Id` (raffle 디렉터리) → 0건
  - SecurityConfig에 `"USER"`/`"SUBSCRIBER"`/`"ADMIN"` (SUPER_ADMIN 제외) → 0건
  - `./gradlew compileJava` → BUILD SUCCESSFUL