### PR TITLE
[FEAT] SubscriptionMembershipService 구독 확인 공개 메서드 3종 추가 (#80)

### DIFF
--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/dto/response/FanLetterWritePermission.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/dto/response/FanLetterWritePermission.java
@@ -1,0 +1,13 @@
+package com.example.infinite.domain.subscriptionmembership.dto.response;
+
+/**
+ * 팬레터 작성 가능 여부 응답.
+ * 팬레터는 팬 멤버십 보유자만 작성할 수 있으므로 FanMembership 활성 여부로 판단한다.
+ * 추후 조건이 추가되더라도 allowed 외 필드를 확장하는 방식으로 대응 가능하다.
+ */
+public record FanLetterWritePermission(
+        Long artistId,
+        Long memberId,
+        // 팬 멤버십 활성 상태일 때만 true
+        boolean allowed
+) {}

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/dto/response/WriterSubscriptionBadge.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/dto/response/WriterSubscriptionBadge.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.subscriptionmembership.dto.response;
+
+/**
+ * 팬포스트·팬레터·댓글 목록에서 작성자 닉네임 옆에 표시할 구독 뱃지 정보.
+ * artistId 기준으로 해당 작성자(writerId)가 보유한 구독 종류를 담는다.
+ * 응답 Map에 포함되지 않은 writerId는 양쪽 모두 false로 간주한다.
+ */
+public record WriterSubscriptionBadge(
+        Long writerId,
+        // 해당 작성자가 이 아티스트의 팬 멤버십을 보유 중인지 여부
+        boolean fanMembershipSubscribed,
+        // 해당 작성자가 이 아티스트의 DM 구독권을 보유 중인지 여부
+        boolean dmSubscribed
+) {}

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/DmSubscriptionRepository.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/DmSubscriptionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,7 @@ public interface DmSubscriptionRepository extends JpaRepository<DmSubscription, 
     Page<DmSubscription> findByUserId(Long userId, Pageable pageable);
 
     List<DmSubscription> findByStatusAndExpiredAtBefore(SubscriptionStatus status, LocalDateTime now);
+
+    // 특정 아티스트에 대해 여러 유저의 DM 구독 상태를 한 번에 조회 (뱃지 배치 조회용, N+1 방지)
+    List<DmSubscription> findByArtistIdAndUserIdInAndStatus(Long artistId, Collection<Long> userIds, SubscriptionStatus status);
 }

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/FanMembershipRepository.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/FanMembershipRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,7 @@ public interface FanMembershipRepository extends JpaRepository<FanMembership, Lo
     Page<FanMembership> findByUserId(Long userId, Pageable pageable);
 
     List<FanMembership> findByStatusAndExpiredAtBefore(SubscriptionStatus status, LocalDateTime now);
+
+    // 특정 아티스트에 대해 여러 유저의 팬 멤버십 상태를 한 번에 조회 (뱃지 배치 조회용, N+1 방지)
+    List<FanMembership> findByArtistIdAndUserIdInAndStatus(Long artistId, Collection<Long> userIds, SubscriptionStatus status);
 }

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/service/SubscriptionMembershipService.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/service/SubscriptionMembershipService.java
@@ -3,8 +3,10 @@ package com.example.infinite.domain.subscriptionmembership.service;
 import com.example.infinite.domain.payment.config.JellyProperties;
 import com.example.infinite.domain.payment.enums.ReferenceType;
 import com.example.infinite.domain.payment.service.JellyService;
+import com.example.infinite.domain.subscriptionmembership.dto.response.FanLetterWritePermission;
 import com.example.infinite.domain.subscriptionmembership.dto.response.SubscriptionHistoryResponse;
 import com.example.infinite.domain.subscriptionmembership.dto.response.SubscriptionStatusResponse;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
 import com.example.infinite.domain.subscriptionmembership.entity.DmSubscription;
 import com.example.infinite.domain.subscriptionmembership.entity.FanMembership;
 import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
@@ -19,6 +21,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -97,5 +103,75 @@ public class SubscriptionMembershipService {
                 fanMembershipRepository.findByUserId(userId, pageable)
                         .map(SubscriptionHistoryResponse::from)
         );
+    }
+
+    // ── 타 도메인 공개 API ────────────────────────────────────────────────────
+
+    /**
+     * DM 구독 활성 여부 확인.
+     * 래플 응모(MEMBERSHIP_ONLY) 검증, DM 메시지 발송 시 구독 확인에 사용.
+     * 다른 도메인이 DmSubscriptionRepository를 직접 주입받지 않아도 되도록 캡슐화.
+     */
+    @Transactional(readOnly = true)
+    public boolean hasActiveSubscription(Long userId, Long artistId) {
+        return dmSubscriptionRepository
+                .findByUserIdAndArtistIdAndStatus(userId, artistId, SubscriptionStatus.ACTIVE)
+                .map(DmSubscription::isActive)
+                .orElse(false);
+    }
+
+    /**
+     * 작성자 목록의 구독 뱃지 배치 조회.
+     * 팬포스트·팬레터·댓글 목록에서 작성자 닉네임 옆 뱃지 표시에 사용.
+     * IN절 단일 쿼리 2회(DM·멤버십)로 처리하여 N+1 없이 동작한다.
+     *
+     * @param artistId  뱃지 기준이 되는 아티스트
+     * @param writerIds 뱃지를 표시할 작성자 userId 목록
+     * @return key=writerId, value=뱃지 정보 (Map에 없는 writerId는 양쪽 모두 false)
+     */
+    @Transactional(readOnly = true)
+    public Map<Long, WriterSubscriptionBadge> getWriterBadges(Long artistId, Collection<Long> writerIds) {
+        // DM 구독 중인 writerId Set
+        Set<Long> dmSubscribedIds = dmSubscriptionRepository
+                .findByArtistIdAndUserIdInAndStatus(artistId, writerIds, SubscriptionStatus.ACTIVE)
+                .stream()
+                .filter(DmSubscription::isActive)   // 만료일 이중 검증
+                .map(DmSubscription::getUserId)
+                .collect(Collectors.toSet());
+
+        // 팬 멤버십 보유 중인 writerId Set
+        Set<Long> fanMembershipIds = fanMembershipRepository
+                .findByArtistIdAndUserIdInAndStatus(artistId, writerIds, SubscriptionStatus.ACTIVE)
+                .stream()
+                .filter(FanMembership::isActive)    // 만료일 이중 검증
+                .map(FanMembership::getUserId)
+                .collect(Collectors.toSet());
+
+        return writerIds.stream()
+                .distinct()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        id -> new WriterSubscriptionBadge(
+                                id,
+                                fanMembershipIds.contains(id),
+                                dmSubscribedIds.contains(id)
+                        )
+                ));
+    }
+
+    /**
+     * 팬레터 작성 가능 여부 확인.
+     * 팬레터는 팬 멤버십 보유자만 작성 가능하므로 FanMembership 활성 여부로 판단.
+     *
+     * @param artistId 대상 아티스트
+     * @param memberId 팬레터를 쓰려는 유저 userId
+     */
+    @Transactional(readOnly = true)
+    public FanLetterWritePermission checkFanLetterPermission(Long artistId, Long memberId) {
+        boolean allowed = fanMembershipRepository
+                .findByUserIdAndArtistIdAndStatus(memberId, artistId, SubscriptionStatus.ACTIVE)
+                .map(FanMembership::isActive)
+                .orElse(false);
+        return new FanLetterWritePermission(artistId, memberId, allowed);
     }
 }


### PR DESCRIPTION
## 💡 기능 상세 내용                                                                                                                                           
  여러 도메인(래플, DM, 팬포스트, 팬레터)에서 DmSubscriptionRepository를 직접 주입받아                                                                           
  구독 검증 로직이 분산되는 문제를 해결하기 위해 서비스 레이어에 공개 메서드 3종 캡슐화                                                                          
                                                                                                                                                                 
  - [x] `hasActiveSubscription(userId, artistId)` — DM 구독 활성 여부 boolean 반환 (래플·DM용)                                                                   
  - [x] `getWriterBadges(artistId, writerIds)` — 작성자별 팬멤버십·DM구독 뱃지 배치 조회 (팬포스트·팬레터·댓글용)                                                
  - [x] `checkFanLetterPermission(artistId, memberId)` — 팬멤버십 보유 여부로 팬레터 작성 가능 여부 반환 (팬레터용)                                              
  - [x] Repository IN절 배치 조회 메서드 추가 (N+1 방지)                                                                                                         
  - [x] `WriterSubscriptionBadge`, `FanLetterWritePermission` record 신규 추가

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] 다른 도메인이 Repository를 직접 주입받지 않고 서비스 메서드만으로 구독 검증 가능
  - [x] getWriterBadges가 단일 쿼리(IN절)로 배치 조회되어 N+1 없음

  ## 🔗 기타 참고 사항
  - 팬레터 작성 조건: FanMembership 보유
  - DM 발송 조건: DmSubscription 보유 (별개)
  - Close #80