### PR TITLE
Feat: 라이브 CRUD, DM 기능, 보안·예외 통합

### DIFF
--- a/src/main/java/com/example/infinite/domain/dm/controller/DmAdminController.java
+++ b/src/main/java/com/example/infinite/domain/dm/controller/DmAdminController.java
@@ -1,0 +1,27 @@
+package com.example.infinite.domain.dm.controller;
+
+import com.example.infinite.domain.dm.dto.response.DmRoomResponse;
+import com.example.infinite.domain.dm.service.DmService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/artists/{artistId}/dm")
+@RequiredArgsConstructor
+public class DmAdminController {
+
+    private final DmService dmService;
+
+    @GetMapping("/rooms")
+    public ResponseEntity<ApiResponse<List<DmRoomResponse>>> getArtistRooms(
+            @PathVariable Long artistId) {
+        return ResponseEntity.ok(ApiResponse.success(dmService.getArtistRooms(artistId)));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/controller/DmController.java
+++ b/src/main/java/com/example/infinite/domain/dm/controller/DmController.java
@@ -1,0 +1,41 @@
+package com.example.infinite.domain.dm.controller;
+
+import com.example.infinite.domain.dm.dto.response.DmMessageResponse;
+import com.example.infinite.domain.dm.dto.response.DmRoomResponse;
+import com.example.infinite.domain.dm.service.DmService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class DmController {
+
+    private final DmService dmService;
+
+    @GetMapping("/api/v1/dm/rooms")
+    public ResponseEntity<ApiResponse<List<DmRoomResponse>>> getMyRooms(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return ResponseEntity.ok(ApiResponse.success(
+                dmService.getMyRooms(memberDetails.getMemberId())));
+    }
+
+    @GetMapping("/api/v1/dm/rooms/{roomId}/messages")
+    public ResponseEntity<ApiResponse<CursorSliceResponse<DmMessageResponse>>> getRoomMessages(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long before,
+            @RequestParam(defaultValue = "50") int size,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
+        return ResponseEntity.ok(ApiResponse.success(
+                dmService.getRoomMessages(roomId, memberDetails.getMemberId(), before, size)));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/controller/DmMessageHandler.java
+++ b/src/main/java/com/example/infinite/domain/dm/controller/DmMessageHandler.java
@@ -1,0 +1,69 @@
+package com.example.infinite.domain.dm.controller;
+
+import com.example.infinite.domain.dm.service.DmService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class DmMessageHandler {
+
+    private final DmService dmService;
+
+    @MessageMapping("/dm/{roomId}")
+    public void handleDmMessage(
+            @DestinationVariable Long roomId,
+            @Payload String content,
+            Principal principal) {
+
+        Long senderId = extractMemberId(principal);
+        if (senderId == null) {
+            log.warn("인증 정보 없는 DM 메시지 무시: roomId={}", roomId);
+            return;
+        }
+
+        try {
+            dmService.sendMessage(roomId, senderId, content);
+        } catch (Exception e) {
+            log.warn("DM 메시지 전송 실패: roomId={}, senderId={}, error={}",
+                    roomId, senderId, e.getMessage());
+        }
+    }
+
+    @MessageMapping("/dm/broadcast/{artistId}")
+    public void handleBroadcast(
+            @DestinationVariable Long artistId,
+            @Payload String content,
+            Principal principal) {
+
+        Long senderId = extractMemberId(principal);
+        if (senderId == null) {
+            log.warn("인증 정보 없는 broadcast 무시: artistId={}", artistId);
+            return;
+        }
+
+        try {
+            dmService.broadcast(artistId, content);
+        } catch (Exception e) {
+            log.warn("DM broadcast 실패: artistId={}, senderId={}, error={}",
+                    artistId, senderId, e.getMessage());
+        }
+    }
+
+    private Long extractMemberId(Principal principal) {
+        if (principal instanceof UsernamePasswordAuthenticationToken auth
+                && auth.getPrincipal() instanceof MemberDetailsImpl memberDetails) {
+            return memberDetails.getMemberId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/dto/response/DmMessageResponse.java
+++ b/src/main/java/com/example/infinite/domain/dm/dto/response/DmMessageResponse.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.dm.dto.response;
+
+import com.example.infinite.domain.dm.entity.DmMessage;
+import com.example.infinite.domain.dm.enums.SenderType;
+
+import java.time.LocalDateTime;
+
+public record DmMessageResponse(
+        Long id,
+        Long roomId,
+        SenderType senderType,
+        String content,
+        LocalDateTime sentAt
+) {
+    public static DmMessageResponse from(DmMessage msg) {
+        return new DmMessageResponse(
+                msg.getId(),
+                msg.getDmRoom().getId(),
+                msg.getSenderType(),
+                msg.getContent(),
+                msg.getSentAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/dto/response/DmRoomResponse.java
+++ b/src/main/java/com/example/infinite/domain/dm/dto/response/DmRoomResponse.java
@@ -1,0 +1,21 @@
+package com.example.infinite.domain.dm.dto.response;
+
+import com.example.infinite.domain.dm.entity.DmRoom;
+
+import java.time.LocalDateTime;
+
+public record DmRoomResponse(
+        Long id,
+        Long userId,
+        Long artistId,
+        LocalDateTime updatedAt
+) {
+    public static DmRoomResponse from(DmRoom room) {
+        return new DmRoomResponse(
+                room.getId(),
+                room.getUserId(),
+                room.getArtistId(),
+                room.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/error/DmErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/dm/error/DmErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.infinite.domain.dm.error;
+
+import com.example.infinite.global.error.ErrorCodeType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DmErrorCode implements ErrorCodeType {
+
+    DM_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "DM001", "DM 룸을 찾을 수 없습니다."),
+    DM_SUBSCRIPTION_REQUIRED(HttpStatus.FORBIDDEN, "DM002", "DM 구독 상태인 유저만 이용 가능합니다."),
+    DM_REPLY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "DM003", "아티스트 답장 전 최대 3건까지만 보낼 수 있습니다."),
+    DM_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "DM004", "이미 해당 아티스트와의 DM 룸이 존재합니다."),
+    DM_NOT_ROOM_MEMBER(HttpStatus.FORBIDDEN, "DM005", "해당 DM 룸의 참여자가 아닙니다."),
+    DM_ARTIST_MISMATCH(HttpStatus.FORBIDDEN, "DM006", "해당 아티스트의 DM이 아닙니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/infinite/domain/dm/error/DmException.java
+++ b/src/main/java/com/example/infinite/domain/dm/error/DmException.java
@@ -1,0 +1,15 @@
+package com.example.infinite.domain.dm.error;
+
+import com.example.infinite.global.error.ErrorCodeType;
+import lombok.Getter;
+
+@Getter
+public class DmException extends RuntimeException {
+
+    private final ErrorCodeType errorCode;
+
+    public DmException(ErrorCodeType errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/dm/repository/DmMessageRepository.java
+++ b/src/main/java/com/example/infinite/domain/dm/repository/DmMessageRepository.java
@@ -1,0 +1,37 @@
+package com.example.infinite.domain.dm.repository;
+
+import com.example.infinite.domain.dm.entity.DmMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
+
+    @Query("""
+            SELECT m FROM DmMessage m
+            WHERE m.dmRoom.id = :roomId
+              AND (:cursor IS NULL OR m.id < :cursor)
+            ORDER BY m.id DESC
+            LIMIT :limit
+            """)
+    List<DmMessage> findByRoomIdWithCursor(
+            @Param("roomId") Long roomId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit
+    );
+
+    @Query("""
+            SELECT COUNT(m) FROM DmMessage m
+            WHERE m.dmRoom.id = :roomId
+              AND m.senderType = com.example.infinite.domain.dm.enums.SenderType.USER
+              AND m.id > COALESCE(
+                (SELECT MAX(am.id) FROM DmMessage am
+                 WHERE am.dmRoom.id = :roomId
+                   AND am.senderType = com.example.infinite.domain.dm.enums.SenderType.ARTIST),
+                0
+              )
+            """)
+    long countUserMessagesSinceLastArtistReply(@Param("roomId") Long roomId);
+}

--- a/src/main/java/com/example/infinite/domain/dm/repository/DmRoomRepository.java
+++ b/src/main/java/com/example/infinite/domain/dm/repository/DmRoomRepository.java
@@ -3,9 +3,14 @@ package com.example.infinite.domain.dm.repository;
 import com.example.infinite.domain.dm.entity.DmRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DmRoomRepository extends JpaRepository<DmRoom, Long> {
 
     Optional<DmRoom> findByUserIdAndArtistId(Long userId, Long artistId);
+
+    List<DmRoom> findByUserId(Long userId);
+
+    List<DmRoom> findByArtistId(Long artistId);
 }

--- a/src/main/java/com/example/infinite/domain/dm/service/DmService.java
+++ b/src/main/java/com/example/infinite/domain/dm/service/DmService.java
@@ -1,0 +1,145 @@
+package com.example.infinite.domain.dm.service;
+
+import com.example.infinite.domain.dm.dto.response.DmMessageResponse;
+import com.example.infinite.domain.dm.dto.response.DmRoomResponse;
+import com.example.infinite.domain.dm.entity.DmMessage;
+import com.example.infinite.domain.dm.entity.DmRoom;
+import com.example.infinite.domain.dm.enums.SenderType;
+import com.example.infinite.domain.dm.error.DmErrorCode;
+import com.example.infinite.domain.dm.error.DmException;
+import com.example.infinite.domain.dm.repository.DmMessageRepository;
+import com.example.infinite.domain.dm.repository.DmRoomRepository;
+import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
+import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DmService {
+
+    private static final int MAX_USER_REPLIES_BEFORE_ARTIST = 3;
+
+    private final DmRoomRepository dmRoomRepository;
+    private final DmMessageRepository dmMessageRepository;
+    private final DmSubscriptionRepository dmSubscriptionRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public List<DmRoomResponse> getMyRooms(Long userId) {
+        return dmRoomRepository.findByUserId(userId).stream()
+                .map(DmRoomResponse::from)
+                .toList();
+    }
+
+    public CursorSliceResponse<DmMessageResponse> getRoomMessages(
+            Long roomId, Long userId, Long cursor, int size) {
+        DmRoom room = findRoomOrThrow(roomId);
+        validateRoomAccess(room, userId);
+
+        int effectiveSize = Math.min(Math.max(size, 1), 100);
+
+        List<DmMessage> rows = dmMessageRepository
+                .findByRoomIdWithCursor(roomId, cursor, effectiveSize + 1);
+
+        List<DmMessageResponse> mapped = rows.stream()
+                .map(DmMessageResponse::from)
+                .toList();
+
+        return CursorSliceResponse.of(mapped, effectiveSize, DmMessageResponse::id);
+    }
+
+    public List<DmRoomResponse> getArtistRooms(Long artistId) {
+        return dmRoomRepository.findByArtistId(artistId).stream()
+                .map(DmRoomResponse::from)
+                .toList();
+    }
+
+    /**
+     * 아티스트 전체 발송 (fan-out).
+     * 해당 아티스트의 모든 DM 룸에 메시지 생성 + 각 룸 구독자에게 STOMP 전송.
+     */
+    @Transactional
+    public void broadcast(Long artistId, String content) {
+        List<DmRoom> rooms = dmRoomRepository.findByArtistId(artistId);
+
+        for (DmRoom room : rooms) {
+            DmMessage message = DmMessage.builder()
+                    .dmRoom(room)
+                    .senderType(SenderType.ARTIST)
+                    .content(content)
+                    .build();
+            dmMessageRepository.save(message);
+
+            messagingTemplate.convertAndSend(
+                    "/sub/dm/" + room.getId(),
+                    DmMessageResponse.from(message)
+            );
+        }
+
+        log.info("아티스트 DM 일괄 발송 완료: artistId={}, rooms={}", artistId, rooms.size());
+    }
+
+    /**
+     * 개별 DM 메시지 전송 (STOMP 핸들러에서 호출).
+     * 유저: 구독 검증 + 답장 제한. 아티스트: 제한 없음.
+     */
+    @Transactional
+    public void sendMessage(Long roomId, Long senderId, String content) {
+        DmRoom room = findRoomOrThrow(roomId);
+
+        SenderType senderType;
+        if (room.getArtistId().equals(senderId)) {
+            senderType = SenderType.ARTIST;
+        } else if (room.getUserId().equals(senderId)) {
+            senderType = SenderType.USER;
+
+            if (!hasActiveSubscription(room.getUserId(), room.getArtistId())) {
+                throw new DmException(DmErrorCode.DM_SUBSCRIPTION_REQUIRED);
+            }
+
+            long pendingCount = dmMessageRepository.countUserMessagesSinceLastArtistReply(roomId);
+            if (pendingCount >= MAX_USER_REPLIES_BEFORE_ARTIST) {
+                throw new DmException(DmErrorCode.DM_REPLY_LIMIT_EXCEEDED);
+            }
+        } else {
+            throw new DmException(DmErrorCode.DM_NOT_ROOM_MEMBER);
+        }
+
+        DmMessage message = DmMessage.builder()
+                .dmRoom(room)
+                .senderType(senderType)
+                .content(content)
+                .build();
+        dmMessageRepository.save(message);
+
+        messagingTemplate.convertAndSend(
+                "/sub/dm/" + roomId,
+                DmMessageResponse.from(message)
+        );
+    }
+
+    private boolean hasActiveSubscription(Long userId, Long artistId) {
+        return dmSubscriptionRepository
+                .findByUserIdAndArtistIdAndStatus(userId, artistId, SubscriptionStatus.ACTIVE)
+                .isPresent();
+    }
+
+    private DmRoom findRoomOrThrow(Long roomId) {
+        return dmRoomRepository.findById(roomId)
+                .orElseThrow(() -> new DmException(DmErrorCode.DM_ROOM_NOT_FOUND));
+    }
+
+    private void validateRoomAccess(DmRoom room, Long userId) {
+        if (!room.getUserId().equals(userId) && !room.getArtistId().equals(userId)) {
+            throw new DmException(DmErrorCode.DM_NOT_ROOM_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveAdminController.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveAdminController.java
@@ -1,0 +1,56 @@
+package com.example.infinite.domain.realtimelive.controller;
+
+import com.example.infinite.domain.realtimelive.dto.request.LiveCreateRequest;
+import com.example.infinite.domain.realtimelive.dto.response.LiveResponse;
+import com.example.infinite.domain.realtimelive.service.RealtimeLiveService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/artists/{artistId}/lives")
+@RequiredArgsConstructor
+public class LiveAdminController {
+
+    private final RealtimeLiveService realtimeLiveService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<LiveResponse>> createLive(
+            @PathVariable Long artistId,
+            @Valid @RequestBody LiveCreateRequest request) {
+        LiveResponse response = realtimeLiveService.createLive(artistId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/{liveId}/start")
+    public ResponseEntity<ApiResponse<LiveResponse>> startLive(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId) {
+        return ResponseEntity.ok(ApiResponse.success(realtimeLiveService.startLive(artistId, liveId)));
+    }
+
+    @PatchMapping("/{liveId}/end")
+    public ResponseEntity<ApiResponse<LiveResponse>> endLive(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId) {
+        return ResponseEntity.ok(ApiResponse.success(realtimeLiveService.endLive(artistId, liveId)));
+    }
+
+    @DeleteMapping("/{liveId}/chat/messages/{messageId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChatMessage(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId,
+            @PathVariable Long messageId) {
+        realtimeLiveService.deleteChatMessage(artistId, liveId, messageId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveAdminController.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveAdminController.java
@@ -53,4 +53,22 @@ public class LiveAdminController {
         realtimeLiveService.deleteChatMessage(artistId, liveId, messageId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    @PostMapping("/{liveId}/chat/mute/{userId}")
+    public ResponseEntity<ApiResponse<Void>> muteUser(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId,
+            @PathVariable Long userId) {
+        realtimeLiveService.muteUser(artistId, liveId, userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/{liveId}/chat/mute/{userId}")
+    public ResponseEntity<ApiResponse<Void>> unmuteUser(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId,
+            @PathVariable Long userId) {
+        realtimeLiveService.unmuteUser(artistId, liveId, userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveChatMessageHandler.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/controller/LiveChatMessageHandler.java
@@ -3,6 +3,7 @@ package com.example.infinite.domain.realtimelive.controller;
 import com.example.infinite.domain.realtimelive.dto.LiveChatMessageDto;
 import com.example.infinite.domain.realtimelive.service.LiveChatBuffer;
 import com.example.infinite.domain.realtimelive.service.LiveChatThrottleService;
+import com.example.infinite.domain.realtimelive.service.RealtimeLiveService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,7 @@ import java.security.Principal;
 /**
  * STOMP /pub/live/{liveId}/chat 메시지 핸들러.
  *
- * 메시지 인입 → 뮤트 체크 → 쓰로틀링 체크 → 200자 체크 → 버퍼 적재
+ * 메시지 인입 → LIVE 상태 검증 → 뮤트 체크 → 쓰로틀링 체크 → 200자 체크 → 버퍼 적재
  * 위반 시 조용히 무시 (에러 응답 없음).
  */
 @Slf4j
@@ -27,6 +28,7 @@ public class LiveChatMessageHandler {
 
     private final LiveChatThrottleService throttleService;
     private final LiveChatBuffer liveChatBuffer;
+    private final RealtimeLiveService realtimeLiveService;
 
     @MessageMapping("/live/{liveId}/chat")
     public void handleChatMessage(
@@ -37,6 +39,10 @@ public class LiveChatMessageHandler {
         Long userId = extractUserId(principal);
         if (userId == null) {
             log.warn("인증 정보 없는 채팅 메시지 무시: liveId={}", liveId);
+            return;
+        }
+
+        if (!realtimeLiveService.isLiveActive(liveId)) {
             return;
         }
 

--- a/src/main/java/com/example/infinite/domain/realtimelive/controller/RealtimeLiveController.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/controller/RealtimeLiveController.java
@@ -1,4 +1,47 @@
 package com.example.infinite.domain.realtimelive.controller;
 
+import com.example.infinite.domain.realtimelive.dto.response.LiveChatMessageResponse;
+import com.example.infinite.domain.realtimelive.dto.response.LiveResponse;
+import com.example.infinite.domain.realtimelive.enums.LiveStatus;
+import com.example.infinite.domain.realtimelive.service.RealtimeLiveService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
 public class RealtimeLiveController {
+
+    private final RealtimeLiveService realtimeLiveService;
+
+    @GetMapping("/api/v1/artists/{artistId}/lives")
+    public ResponseEntity<ApiResponse<List<LiveResponse>>> getLiveList(
+            @PathVariable Long artistId,
+            @RequestParam(required = false) LiveStatus status) {
+        return ResponseEntity.ok(ApiResponse.success(realtimeLiveService.getLiveList(artistId, status)));
+    }
+
+    @GetMapping("/api/v1/artists/{artistId}/lives/{liveId}")
+    public ResponseEntity<ApiResponse<LiveResponse>> getLiveDetail(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId) {
+        return ResponseEntity.ok(ApiResponse.success(realtimeLiveService.getLiveDetail(artistId, liveId)));
+    }
+
+    @GetMapping("/api/v1/artists/{artistId}/lives/{liveId}/chat/messages")
+    public ResponseEntity<ApiResponse<CursorSliceResponse<LiveChatMessageResponse>>> getChatMessages(
+            @PathVariable Long artistId,
+            @PathVariable Long liveId,
+            @RequestParam(required = false) Long before,
+            @RequestParam(defaultValue = "50") int size) {
+        return ResponseEntity.ok(ApiResponse.success(
+                realtimeLiveService.getChatMessages(liveId, before, size)));
+    }
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/dto/RealtimeLiveDto.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/dto/RealtimeLiveDto.java
@@ -1,4 +1,0 @@
-package com.example.infinite.domain.realtimelive.dto;
-
-public class RealtimeLiveDto {
-}

--- a/src/main/java/com/example/infinite/domain/realtimelive/dto/request/LiveCreateRequest.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/dto/request/LiveCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.infinite.domain.realtimelive.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LiveCreateRequest(
+        @NotBlank String title,
+        String description,
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/dto/response/LiveChatMessageResponse.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/dto/response/LiveChatMessageResponse.java
@@ -1,0 +1,21 @@
+package com.example.infinite.domain.realtimelive.dto.response;
+
+import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
+
+import java.time.LocalDateTime;
+
+public record LiveChatMessageResponse(
+        Long id,
+        Long senderUserId,
+        String message,
+        LocalDateTime createdAt
+) {
+    public static LiveChatMessageResponse from(LiveChatMessage entity) {
+        return new LiveChatMessageResponse(
+                entity.getId(),
+                entity.getSenderUserId(),
+                entity.getMessage(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/dto/response/LiveResponse.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/dto/response/LiveResponse.java
@@ -1,0 +1,34 @@
+package com.example.infinite.domain.realtimelive.dto.response;
+
+import com.example.infinite.domain.realtimelive.entity.RealtimeLive;
+import com.example.infinite.domain.realtimelive.enums.LiveStatus;
+
+import java.time.LocalDateTime;
+
+public record LiveResponse(
+        Long id,
+        Long artistId,
+        String title,
+        String description,
+        LiveStatus liveStatus,
+        String thumbnailUrl,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        String replayUrl,
+        LocalDateTime createdAt
+) {
+    public static LiveResponse from(RealtimeLive entity) {
+        return new LiveResponse(
+                entity.getId(),
+                entity.getArtistId(),
+                entity.getTitle(),
+                entity.getDescription(),
+                entity.getLiveStatus(),
+                entity.getThumbnailUrl(),
+                entity.getStartedAt(),
+                entity.getEndedAt(),
+                entity.getReplayUrl(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/error/LiveErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/error/LiveErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.infinite.domain.realtimelive.error;
+
+import com.example.infinite.global.error.ErrorCodeType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum LiveErrorCode implements ErrorCodeType {
+
+    LIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "RL001", "라이브를 찾을 수 없습니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "RL002", "채팅 메시지를 찾을 수 없습니다."),
+    LIVE_NOT_SCHEDULED(HttpStatus.CONFLICT, "RL003", "예정 상태의 라이브만 시작할 수 있습니다."),
+    LIVE_NOT_LIVE(HttpStatus.CONFLICT, "RL004", "진행 중인 라이브만 종료할 수 있습니다."),
+    NOT_LIVE_OWNER(HttpStatus.FORBIDDEN, "RL005", "해당 라이브의 소유자가 아닙니다."),
+    MESSAGE_ALREADY_DELETED(HttpStatus.CONFLICT, "RL006", "이미 삭제된 메시지입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/error/LiveException.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/error/LiveException.java
@@ -1,0 +1,15 @@
+package com.example.infinite.domain.realtimelive.error;
+
+import com.example.infinite.global.error.ErrorCodeType;
+import lombok.Getter;
+
+@Getter
+public class LiveException extends RuntimeException {
+
+    private final ErrorCodeType errorCode;
+
+    public LiveException(ErrorCodeType errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/realtimelive/repository/LiveChatMessageRepository.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/repository/LiveChatMessageRepository.java
@@ -2,6 +2,23 @@ package com.example.infinite.domain.realtimelive.repository;
 
 import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface LiveChatMessageRepository extends JpaRepository<LiveChatMessage, Long> {
+
+    @Query("""
+            SELECT m FROM LiveChatMessage m
+            WHERE m.liveStreamId = :liveStreamId
+              AND (:cursor IS NULL OR m.id < :cursor)
+            ORDER BY m.id DESC
+            LIMIT :limit
+            """)
+    List<LiveChatMessage> findByCursor(
+            @Param("liveStreamId") Long liveStreamId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit
+    );
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/repository/RealtimeLiveRepository.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/repository/RealtimeLiveRepository.java
@@ -1,4 +1,14 @@
 package com.example.infinite.domain.realtimelive.repository;
 
-public class RealtimeLiveRepository {
+import com.example.infinite.domain.realtimelive.entity.RealtimeLive;
+import com.example.infinite.domain.realtimelive.enums.LiveStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RealtimeLiveRepository extends JpaRepository<RealtimeLive, Long> {
+
+    List<RealtimeLive> findByArtistIdOrderByCreatedAtDesc(Long artistId);
+
+    List<RealtimeLive> findByArtistIdAndLiveStatusOrderByCreatedAtDesc(Long artistId, LiveStatus liveStatus);
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBroadcastService.java
@@ -10,8 +10,10 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Slf4j
 @Service
@@ -68,5 +70,38 @@ public class LiveChatBroadcastService {
                         liveId, messages.size(), e.getMessage());
             }
         });
+    }
+
+    /**
+     * 라이브 종료 시 해당 liveId 버퍼를 즉시 flush하고 제거한다.
+     */
+    public void drainAndRemove(Long liveId) {
+        ConcurrentLinkedQueue<LiveChatMessageDto> queue = liveChatBuffer.getQueue(liveId);
+        if (queue != null) {
+            List<LiveChatMessageDto> remaining = new ArrayList<>();
+            LiveChatMessageDto msg;
+            while ((msg = queue.poll()) != null) {
+                remaining.add(msg);
+            }
+
+            if (!remaining.isEmpty()) {
+                messagingTemplate.convertAndSend("/sub/live/" + liveId, remaining);
+
+                try {
+                    List<LiveChatMessage> entities = remaining.stream()
+                            .map(m -> LiveChatMessage.builder()
+                                    .liveStreamId(m.liveId())
+                                    .senderUserId(m.senderId())
+                                    .message(m.message())
+                                    .build())
+                            .toList();
+                    liveChatMessageRepository.saveAll(entities);
+                } catch (Exception e) {
+                    log.error("종료 시 채팅 DB 저장 실패: liveId={}, count={}", liveId, remaining.size());
+                }
+            }
+        }
+
+        liveChatBuffer.remove(liveId);
     }
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBuffer.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/LiveChatBuffer.java
@@ -61,4 +61,11 @@ public class LiveChatBuffer {
     public void remove(Long liveId) {
         buffers.remove(liveId);
     }
+
+    /**
+     * 특정 liveId의 큐를 직접 반환한다. 없으면 null.
+     */
+    public ConcurrentLinkedQueue<LiveChatMessageDto> getQueue(Long liveId) {
+        return buffers.get(liveId);
+    }
 }

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/RealtimeLiveService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/RealtimeLiveService.java
@@ -28,6 +28,7 @@ public class RealtimeLiveService {
     private final RealtimeLiveRepository realtimeLiveRepository;
     private final LiveChatMessageRepository liveChatMessageRepository;
     private final LiveChatBroadcastService liveChatBroadcastService;
+    private final LiveChatThrottleService liveChatThrottleService;
     private final StringRedisTemplate stringRedisTemplate;
 
     @Transactional
@@ -89,6 +90,18 @@ public class RealtimeLiveService {
         }
 
         message.softDelete();
+    }
+
+    public void muteUser(Long artistId, Long liveId, Long userId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        validateOwnership(live, artistId);
+        liveChatThrottleService.mute(liveId, userId);
+    }
+
+    public void unmuteUser(Long artistId, Long liveId, Long userId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        validateOwnership(live, artistId);
+        liveChatThrottleService.unmute(liveId, userId);
     }
 
     public List<LiveResponse> getLiveList(Long artistId, LiveStatus status) {

--- a/src/main/java/com/example/infinite/domain/realtimelive/service/RealtimeLiveService.java
+++ b/src/main/java/com/example/infinite/domain/realtimelive/service/RealtimeLiveService.java
@@ -1,4 +1,141 @@
 package com.example.infinite.domain.realtimelive.service;
 
+import com.example.infinite.domain.realtimelive.dto.request.LiveCreateRequest;
+import com.example.infinite.domain.realtimelive.dto.response.LiveChatMessageResponse;
+import com.example.infinite.domain.realtimelive.dto.response.LiveResponse;
+import com.example.infinite.domain.realtimelive.entity.LiveChatMessage;
+import com.example.infinite.domain.realtimelive.entity.RealtimeLive;
+import com.example.infinite.domain.realtimelive.enums.LiveStatus;
+import com.example.infinite.domain.realtimelive.error.LiveErrorCode;
+import com.example.infinite.domain.realtimelive.error.LiveException;
+import com.example.infinite.domain.realtimelive.repository.LiveChatMessageRepository;
+import com.example.infinite.domain.realtimelive.repository.RealtimeLiveRepository;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RealtimeLiveService {
+
+    private static final String LIVE_STATUS_KEY = "live:%d:status";
+
+    private final RealtimeLiveRepository realtimeLiveRepository;
+    private final LiveChatMessageRepository liveChatMessageRepository;
+    private final LiveChatBroadcastService liveChatBroadcastService;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Transactional
+    public LiveResponse createLive(Long artistId, LiveCreateRequest request) {
+        RealtimeLive live = RealtimeLive.builder()
+                .artistId(artistId)
+                .title(request.title())
+                .description(request.description())
+                .thumbnailUrl(request.thumbnailUrl())
+                .build();
+        return LiveResponse.from(realtimeLiveRepository.save(live));
+    }
+
+    @Transactional
+    public LiveResponse startLive(Long artistId, Long liveId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        validateOwnership(live, artistId);
+
+        if (live.getLiveStatus() != LiveStatus.SCHEDULED) {
+            throw new LiveException(LiveErrorCode.LIVE_NOT_SCHEDULED);
+        }
+
+        live.start();
+
+        stringRedisTemplate.opsForValue()
+                .set(String.format(LIVE_STATUS_KEY, liveId), "LIVE");
+
+        return LiveResponse.from(live);
+    }
+
+    @Transactional
+    public LiveResponse endLive(Long artistId, Long liveId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        validateOwnership(live, artistId);
+
+        if (live.getLiveStatus() != LiveStatus.LIVE) {
+            throw new LiveException(LiveErrorCode.LIVE_NOT_LIVE);
+        }
+
+        live.end();
+
+        stringRedisTemplate.delete(String.format(LIVE_STATUS_KEY, liveId));
+
+        liveChatBroadcastService.drainAndRemove(liveId);
+
+        return LiveResponse.from(live);
+    }
+
+    @Transactional
+    public void deleteChatMessage(Long artistId, Long liveId, Long messageId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        validateOwnership(live, artistId);
+
+        LiveChatMessage message = liveChatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new LiveException(LiveErrorCode.CHAT_MESSAGE_NOT_FOUND));
+
+        if (message.getDeletedAt() != null) {
+            throw new LiveException(LiveErrorCode.MESSAGE_ALREADY_DELETED);
+        }
+
+        message.softDelete();
+    }
+
+    public List<LiveResponse> getLiveList(Long artistId, LiveStatus status) {
+        List<RealtimeLive> lives = (status != null)
+                ? realtimeLiveRepository.findByArtistIdAndLiveStatusOrderByCreatedAtDesc(artistId, status)
+                : realtimeLiveRepository.findByArtistIdOrderByCreatedAtDesc(artistId);
+        return lives.stream().map(LiveResponse::from).toList();
+    }
+
+    public LiveResponse getLiveDetail(Long artistId, Long liveId) {
+        RealtimeLive live = findLiveOrThrow(liveId);
+        if (!live.getArtistId().equals(artistId)) {
+            throw new LiveException(LiveErrorCode.LIVE_NOT_FOUND);
+        }
+        return LiveResponse.from(live);
+    }
+
+    public CursorSliceResponse<LiveChatMessageResponse> getChatMessages(
+            Long liveId, Long cursor, int size) {
+        findLiveOrThrow(liveId);
+
+        int effectiveSize = Math.min(Math.max(size, 1), 100);
+
+        List<LiveChatMessage> rows = liveChatMessageRepository
+                .findByCursor(liveId, cursor, effectiveSize + 1);
+
+        List<LiveChatMessageResponse> mapped = rows.stream()
+                .map(LiveChatMessageResponse::from)
+                .toList();
+
+        return CursorSliceResponse.of(mapped, effectiveSize, LiveChatMessageResponse::id);
+    }
+
+    public boolean isLiveActive(Long liveId) {
+        return Boolean.TRUE.equals(
+                stringRedisTemplate.hasKey(String.format(LIVE_STATUS_KEY, liveId))
+        );
+    }
+
+    private RealtimeLive findLiveOrThrow(Long liveId) {
+        return realtimeLiveRepository.findById(liveId)
+                .orElseThrow(() -> new LiveException(LiveErrorCode.LIVE_NOT_FOUND));
+    }
+
+    private void validateOwnership(RealtimeLive live, Long artistId) {
+        if (!live.getArtistId().equals(artistId)) {
+            throw new LiveException(LiveErrorCode.NOT_LIVE_OWNER);
+        }
+    }
 }

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                         // ── 3. ARTIST + SUPER_ADMIN (관리자) ──
                         .requestMatchers("/api/v1/admin/artists/*/raffles/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
                         .requestMatchers("/api/v1/admin/artists/*/lives/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
+                        .requestMatchers("/api/v1/admin/artists/*/dm/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
                         .requestMatchers("/api/post/v1/artist-posts").hasAnyRole("ARTIST", "SUPER_ADMIN")
                         .requestMatchers("/api/media/v1/media/import-youtube").hasAnyRole("ARTIST", "SUPER_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/media/v1/**").hasAnyRole("ARTIST", "SUPER_ADMIN")
@@ -115,6 +116,9 @@ public class SecurityConfig {
 
                         // 팬레터 (구독 검증은 서비스 레이어에서 수행)
                         .requestMatchers("/api/post/v1/fan-letters/**").authenticated()
+
+                        // DM (구독 검증은 서비스 레이어에서 수행)
+                        .requestMatchers("/api/v1/dm/**").authenticated()
 
                         // 웹훅 — PortOne 서버가 JWT 없이 직접 호출하므로 인증 제외
                         // 위변조 방지는 Controller의 HMAC-SHA256 서명 검증으로 수행

--- a/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package com.example.infinite.global.error;
 import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.hashtag.error.HashtagException;
 import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.domain.dm.error.DmException;
 import com.example.infinite.domain.member.artist.error.ArtistException;
 import com.example.infinite.domain.member.member.error.MemberErrorCode;
 import com.example.infinite.domain.member.member.error.MemberException;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.raffle.error.RaffleException;
+import com.example.infinite.domain.realtimelive.error.LiveException;
 import com.example.infinite.global.common.dto.ApiResponse;
 import com.example.infinite.global.common.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -170,11 +172,27 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 4xx/5xx: 라이브 도메인 커스텀 예외 처리
+     * 4xx/5xx: 라이브 도메인 커스텀 예외 처리 (global ErrorCode 기반 레거시)
      */
     @ExceptionHandler(RealtimeLiveException.class)
     public ResponseEntity<ApiResponse<Void>> handleRealtimeLiveException(RealtimeLiveException e, HttpServletRequest request) {
         return handleCustomException("RealtimeLiveException", e.getErrorCode(), e, request);
+    }
+
+    /**
+     * 4xx/5xx: 라이브 도메인 커스텀 예외 처리 (도메인별 ErrorCode)
+     */
+    @ExceptionHandler(LiveException.class)
+    public ResponseEntity<ApiResponse<Void>> handleLiveException(LiveException e, HttpServletRequest request) {
+        return handleCustomException("LiveException", e.getErrorCode(), e, request);
+    }
+
+    /**
+     * 4xx/5xx: DM 도메인 커스텀 예외 처리 (도메인별 ErrorCode)
+     */
+    @ExceptionHandler(DmException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDmException(DmException e, HttpServletRequest request) {
+        return handleCustomException("DmException", e.getErrorCode(), e, request);
     }
 
     /**


### PR DESCRIPTION
## Summary

라이브 스트리밍 CRUD REST, DM 기능, 보안·예외 핸들러 통합 작업.

- **라이브 CRUD** (#75): 관리자 API(생성/시작/종료/메시지 삭제/뮤트), 사용자 목록·상세·채팅 내역 조회(커서 페이징), Redis `live:{id}:status` 캐싱으로 채팅 핸들러 LIVE 상태 검증, 종료 시 버퍼 drain
- **DM 기능** (#76): 사용자/아티스트 REST 조회, STOMP 개별 메시지(`/pub/dm/{roomId}`), 아티스트 fan-out broadcast(`/pub/dm/broadcast/{artistId}`), 유저 답장 3건 제한 + DM 구독 검증
- **통합** (#77): SecurityConfig DM 경로 매처, GlobalExceptionHandler에 `LiveException`/`DmException` 등록, 뮤트 POST/DELETE REST

## 주요 설계 포인트

- 도메인별 `LiveErrorCode`/`DmErrorCode` + Exception (래플 패턴 준수). 기존 글로벌 `RealtimeLiveException`/`DMException` 핸들러는 레거시 호환 유지
- `@SQLRestriction` 자동 필터로 JPQL의 `deletedAt IS NULL` 조건 생략
- `CursorSliceResponse` 글로벌 인프라 활용 (limit+1 방식으로 hasNext 판별)
- `RealtimeLiveRepository` 빈 class → `interface extends JpaRepository`, 미사용 `RealtimeLiveDto` 제거
- DM 구독 검증은 `DmSubscriptionRepository.findByUserIdAndArtistIdAndStatus(ACTIVE)` 직접 참조 (민교 씨 `hasActiveSubscription` 공개 후 교체 예정)

## Test plan

- [ ] 라이브 생성 → SCHEDULED 저장
- [ ] 라이브 시작 → SCHEDULED→LIVE 전이 + Redis `live:{id}:status` SET
- [ ] 라이브 종료 → LIVE→ENDED + Redis DEL + 버퍼 잔여 메시지 flush
- [ ] LIVE 아닌 상태에서 STOMP 채팅 전송 → 조용히 무시
- [ ] 채팅 메시지 soft delete → `@SQLRestriction` 자동 필터로 목록 조회 제외
- [ ] 뮤트 POST/DELETE → Redis Set `live:{id}:muted` 반영
- [ ] DM 룸 목록·메시지 내역 조회 (`CursorSliceResponse` 정상 반환)
- [ ] STOMP 개별 DM — 유저: 구독 없으면 차단, 4번째 연속 메시지 차단
- [ ] STOMP 개별 DM — 아티스트: 제한 없이 전송
- [ ] STOMP broadcast — 아티스트 전체 DM 룸에 메시지 생성 + STOMP 전달
- [ ] SecurityConfig: 사용자 `/api/v1/dm/**` 인증, 관리자 `/api/v1/admin/artists/*/dm/**` ARTIST+SUPER_ADMIN
- [ ] `LiveException`/`DmException` 발생 시 HTTP 상태·에러 코드 정상 매핑

Closes #75
Closes #76
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)