### PR TITLE
Feat: #72 라이브 채팅 배치 브로드캐스트 + 쓰로틀링 + Pub/Sub Jackson 통일

### DIFF
--- a/src/main/java/com/example/infinite/domain/realtimelive/config/RedisLiveChatConfig.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/config/RedisLiveChatConfig.java
@@ -1,0 +1,36 @@
+package com.example.infinite.domain.realtimelive.config;
+
+import com.example.infinite.domain.realtimelive.service.RedisLiveChatSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class RedisLiveChatConfig {
+
+    private static final String REDIS_LIVE_CHAT_CHANNEL = "live:chat:broadcast";
+
+    @Bean
+    public ChannelTopic liveChatTopic() {
+        return new ChannelTopic(REDIS_LIVE_CHAT_CHANNEL);
+    }
+
+    @Bean
+    public MessageListenerAdapter liveChatListenerAdapter(RedisLiveChatSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    @Bean
+    public RedisMessageListenerContainer liveChatListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter liveChatListenerAdapter,
+            ChannelTopic liveChatTopic) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(liveChatListenerAdapter, liveChatTopic);
+        return container;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/config/RedisLiveChatConfig.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/config/RedisLiveChatConfig.java
@@ -1,12 +1,16 @@
 package com.example.infinite.domain.realtimelive.config;
 
 import com.example.infinite.domain.realtimelive.service.RedisLiveChatSubscriber;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisLiveChatConfig {
@@ -18,9 +22,28 @@ public class RedisLiveChatConfig {
         return new ChannelTopic(REDIS_LIVE_CHAT_CHANNEL);
     }
 
+    /**
+     * 라이브 채팅 Pub/Sub 전용 RedisTemplate.
+     * 값 직렬화를 Jackson JSON으로 통일해 구독 측 ObjectMapper.readValue와 호환시킨다.
+     */
+    @Bean
+    public RedisTemplate<String, Object> liveChatRedisTemplate(
+            RedisConnectionFactory connectionFactory,
+            ObjectMapper objectMapper) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
+    }
+
     @Bean
     public MessageListenerAdapter liveChatListenerAdapter(RedisLiveChatSubscriber subscriber) {
-        return new MessageListenerAdapter(subscriber, "onMessage");
+        MessageListenerAdapter adapter = new MessageListenerAdapter(subscriber, "onMessage");
+        // 발행 측이 Jackson으로 JSON 바이트를 보내므로 어댑터도 StringRedisSerializer로 맞춰
+        // onMessage(String) 시그니처에 JSON 텍스트가 그대로 전달되도록 한다.
+        adapter.setSerializer(new StringRedisSerializer());
+        return adapter;
     }
 
     @Bean

--- a/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveChatMessageHandler.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveChatMessageHandler.java
@@ -1,0 +1,59 @@
+package com.example.infinite.domain.realtimelive.controller;
+
+import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
+import com.example.infinite.domain.realtimelive.service.LiveChatBuffer;
+import com.example.infinite.domain.realtimelive.service.LiveChatThrottleService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * STOMP /pub/live/{liveId}/chat 메시지 핸들러.
+ *
+ * 메시지 인입 → 뮤트 체크 → 쓰로틀링 체크 → 200자 체크 → 버퍼 적재
+ * 위반 시 조용히 무시 (에러 응답 없음).
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class LiveChatMessageHandler {
+
+    private final LiveChatThrottleService throttleService;
+    private final LiveChatBuffer liveChatBuffer;
+
+    @MessageMapping("/live/{liveId}/chat")
+    public void handleChatMessage(
+            @DestinationVariable Long liveId,
+            @Payload String message,
+            Principal principal) {
+
+        Long userId = extractUserId(principal);
+        if (userId == null) {
+            log.warn("인증 정보 없는 채팅 메시지 무시: liveId={}", liveId);
+            return;
+        }
+
+        // 3중 검증: 뮤트 → 쓰로틀링 → 글자수
+        if (!throttleService.isAllowed(liveId, userId, message)) {
+            return; // 조용히 무시
+        }
+
+        // 버퍼에 적재 — flush 스케줄러가 300ms마다 배치 전송
+        liveChatBuffer.add(LiveChatMessageDto.of(liveId, userId, message));
+    }
+
+    private Long extractUserId(Principal principal) {
+        if (principal instanceof UsernamePasswordAuthenticationToken auth
+                && auth.getPrincipal() instanceof MemberDetailsImpl memberDetails) {
+            return memberDetails.getMemberId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/dto/LiveChatMessageDto.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/dto/LiveChatMessageDto.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.realtimelive.dto;
+
+import java.time.LocalDateTime;
+
+public record LiveChatMessageDto(
+        Long liveId,
+        Long senderId,
+        String message,
+        LocalDateTime sentAt
+) {
+    public static LiveChatMessageDto of(Long liveId, Long senderId, String message) {
+        return new LiveChatMessageDto(liveId, senderId, message, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/repository/LiveChatMessageRepository.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/repository/LiveChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.realtimelive.repository;
+
+import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LiveChatMessageRepository extends JpaRepository<LiveChatMessage, Long> {
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
@@ -1,0 +1,62 @@
+package com.example.infinite.domain.realtimelive.service;
+
+import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
+import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
+import com.example.infinite.domain.realtimelive.repository.LiveChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveChatBroadcastService {
+
+    private static final String REDIS_LIVE_CHAT_CHANNEL = "live:chat:broadcast";
+
+    private final LiveChatBuffer liveChatBuffer;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final LiveChatMessageRepository liveChatMessageRepository;
+
+    /**
+     * 300ms 간격으로 버퍼를 flush하여 구독자에게 일괄 전송 + DB 저장 + Redis Pub/Sub 전파.
+     */
+    @Scheduled(fixedRate = 300)
+    public void flush() {
+        Map<Long, List<LiveChatMessageDto>> flushed = liveChatBuffer.flushAll();
+
+        flushed.forEach((liveId, messages) -> {
+            // 1. STOMP 구독자에게 배치 전송
+            messagingTemplate.convertAndSend("/sub/live/" + liveId, messages);
+
+            // 2. Redis Pub/Sub으로 다른 서버 인스턴스에 전파
+            try {
+                redisTemplate.convertAndSend(REDIS_LIVE_CHAT_CHANNEL, messages);
+            } catch (Exception e) {
+                log.warn("Redis Pub/Sub 전파 실패: liveId={}, error={}", liveId, e.getMessage());
+            }
+
+            // 3. DB Batch INSERT
+            try {
+                List<LiveChatMessage> entities = messages.stream()
+                        .map(msg -> LiveChatMessage.builder()
+                                .liveStreamId(msg.liveId())
+                                .senderUserId(msg.senderId())
+                                .message(msg.message())
+                                .build())
+                        .toList();
+                liveChatMessageRepository.saveAll(entities);
+            } catch (Exception e) {
+                log.error("채팅 DB 저장 실패: liveId={}, count={}, error={}",
+                        liveId, messages.size(), e.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
@@ -3,8 +3,8 @@ package com.example.infinite.domain.realtimelive.service;
 import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
 import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
 import com.example.infinite.domain.realtimelive.repository.LiveChatMessageRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,15 +15,25 @@ import java.util.Map;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class LiveChatBroadcastService {
 
     private static final String REDIS_LIVE_CHAT_CHANNEL = "live:chat:broadcast";
 
     private final LiveChatBuffer liveChatBuffer;
     private final SimpMessagingTemplate messagingTemplate;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> liveChatRedisTemplate;
     private final LiveChatMessageRepository liveChatMessageRepository;
+
+    public LiveChatBroadcastService(
+            LiveChatBuffer liveChatBuffer,
+            SimpMessagingTemplate messagingTemplate,
+            @Qualifier("liveChatRedisTemplate") RedisTemplate<String, Object> liveChatRedisTemplate,
+            LiveChatMessageRepository liveChatMessageRepository) {
+        this.liveChatBuffer = liveChatBuffer;
+        this.messagingTemplate = messagingTemplate;
+        this.liveChatRedisTemplate = liveChatRedisTemplate;
+        this.liveChatMessageRepository = liveChatMessageRepository;
+    }
 
     /**
      * 300ms 간격으로 버퍼를 flush하여 구독자에게 일괄 전송 + DB 저장 + Redis Pub/Sub 전파.
@@ -38,7 +48,7 @@ public class LiveChatBroadcastService {
 
             // 2. Redis Pub/Sub으로 다른 서버 인스턴스에 전파
             try {
-                redisTemplate.convertAndSend(REDIS_LIVE_CHAT_CHANNEL, messages);
+                liveChatRedisTemplate.convertAndSend(REDIS_LIVE_CHAT_CHANNEL, messages);
             } catch (Exception e) {
                 log.warn("Redis Pub/Sub 전파 실패: liveId={}, error={}", liveId, e.getMessage());
             }

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBuffer.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBuffer.java
@@ -1,0 +1,64 @@
+package com.example.infinite.domain.realtimelive.service;
+
+import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * liveId별 인메모리 메시지 버퍼.
+ * 메시지 인입 시 큐에 적재, flush 시 큐를 비우고 리스트로 반환.
+ *
+ * <p>적응형 flush 확장 가이드:
+ * 현재는 고정 300ms 간격으로 flush한다.
+ * 트래픽 적응형으로 전환하려면:
+ * - 큐 사이즈 기반: flush 시점에 큐 사이즈가 N 이상이면 간격을 200ms로 줄이고, 비어있으면 500ms로 늘린다
+ * - 메시지 수신률 기반: 최근 1초간 인입 카운터를 두고 임계값으로 간격을 조절한다
+ * - 구현 시 @Scheduled를 제거하고 ScheduledExecutorService로 동적 scheduleAtFixedRate를 사용한다
+ * </p>
+ */
+@Component
+public class LiveChatBuffer {
+
+    private final Map<Long, ConcurrentLinkedQueue<LiveChatMessageDto>> buffers = new ConcurrentHashMap<>();
+
+    /**
+     * 메시지를 해당 liveId 버퍼에 적재한다.
+     */
+    public void add(LiveChatMessageDto message) {
+        buffers.computeIfAbsent(message.liveId(), k -> new ConcurrentLinkedQueue<>())
+                .add(message);
+    }
+
+    /**
+     * 모든 liveId의 버퍼를 flush하여 liveId별 메시지 리스트를 반환한다.
+     * 호출 후 버퍼는 비워진다.
+     */
+    public Map<Long, List<LiveChatMessageDto>> flushAll() {
+        Map<Long, List<LiveChatMessageDto>> flushed = new ConcurrentHashMap<>();
+
+        buffers.forEach((liveId, queue) -> {
+            List<LiveChatMessageDto> messages = new ArrayList<>();
+            LiveChatMessageDto msg;
+            while ((msg = queue.poll()) != null) {
+                messages.add(msg);
+            }
+            if (!messages.isEmpty()) {
+                flushed.put(liveId, messages);
+            }
+        });
+
+        return flushed;
+    }
+
+    /**
+     * 라이브 종료 시 해당 버퍼를 제거한다.
+     */
+    public void remove(Long liveId) {
+        buffers.remove(liveId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatThrottleService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatThrottleService.java
@@ -1,0 +1,114 @@
+package com.example.infinite.domain.realtimelive.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * 라이브 채팅 도배 방지 3중 검증.
+ * 메시지 인입 시점에서 순서대로 체크하며, 위반 시 조용히 무시한다.
+ *
+ * 1. 뮤트 체크: Redis Set `live:{liveId}:muted`에 userId가 있으면 차단
+ * 2. 쓰로틀링: Redis 슬라이딩 윈도우 — 사용자당 2건/초
+ * 3. 글자수: 200자 초과 차단
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveChatThrottleService {
+
+    private static final int MAX_MESSAGES_PER_SECOND = 2;
+    private static final int MAX_MESSAGE_LENGTH = 200;
+    private static final Duration WINDOW_SIZE = Duration.ofSeconds(1);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 메시지 전송 가능 여부를 판단한다.
+     * @return true면 전송 허용, false면 차단 (조용히 무시)
+     */
+    public boolean isAllowed(Long liveId, Long userId, String message) {
+        // 1. 뮤트 체크
+        if (isMuted(liveId, userId)) {
+            log.debug("뮤트된 사용자 메시지 차단: liveId={}, userId={}", liveId, userId);
+            return false;
+        }
+
+        // 2. 쓰로틀링 체크 (슬라이딩 윈도우)
+        if (!checkRateLimit(liveId, userId)) {
+            log.debug("쓰로틀링 초과 메시지 차단: liveId={}, userId={}", liveId, userId);
+            return false;
+        }
+
+        // 3. 글자수 체크
+        if (message == null || message.length() > MAX_MESSAGE_LENGTH) {
+            log.debug("글자수 초과/빈 메시지 차단: liveId={}, userId={}, length={}",
+                    liveId, userId, message == null ? 0 : message.length());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 관리자가 특정 사용자를 뮤트한다.
+     */
+    public void mute(Long liveId, Long userId) {
+        String key = muteKey(liveId);
+        stringRedisTemplate.opsForSet().add(key, userId.toString());
+    }
+
+    /**
+     * 관리자가 특정 사용자의 뮤트를 해제한다.
+     */
+    public void unmute(Long liveId, Long userId) {
+        String key = muteKey(liveId);
+        stringRedisTemplate.opsForSet().remove(key, userId.toString());
+    }
+
+    private boolean isMuted(Long liveId, Long userId) {
+        String key = muteKey(liveId);
+        return Boolean.TRUE.equals(
+                stringRedisTemplate.opsForSet().isMember(key, userId.toString()));
+    }
+
+    /**
+     * Redis Sorted Set 기반 슬라이딩 윈도우.
+     * score = 현재 시각(epoch millis), member = 고유값(현재 시각 나노).
+     * 1초 윈도우 내 멤버 수가 MAX_MESSAGES_PER_SECOND 이상이면 차단.
+     */
+    private boolean checkRateLimit(Long liveId, Long userId) {
+        String key = throttleKey(liveId, userId);
+        long now = Instant.now().toEpochMilli();
+        long windowStart = now - WINDOW_SIZE.toMillis();
+
+        // 윈도우 밖 오래된 항목 제거
+        stringRedisTemplate.opsForZSet().removeRangeByScore(key, 0, windowStart);
+
+        // 현재 윈도우 내 요청 수 확인
+        Long count = stringRedisTemplate.opsForZSet().zCard(key);
+        if (count != null && count >= MAX_MESSAGES_PER_SECOND) {
+            return false;
+        }
+
+        // 현재 요청 추가 (member를 nano 시각으로 고유하게)
+        stringRedisTemplate.opsForZSet().add(key, String.valueOf(System.nanoTime()), now);
+
+        // 키 TTL 설정 (윈도우 크기 + 여유 1초)
+        stringRedisTemplate.expire(key, WINDOW_SIZE.plusSeconds(1));
+
+        return true;
+    }
+
+    private String muteKey(Long liveId) {
+        return "live:" + liveId + ":muted";
+    }
+
+    private String throttleKey(Long liveId, Long userId) {
+        return "live:" + liveId + ":throttle:" + userId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/RedisLiveChatSubscriber.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/RedisLiveChatSubscriber.java
@@ -1,0 +1,38 @@
+package com.example.infinite.domain.realtimelive.service;
+
+import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Redis Pub/Sub으로 다른 서버 인스턴스에서 전파된 채팅 메시지를 수신하여
+ * 현재 인스턴스의 STOMP 구독자에게 전달한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisLiveChatSubscriber {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void onMessage(String message) {
+        try {
+            List<LiveChatMessageDto> messages = objectMapper.readValue(
+                    message, new TypeReference<>() {});
+
+            if (!messages.isEmpty()) {
+                Long liveId = messages.get(0).liveId();
+                messagingTemplate.convertAndSend("/sub/live/" + liveId, messages);
+            }
+        } catch (Exception e) {
+            log.error("Redis Pub/Sub 메시지 처리 실패: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                       
  - 300ms 간격 배치 브로드캐스트(`LiveChatBuffer`, `LiveChatBroadcastService`)와 다중 서버 전파를 위한 Redis Pub/Sub(`RedisLiveChatSubscriber`,    
  `RedisLiveChatConfig`) 추가                                                                                                                      
  - 도배 방지 3중 검증(`LiveChatThrottleService`: 뮤트 → 슬라이딩 윈도우 2건/초 → 200자)과 STOMP 진입점(`LiveChatMessageHandler`) 추가
  - Pub/Sub 발행·구독 간 직렬화 정합성을 위해 `liveChatRedisTemplate`(Jackson) 빈 추가, `MessageListenerAdapter`에 `StringRedisSerializer` 적용    
                                                                                                                                                   
  ## Notes
  - `GenericJackson2JsonRedisSerializer`는 deprecated/marked-for-removal 경고가 발생. 필요 시 기존 `RedisCacheConfig`의
  `GenericJacksonJsonRedisSerializer`로 후속 교체 가능
  - 관리자 뮤트/언뮤트 REST API, 라이브 CRUD, 커서 기반 채팅 내역 조회 등은 별도 범위로 제외

  ## Test plan
  - [ ] `./gradlew compileJava` BUILD SUCCESSFUL
  - [ ] STOMP `/pub/live/{liveId}/chat` 전송 시 `/sub/live/{liveId}` 구독자에게 300ms 배치 수신
  - [ ] 동일 사용자가 1초 내 3건 전송 시 3번째가 조용히 차단
  - [ ] 200자 초과 메시지 차단
  - [ ] 뮤트 상태 사용자의 메시지 차단
  - [ ] 다중 인스턴스 환경에서 Redis Pub/Sub으로 타 인스턴스 구독자에게 전파
  - [ ] `live_chat_messages` 테이블에 배치 INSERT 확인

  Closes #72 
