### PR TITLE
Fix/#70 payment webhook security

### DIFF
--- a/src/main/java/com/example/infinite/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/PaymentController.java
@@ -5,16 +5,31 @@ import com.example.infinite.domain.payment.dto.request.PortOneWebhookRequest;
 import com.example.infinite.domain.payment.dto.response.PaymentPrepareResponse;
 import com.example.infinite.domain.payment.service.PaymentService;
 import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.HexFormat;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/payment/v1/payments")
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final ObjectMapper objectMapper;
+
+    // PortOne 콘솔 → 웹훅 시크릿 값 (application.yml → 환경변수)
+    @Value("${portone.webhook-secret}")
+    private String webhookSecret;
 
     // 결제 준비 — paymentId 발급
     // 클라이언트는 응답받은 paymentId와 amount를 PortOne SDK에 전달해 결제 진행
@@ -26,10 +41,59 @@ public class PaymentController {
     }
 
     // PortOne 웹훅 수신 — 결제 완료 시 PortOne 서버에서 직접 호출
-    // 인증 헤더 불필요, 내부에서 PortOne API 재검증으로 위변조 방지
+    // 1. 요청 본문을 byte[] 로 받아 HMAC-SHA256 서명을 먼저 검증한다 (위변조 방지).
+    // 2. 검증 통과 후 byte[] 를 PortOneWebhookRequest 로 역직렬화해 서비스에 전달한다.
+    // SecurityConfig 에서 이 경로는 permitAll() 로 열어두었기 때문에
+    // JWT 없이 호출하는 PortOne 서버가 401 로 차단되지 않는다.
     @PostMapping("/webhook")
-    public ApiResponse<Void> webhook(@RequestBody PortOneWebhookRequest request) {
-        paymentService.handleWebhook(request);
+    public ApiResponse<Void> webhook(
+            // PortOne이 요청마다 붙이는 HMAC-SHA256 서명 헤더
+            @RequestHeader("x-portone-signature") String signature,
+            // 서명 검증을 위해 원본 바이트를 그대로 받는다 (Jackson 파싱 전)
+            @RequestBody byte[] rawBody) {
+
+        // ── 서명 검증 ──────────────────────────────────────────────────────
+        // 서명 불일치 시 공격성 요청으로 간주하고 즉시 거부
+        verifySignature(rawBody, signature);
+
+        // ── 역직렬화 ───────────────────────────────────────────────────────
+        PortOneWebhookRequest request;
+        try {
+            request = objectMapper.readValue(rawBody, PortOneWebhookRequest.class);
+        } catch (Exception e) {
+            log.error("웹훅 본문 역직렬화 실패: {}", e.getMessage());
+            throw new PaymentException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // paymentId를 파라미터로 분리해서 전달 — RedisLock SpEL 안정성 확보
+        paymentService.handleWebhook(request.data().paymentId(), request);
         return ApiResponse.success(null);
+    }
+
+    /**
+     * PortOne 웹훅 서명 검증 (HMAC-SHA256)
+     * <p>
+     * PortOne은 웹훅 요청 본문을 webhook-secret 키로 HMAC-SHA256 해시한 뒤
+     * 결과를 16진수 문자열로 인코딩해 x-portone-signature 헤더에 담아 보낸다.
+     * 동일한 연산을 서버에서 수행해 일치 여부를 확인함으로써
+     * 요청이 PortOne 서버에서 온 것임을 보장한다.
+     */
+    private void verifySignature(byte[] rawBody, String signature) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(webhookSecret.getBytes(), "HmacSHA256"));
+            String expected = HexFormat.of().formatHex(mac.doFinal(rawBody));
+
+            if (!expected.equals(signature)) {
+                log.warn("웹훅 서명 불일치: expected={}, received={}", expected, signature);
+                throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
+            }
+        } catch (PaymentException e) {
+            throw e;
+        } catch (Exception e) {
+            // HMAC 알고리즘 초기화 실패 등 예상치 못한 오류
+            log.error("웹훅 서명 검증 중 오류 발생: {}", e.getMessage());
+            throw new PaymentException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/PaymentService.java
@@ -53,16 +53,19 @@ public class PaymentService {
     }
 
     // 웹훅 처리 — PortOne 결제 완료 시 호출
+    // paymentId를 메서드 파라미터로 분리한 이유:
+    //   SpEL에서 중첩 record 접근( #request.data().paymentId() )은 프록시 구조상
+    //   컴파일 타임에 파라미터명 바인딩이 불안정할 수 있다.
+    //   최상위 파라미터( #paymentId )로 키를 지정해 확실한 락 동작을 보장한다.
     // @RedisLock: 동일 paymentId 웹훅 중복 수신 시 직렬화하여 이중 지급 방지
-    @RedisLock(key = "'payment:webhook:' + #request.data().paymentId()", waitTime = 3, leaseTime = 10)
+    @RedisLock(key = "'payment:webhook:' + #paymentId", waitTime = 3, leaseTime = 10)
     @Transactional
-    public void handleWebhook(PortOneWebhookRequest request) {
+    public void handleWebhook(String paymentId, PortOneWebhookRequest request) {
         // Transaction.Paid 타입만 처리, 그 외 이벤트(취소 등)는 무시
         if (!"Transaction.Paid".equals(request.type())) {
             return;
         }
 
-        String paymentId = request.data().paymentId();
         PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_ORDER_NOT_FOUND));
 

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -100,6 +100,10 @@ public class SecurityConfig {
                         // 팬레터 (구독 검증은 서비스 레이어에서 수행)
                         .requestMatchers("/api/post/v1/fan-letters/**").authenticated()
 
+                        // 웹훅 — PortOne 서버가 JWT 없이 직접 호출하므로 인증 제외
+                        // 위변조 방지는 Controller의 HMAC-SHA256 서명 검증으로 수행
+                        .requestMatchers("/api/payment/v1/payments/webhook").permitAll()
+
                         // 회원, 결제, 구독, 알림
                         .requestMatchers("/api/member/v1/**").authenticated()
                         .requestMatchers("/api/payment/v1/**").authenticated()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,8 @@ jwt:
 # PortOne
 portone:
   api-secret: ${PORTONE_API_SECRET:test_dummy_secret_for_local}
+  # 웹훅 서명 검증용 시크릿 — PortOne 콘솔에서 발급, 운영 환경에서는 반드시 환경변수로 주입
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:test_dummy_webhook_secret_for_local}
 
 # Jelly
 jelly:


### PR DESCRIPTION
  제목:                                                                                                                                                          
  Fix: PortOne 웹훅 보안 취약점 3종 수정 (#70)                                                                                                                   
                                                                                                                                                                 
  본문:                                                                                                                                                          
  ## Summary                                                                                                                                                     
  - SecurityConfig에 웹훅 엔드포인트 permitAll 추가 (PortOne 서버 JWT 없이 호출)
  - application.yml에 portone.webhook-secret 설정 추가
  - PaymentService RedisLock SpEL 키를 최상위 파라미터로 분리 (중첩 record 불안정 이슈)
  - PaymentController에 HMAC-SHA256 서명 검증 추가 (위변조 요청 차단)

  ## Test plan
  - [ ] PortOne 웹훅 호출 시 401 없이 정상 수신되는지 확인
  - [ ] 잘못된 서명(x-portone-signature)으로 요청 시 결제 검증 실패 에러 반환 확인
  - [ ] 동일 paymentId 웹훅 중복 수신 시 RedisLock 동작 및 이중 지급 방지 확인
 Closes #70 