### PR TITLE
Feat: JWT memberId claim 추가 + WebSocket/STOMP 기본 설정   

### DIFF
--- a/src/main/java/com/example/infinite/domain/member/member/service/AuthService.java
+++ b/src/main/java/com/example/infinite/domain/member/member/service/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
         }
 
         // 토큰 생성 (Subject로 이메일 사용)
-        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name());
+        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name(), member.getId());
         return new TokenResponse(accessToken, "Bearer");
     }
 }

--- a/src/main/java/com/example/infinite/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/example/infinite/domain/member/member/service/MemberService.java
@@ -78,7 +78,7 @@ public class MemberService {
         member.changeEmail(nextEmail);
 
         // JWT subject가 email이므로 이메일 변경 직후 새 토큰을 재발급한다.
-        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name());
+        String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().name(), member.getId());
         return new TokenResponse(accessToken, "Bearer");
     }
 

--- a/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
+++ b/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
@@ -1,7 +1,5 @@
 package com.example.infinite.domain.raffle.controller;
 
-import com.example.infinite.domain.member.member.support.MemberInputSupport;
-import com.example.infinite.domain.member.member.support.MemberReader;
 import com.example.infinite.domain.raffle.dto.EntryResponse;
 import com.example.infinite.domain.raffle.dto.MyEntryResultResponse;
 import com.example.infinite.domain.raffle.dto.MyRaffleEntryResponse;
@@ -25,14 +23,13 @@ public class RaffleController {
 
     private final RaffleEntryService raffleEntryService;
     private final RaffleService raffleService;
-    private final MemberReader memberReader;
 
     @PostMapping("/api/v1/artists/{artistId}/raffles/{raffleId}/entries")
     public ResponseEntity<ApiResponse<EntryResponse>> enter(
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
+        Long userId = memberDetails.getMemberId();
         EntryResponse response = raffleEntryService.enter(artistId, raffleId, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -49,7 +46,7 @@ public class RaffleController {
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
+        Long userId = memberDetails.getMemberId();
         RaffleDetailResponse response = raffleService.getRaffleDetail(artistId, raffleId, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -59,7 +56,7 @@ public class RaffleController {
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
+        Long userId = memberDetails.getMemberId();
         MyEntryResultResponse response = raffleService.getMyResult(artistId, raffleId, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -67,7 +64,7 @@ public class RaffleController {
     @GetMapping("/api/v1/users/me/raffle-entries")
     public ResponseEntity<ApiResponse<List<MyRaffleEntryResponse>>> getMyEntries(
             @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        Long userId = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails)).getId();
+        Long userId = memberDetails.getMemberId();
         List<MyRaffleEntryResponse> response = raffleService.getMyEntries(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/infinite/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/infinite/global/auth/JwtTokenProvider.java
@@ -30,6 +30,7 @@ public class JwtTokenProvider {
     // 1. Claim 키 상수 — 생성과 소비가 반드시 같은 키를 참조
     // ──────────────────────────────────────────────
     private static final String CLAIM_ROLE = "role";
+    private static final String CLAIM_MEMBER_ID = "memberId";
     private static final String CLAIM_TYPE = "type";
     private static final String TOKEN_TYPE_ACCESS = "ACCESS";
 
@@ -54,13 +55,14 @@ public class JwtTokenProvider {
     // ──────────────────────────────────────────────
     // 2. 토큰 생성
     // ──────────────────────────────────────────────
-    public String createToken(String userEmail, String role) {
+    public String createToken(String userEmail, String role, Long memberId) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
                 .subject(userEmail)
-                .claim(CLAIM_ROLE, role)           // 상수 사용
+                .claim(CLAIM_ROLE, role)
+                .claim(CLAIM_MEMBER_ID, memberId)
                 .claim(CLAIM_TYPE, TOKEN_TYPE_ACCESS)
                 .issuedAt(now)
                 .expiration(validity)
@@ -94,15 +96,17 @@ public class JwtTokenProvider {
     //    수정: getAuthentication(Claims claims) → 이중 파싱 제거
     // ──────────────────────────────────────────────
     public Authentication getAuthentication(Claims claims) {
-        String role = claims.get(CLAIM_ROLE, String.class);   // 상수 사용 → 불일치 원천 차단
+        String role = claims.get(CLAIM_ROLE, String.class);
+        Long memberId = claims.get(CLAIM_MEMBER_ID, Long.class);
 
         if (role == null) {
             throw new BusinessException(ErrorCode.INVALID_AUTHENTICATION);
         }
 
         UserDetails userDetails = MemberDetailsImpl.fromToken(
-                claims.getSubject(),    // email
-                role                    // role
+                claims.getSubject(),
+                role,
+                memberId
         );
 
         return new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
+++ b/src/main/java/com/example/infinite/global/auth/MemberDetailsImpl.java
@@ -18,19 +18,22 @@ import java.util.Collections;
 @Getter
 public class MemberDetailsImpl implements UserDetails {
 
+    private final Long memberId;
     private final String email;
     private final String role;
     private final String status;
 
     // 1. DB 엔티티 기반 생성자
     public MemberDetailsImpl(Member member) {
+        this.memberId = member.getId();
         this.email = member.getEmail();
         this.role = "ROLE_" + member.getRole().name();
         this.status = member.getStatus().name();
     }
 
     // 2. 토큰 기반 생성자 (동일하게 처리)
-    private MemberDetailsImpl(String email, String role) {
+    private MemberDetailsImpl(String email, String role, Long memberId) {
+        this.memberId = memberId;
         this.email = email;
 
         this.role = role.startsWith("ROLE_") ? role : "ROLE_" + role;
@@ -41,8 +44,8 @@ public class MemberDetailsImpl implements UserDetails {
      * 토큰에서 추출한 정보만으로 인증 객체를 생성하는 정적 팩토리 메서드입니다.
      * 이 메서드 덕분에 매 요청마다 DB Select 쿼리가 발생하는 부하를 원천 차단합니다.
      */
-    public static MemberDetailsImpl fromToken(String email, String role) {
-        return new MemberDetailsImpl(email, role);
+    public static MemberDetailsImpl fromToken(String email, String role, Long memberId) {
+        return new MemberDetailsImpl(email, role, memberId);
     }
 
     @Override

--- a/src/main/java/com/example/infinite/global/auth/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/example/infinite/global/auth/StompAuthChannelInterceptor.java
@@ -1,0 +1,71 @@
+package com.example.infinite.global.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
+
+        // CONNECT 시점에만 JWT 검증 수행
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String token = resolveToken(accessor);
+
+            if (!StringUtils.hasText(token)) {
+                log.warn("STOMP CONNECT: Authorization 헤더 없음");
+                throw new IllegalArgumentException("STOMP 연결에 JWT 토큰이 필요합니다.");
+            }
+
+            try {
+                Claims claims = jwtTokenProvider.validateToken(token);
+                Authentication authentication = jwtTokenProvider.getAuthentication(claims);
+                // 인증 정보를 STOMP 세션에 바인딩
+                // 이후 메시지에서 accessor.getUser()로 접근 가능
+                accessor.setUser(authentication);
+            } catch (ExpiredJwtException e) {
+                log.warn("STOMP CONNECT: 만료된 토큰 - {}", e.getMessage());
+                throw new IllegalArgumentException("만료된 토큰입니다.");
+            } catch (JwtException | IllegalArgumentException e) {
+                log.warn("STOMP CONNECT: 유효하지 않은 토큰 - {}", e.getMessage());
+                throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+            }
+        }
+
+        return message;
+    }
+
+    private String resolveToken(StompHeaderAccessor accessor) {
+        // STOMP 헤더에서 Authorization: Bearer xxx 추출
+        String bearerToken = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/infinite/global/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/WebSocketConfig.java
@@ -1,0 +1,41 @@
+package com.example.infinite.global.common.config;
+
+import com.example.infinite.global.auth.StompAuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독 경로: /sub/live/{liveId}, /sub/dm/{roomId}, /sub/user/{userId}/notifications
+        registry.enableSimpleBroker("/sub");
+        // 발행 경로: /pub/live/{liveId}/chat, /pub/dm/{roomId}
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // SecurityConfig에서 /ws-stomp/** permitAll() 처리됨
+        // JWT 인증은 ChannelInterceptor에서 CONNECT 시점에 수행
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // STOMP CONNECT 시 JWT 검증 인터셉터 등록
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}


### PR DESCRIPTION
## 배경                                                                                                                                          
  1. 래플 등 userId(Long)만 필요한 도메인에서 매 요청마다 email 기반 DB 조회가 발생하던 문제 해결                                                  
  2. 라이브 채팅/DM 실시간 통신 인프라 기반 마련 (연결 + JWT 인증까지)                                                                             
                                                                                                                                                   
  ## 변경 사항

  ### 1. JWT memberId claim 추가 (커밋 1b417e9)
  - `JwtTokenProvider.createToken(email, role, memberId)`로 시그니처 확장, JWT에 `memberId` claim 발행
  - `JwtTokenProvider.getAuthentication(claims)`에서 memberId 추출 후 MemberDetailsImpl에 전달
  - `MemberDetailsImpl`에 `Long memberId` 필드 추가 (DB 생성자/토큰 생성자/`fromToken` 모두 갱신)
  - `AuthService`, `MemberService`의 `createToken` 호출부 3인자로 갱신
  - `RaffleController` 4개 엔드포인트: `memberReader.findByEmailOrThrow(...).getId()` → `memberDetails.getMemberId()` (DB 조회 제거)
  - `MemberReader`/`MemberInputSupport` import 및 필드 제거

  ### 2. WebSocket/STOMP 기본 설정 (커밋 a8aab9f)
  - `WebSocketConfig`: SimpleBroker(`/sub`), App prefix(`/pub`), `/ws-stomp` 엔드포인트 + SockJS, ChannelInterceptor 등록
  - `StompAuthChannelInterceptor`: STOMP CONNECT 시점에만 `Authorization: Bearer ...` 헤더 검증, `accessor.setUser(authentication)`으로 세션에 인증
   바인딩
  - 만료/유효하지 않은 토큰은 `IllegalArgumentException`으로 차단

  ## 설계 근거
  - **CONNECT 1회 검증**: 동일 WebSocket 세션 내 SEND/SUBSCRIBE는 재검증 불필요
  - **HTTP 필터와 동일한 흐름 재사용**: `validateToken → getAuthentication`로 일관성 유지
  - **SockJS 활성화**: 비지원 브라우저 폴백 + 테스트 도구 호환성

  ## 검증
  - `./gradlew compileJava` → BUILD SUCCESSFUL (Phase 1, Phase 2 각각 확인)
  - `createToken` 호출부 모두 3인자 (email, role, memberId)
  - `RaffleController`에서 `memberReader`/`MemberInputSupport` 참조 0건

  ## 범위 외 (별도 처리)
  - 배치 브로드캐스트 / 쓰로틀링 / Redis Pub-Sub 다중 서버: 별도 이슈 & PR 생성
  - DM 메시지 핸들러: 차후 처리
  
  Close #66 
