### PR TITLE
Feat: 젤리 수동 결제 기능 구현 (PortOne 웹훅 연동) + DmSubscription·FanMembership jellyAmount 추가

### DIFF
--- a/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
+++ b/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
@@ -1,5 +1,6 @@
 package com.example.infinite.domain.payment.client;
 
+import com.example.infinite.domain.payment.dto.response.PortOnePaymentResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -55,6 +56,20 @@ public class PortOneClient {
                     .toBodilessEntity();
         } catch (Exception e) {
             log.error("PortOne 자동충전 결제 실패: userId={}, amount={}, error={}", userId, amount, e.getMessage());
+            throw e;
+        }
+    }
+
+    // PortOne 결제 단건 조회 — 웹훅 수신 후 결제 상태·금액 검증에 사용
+    public PortOnePaymentResponse getPayment(String paymentId) {
+        try {
+            return restClient.get()
+                    .uri("/payments/{paymentId}", paymentId)
+                    .header("Authorization", "PortOne " + apiSecret)
+                    .retrieve()
+                    .body(PortOnePaymentResponse.class);
+        } catch (Exception e) {
+            log.error("PortOne 결제 조회 실패: paymentId={}, error={}", paymentId, e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/com/example/infinite/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/PaymentController.java
@@ -1,0 +1,35 @@
+package com.example.infinite.domain.payment.controller;
+
+import com.example.infinite.domain.payment.dto.request.PaymentPrepareRequest;
+import com.example.infinite.domain.payment.dto.request.PortOneWebhookRequest;
+import com.example.infinite.domain.payment.dto.response.PaymentPrepareResponse;
+import com.example.infinite.domain.payment.service.PaymentService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payment/v1/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    // 결제 준비 — paymentId 발급
+    // 클라이언트는 응답받은 paymentId와 amount를 PortOne SDK에 전달해 결제 진행
+    @PostMapping("/prepare")
+    public ApiResponse<PaymentPrepareResponse> prepare(
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody PaymentPrepareRequest request) {
+        return ApiResponse.success(paymentService.prepare(userId, request));
+    }
+
+    // PortOne 웹훅 수신 — 결제 완료 시 PortOne 서버에서 직접 호출
+    // 인증 헤더 불필요, 내부에서 PortOne API 재검증으로 위변조 방지
+    @PostMapping("/webhook")
+    public ApiResponse<Void> webhook(@RequestBody PortOneWebhookRequest request) {
+        paymentService.handleWebhook(request);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/dto/request/PaymentPrepareRequest.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/request/PaymentPrepareRequest.java
@@ -1,0 +1,8 @@
+package com.example.infinite.domain.payment.dto.request;
+
+import com.example.infinite.domain.payment.enums.JellyProduct;
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentPrepareRequest(
+        @NotNull JellyProduct jellyProduct
+) {}

--- a/src/main/java/com/example/infinite/domain/payment/dto/request/PortOneWebhookRequest.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/request/PortOneWebhookRequest.java
@@ -1,0 +1,10 @@
+package com.example.infinite.domain.payment.dto.request;
+
+// PortOne v2 웹훅 페이로드
+// { "type": "Transaction.Paid", "data": { "paymentId": "...", "transactionId": "..." } }
+public record PortOneWebhookRequest(
+        String type,
+        Data data
+) {
+    public record Data(String paymentId, String transactionId) {}
+}

--- a/src/main/java/com/example/infinite/domain/payment/dto/response/PaymentPrepareResponse.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/response/PaymentPrepareResponse.java
@@ -1,0 +1,9 @@
+package com.example.infinite.domain.payment.dto.response;
+
+// 결제 준비 응답 — 클라이언트가 PortOne SDK에 paymentId와 amount를 전달해 결제 진행
+public record PaymentPrepareResponse(
+        String paymentId,   // PortOne SDK에 전달할 결제 식별자
+        String orderName,   // PortOne 결제창에 표시할 상품명
+        int jellyAmount,    // 지급될 젤리 수량
+        int amount          // 원화 결제 금액
+) {}

--- a/src/main/java/com/example/infinite/domain/payment/dto/response/PortOnePaymentResponse.java
+++ b/src/main/java/com/example/infinite/domain/payment/dto/response/PortOnePaymentResponse.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.payment.dto.response;
+
+// PortOne GET /payments/{paymentId} 응답 역직렬화용
+public record PortOnePaymentResponse(
+        String status,  // PAID, FAILED, CANCELLED 등
+        String id,
+        Amount amount
+) {
+    public record Amount(int total) {}
+
+    public boolean isPaid() {
+        return "PAID".equals(status);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/entity/PaymentOrder.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/PaymentOrder.java
@@ -1,0 +1,63 @@
+package com.example.infinite.domain.payment.entity;
+
+import com.example.infinite.domain.payment.enums.JellyProduct;
+import com.example.infinite.domain.payment.enums.PaymentStatus;
+import com.example.infinite.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "payment_orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentOrder extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String paymentId; // PortOne 결제 식별자 (UUID), 웹훅 검증 키
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JellyProduct jellyProduct;
+
+    @Column(nullable = false)
+    private int amount; // 원화 결제 금액 (prepare 시점 스냅샷)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column
+    private LocalDateTime paidAt;
+
+    @Builder
+    public PaymentOrder(String paymentId, Long userId, JellyProduct jellyProduct, int amount) {
+        this.paymentId = paymentId;
+        this.userId = userId;
+        this.jellyProduct = jellyProduct;
+        this.amount = amount;
+        this.status = PaymentStatus.PENDING;
+    }
+
+    // 결제·젤리 지급 완료
+    public void complete() {
+        this.status = PaymentStatus.PAID;
+        this.paidAt = LocalDateTime.now();
+    }
+
+    // 결제 실패 또는 검증 실패
+    public void fail() {
+        this.status = PaymentStatus.FAILED;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/enums/JellyProduct.java
+++ b/src/main/java/com/example/infinite/domain/payment/enums/JellyProduct.java
@@ -1,0 +1,21 @@
+package com.example.infinite.domain.payment.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JellyProduct {
+    JELLY_10(10, "젤리 10개"),
+    JELLY_50(50, "젤리 50개"),
+    JELLY_100(100, "젤리 100개"),
+    JELLY_500(500, "젤리 500개");
+
+    private final int jellyAmount;
+    private final String orderName;
+
+    // 젤리 수량 × 단가 = 원화 결제 금액
+    public int getPrice(int pricePerUnit) {
+        return jellyAmount * pricePerUnit;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/example/infinite/domain/payment/enums/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.payment.enums;
+
+public enum PaymentStatus {
+    PENDING,  // 결제 준비 완료, PortOne 결제 대기 중
+    PAID,     // 결제 완료, 젤리 지급 완료
+    FAILED    // 결제 실패 또는 검증 실패
+}

--- a/src/main/java/com/example/infinite/domain/payment/repository/PaymentOrderRepository.java
+++ b/src/main/java/com/example/infinite/domain/payment/repository/PaymentOrderRepository.java
@@ -1,0 +1,11 @@
+package com.example.infinite.domain.payment.repository;
+
+import com.example.infinite.domain.payment.entity.PaymentOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
+
+    Optional<PaymentOrder> findByPaymentId(String paymentId);
+}

--- a/src/main/java/com/example/infinite/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/PaymentService.java
@@ -1,0 +1,98 @@
+package com.example.infinite.domain.payment.service;
+
+import com.example.infinite.domain.payment.client.PortOneClient;
+import com.example.infinite.domain.payment.config.JellyProperties;
+import com.example.infinite.domain.payment.dto.request.PaymentPrepareRequest;
+import com.example.infinite.domain.payment.dto.request.PortOneWebhookRequest;
+import com.example.infinite.domain.payment.dto.response.PaymentPrepareResponse;
+import com.example.infinite.domain.payment.dto.response.PortOnePaymentResponse;
+import com.example.infinite.domain.payment.entity.PaymentOrder;
+import com.example.infinite.domain.payment.enums.PaymentStatus;
+import com.example.infinite.domain.payment.enums.ReferenceType;
+import com.example.infinite.domain.payment.repository.PaymentOrderRepository;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentOrderRepository paymentOrderRepository;
+    private final PortOneClient portOneClient;
+    private final JellyService jellyService;
+    private final JellyProperties jellyProperties;
+
+    // 결제 준비 — paymentId 발급 후 클라이언트에 반환
+    // 클라이언트는 이 paymentId를 PortOne SDK에 전달해 결제 진행
+    @Transactional
+    public PaymentPrepareResponse prepare(Long userId, PaymentPrepareRequest request) {
+        int amount = request.jellyProduct().getPrice(jellyProperties.pricePerUnit());
+        String paymentId = UUID.randomUUID().toString();
+
+        paymentOrderRepository.save(PaymentOrder.builder()
+                .paymentId(paymentId)
+                .userId(userId)
+                .jellyProduct(request.jellyProduct())
+                .amount(amount)
+                .build());
+
+        return new PaymentPrepareResponse(
+                paymentId,
+                request.jellyProduct().getOrderName(),
+                request.jellyProduct().getJellyAmount(),
+                amount
+        );
+    }
+
+    // 웹훅 처리 — PortOne 결제 완료 시 호출
+    // @RedisLock: 동일 paymentId 웹훅 중복 수신 시 직렬화하여 이중 지급 방지
+    @RedisLock(key = "'payment:webhook:' + #request.data().paymentId()", waitTime = 3, leaseTime = 10)
+    @Transactional
+    public void handleWebhook(PortOneWebhookRequest request) {
+        // Transaction.Paid 타입만 처리, 그 외 이벤트(취소 등)는 무시
+        if (!"Transaction.Paid".equals(request.type())) {
+            return;
+        }
+
+        String paymentId = request.data().paymentId();
+        PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_ORDER_NOT_FOUND));
+
+        // 이미 처리된 주문 — 웹훅 중복 수신 방어 (idempotency)
+        if (order.getStatus() != PaymentStatus.PENDING) {
+            log.info("이미 처리된 결제 웹훅 무시: paymentId={}, status={}", paymentId, order.getStatus());
+            return;
+        }
+
+        // PortOne API로 결제 상태 검증
+        PortOnePaymentResponse portOnePayment = portOneClient.getPayment(paymentId);
+        if (!portOnePayment.isPaid()) {
+            order.fail();
+            log.warn("결제 미완료 웹훅 수신: paymentId={}, portOneStatus={}", paymentId, portOnePayment.status());
+            return;
+        }
+
+        // 금액 검증 — 클라이언트 위변조 방지
+        if (portOnePayment.amount().total() != order.getAmount()) {
+            order.fail();
+            log.error("결제 금액 불일치: paymentId={}, expected={}, actual={}",
+                    paymentId, order.getAmount(), portOnePayment.amount().total());
+            throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        // 젤리 지급 후 주문 완료 처리
+        jellyService.charge(order.getUserId(), order.getJellyProduct().getJellyAmount(),
+                ReferenceType.PAYMENT, order.getId());
+        order.complete();
+        log.info("수동 결제 젤리 지급 완료: userId={}, jellies={}, paymentId={}",
+                order.getUserId(), order.getJellyProduct().getJellyAmount(), paymentId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/DmSubscription.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/DmSubscription.java
@@ -40,13 +40,17 @@ public class DmSubscription extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @Column(nullable = false)
+    private int jellyAmount; // 구매 시점 젤리 차감액 스냅샷 (가격 정책 변경 시에도 이력 보존)
+
     @Builder
-    public DmSubscription(Long userId, Long artistId, LocalDateTime startedAt, LocalDateTime expiredAt) {
+    public DmSubscription(Long userId, Long artistId, LocalDateTime startedAt, LocalDateTime expiredAt, int jellyAmount) {
         this.userId = userId;
         this.artistId = artistId;
         this.status = SubscriptionStatus.ACTIVE;
         this.startedAt = startedAt;
         this.expiredAt = expiredAt;
+        this.jellyAmount = jellyAmount;
     }
 
     public void expire() {

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/FanMembership.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/FanMembership.java
@@ -40,14 +40,18 @@ public class FanMembership extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @Column(nullable = false)
+    private int jellyAmount; // 구매 시점 젤리 차감액 스냅샷 (가격 정책 변경 시에도 이력 보존)
+
     @Builder
     public FanMembership(Long userId, Long artistId,
-                         LocalDateTime startedAt, LocalDateTime expiredAt) {
+                         LocalDateTime startedAt, LocalDateTime expiredAt, int jellyAmount) {
         this.userId = userId;
         this.artistId = artistId;
         this.status = SubscriptionStatus.ACTIVE;
         this.startedAt = startedAt;
         this.expiredAt = expiredAt;
+        this.jellyAmount = jellyAmount;
     }
 
     public void expire() {

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/service/SubscriptionMembershipService.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/service/SubscriptionMembershipService.java
@@ -43,6 +43,7 @@ public class SubscriptionMembershipService {
                 .artistId(artistId)
                 .startedAt(now)
                 .expiredAt(now.plusDays(30))
+                .jellyAmount(jellyProperties.dmSubscriptionCost())
                 .build());
     }
 
@@ -60,6 +61,7 @@ public class SubscriptionMembershipService {
                 .artistId(artistId)
                 .startedAt(now)
                 .expiredAt(now.plusDays(30))
+                .jellyAmount(jellyProperties.fanMembershipCost())
                 .build());
     }
 

--- a/src/main/java/com/example/infinite/global/error/ErrorCode.java
+++ b/src/main/java/com/example/infinite/global/error/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode implements ErrorCodeType {
     REFUND_NOT_ELIGIBLE(HttpStatus.BAD_REQUEST, "P005", "환불 정책 조건을 충족하지 않습니다."),
     BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "P006", "등록된 카드 정보를 찾을 수 없습니다."),
     AUTO_CHARGE_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "P007", "자동충전 설정 정보를 찾을 수 없습니다."),
+    PAYMENT_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P008", "결제 주문 정보를 찾을 수 없습니다."),
+    PAYMENT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "P009", "이미 처리된 결제 주문입니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "P010", "실제 결제 금액과 주문 금액이 일치하지 않습니다."),
 
     // 3. DM (Direct Message)
     DM_SUBSCRIPTION_REQUIRED(HttpStatus.FORBIDDEN, "D001", "DM 구독 상태인 유저만 이용 가능합니다."),


### PR DESCRIPTION
  ## Summary                                                                                                                                                     
  - DmSubscription·FanMembership 엔티티에 구매 시점 jellyAmount 스냅샷 필드 추가 (팀 ERD 검토 반영)                                                              
  - 젤리 수동 결제 기능 구현 (10 / 50 / 100 / 500 젤리 패키지)
  - PortOne 웹훅 수신 후 금액 검증 → 젤리 지급 흐름 구현

  ## 결제 흐름
  1. `POST /api/payment/v1/payments/prepare` — paymentId 발급
  2. 클라이언트 → PortOne SDK로 결제 진행
  3. `POST /api/payment/v1/payments/webhook` — PortOne 콜백 수신
  4. PortOne API 재검증 (상태·금액) → 젤리 지급

  ## 주요 설계 포인트
  - `@RedisLock` 으로 동일 paymentId 웹훅 중복 수신 시 이중 지급 방지
  - status != PENDING 체크로 idempotency 보장
  - 금액 검증으로 클라이언트 위변조 방지
  - 결제 실패 / 금액 불일치 각각 구분하여 PaymentOrder.status 업데이트

  ## Test plan
  - [ ] prepare API 호출 시 paymentId 반환 확인
  - [ ] 정상 웹훅 수신 시 젤리 지급 및 PAID 상태 전환 확인
  - [ ] 동일 paymentId 웹훅 중복 수신 시 이중 지급 없음 확인
  - [ ] 금액 불일치 웹훅 수신 시 FAILED 처리 확인
****