### PR TITLE
Feat: 래플 결과 알림 + DM 도메인 공개 API

### DIFF
--- a/src/main/java/com/example/infinite/domain/dm/repository/DmMessageRepository.java
+++ b/src/main/java/com/example/infinite/domain/dm/repository/DmMessageRepository.java
@@ -1,10 +1,12 @@
 package com.example.infinite.domain.dm.repository;
 
 import com.example.infinite.domain.dm.entity.DmMessage;
+import com.example.infinite.domain.dm.enums.SenderType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
@@ -34,4 +36,13 @@ public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
               )
             """)
     long countUserMessagesSinceLastArtistReply(@Param("roomId") Long roomId);
+
+    /**
+     * 특정 유저가 특정 아티스트와의 DM 룸에서,
+     * 지정 시각 이후에 USER 타입 메시지를 보낸 적이 있는지 확인.
+     * 구독권 환불 검증용 — 결제 도메인에서 DmService를 통해 호출.
+     */
+    boolean existsByDmRoom_UserIdAndDmRoom_ArtistIdAndSenderTypeAndSentAtAfter(
+            Long userId, Long artistId, SenderType senderType, LocalDateTime after
+    );
 }

--- a/src/main/java/com/example/infinite/domain/dm/service/DmService.java
+++ b/src/main/java/com/example/infinite/domain/dm/service/DmService.java
@@ -18,6 +18,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -141,5 +142,21 @@ public class DmService {
         if (!room.getUserId().equals(userId) && !room.getArtistId().equals(userId)) {
             throw new DmException(DmErrorCode.DM_NOT_ROOM_MEMBER);
         }
+    }
+
+    /**
+     * 해당 유저가 특정 아티스트와의 DM에서 지정 시각 이후 메시지를 보낸 적이 있는지 확인.
+     * 환불 서비스에서 호출: dmService.hasUserSentMessageAfter(userId, artistId, subscription.getStartedAt())
+     *
+     * @param userId   유저 ID
+     * @param artistId 아티스트 ID
+     * @param after    기준 시각 (구독 시작일)
+     * @return true면 메시지 발송 이력 있음 → 환불 불가
+     */
+    public boolean hasUserSentMessageAfter(Long userId, Long artistId, LocalDateTime after) {
+        return dmMessageRepository
+                .existsByDmRoom_UserIdAndDmRoom_ArtistIdAndSenderTypeAndSentAtAfter(
+                        userId, artistId, SenderType.USER, after
+                );
     }
 }

--- a/src/main/java/com/example/infinite/domain/raffle/dto/RaffleNotification.java
+++ b/src/main/java/com/example/infinite/domain/raffle/dto/RaffleNotification.java
@@ -1,0 +1,25 @@
+package com.example.infinite.domain.raffle.dto;
+
+/**
+ * STOMP /sub/user/{userId}/notifications 으로 전송되는 래플 결과 알림.
+ */
+public record RaffleNotification(
+        String type,        // "RAFFLE_WIN" | "RAFFLE_LOSE"
+        Long raffleId,
+        String raffleTitle,
+        String message
+) {
+    public static RaffleNotification win(Long raffleId, String title) {
+        return new RaffleNotification(
+                "RAFFLE_WIN", raffleId, title,
+                "축하합니다! '" + title + "' 래플에 당첨되었습니다. DM 구독이 30일 연장됩니다."
+        );
+    }
+
+    public static RaffleNotification lose(Long raffleId, String title) {
+        return new RaffleNotification(
+                "RAFFLE_LOSE", raffleId, title,
+                "'" + title + "' 래플에 아쉽게 당첨되지 못했습니다. 다음 기회에 도전해주세요!"
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/raffle/repository/RaffleEntryRepository.java
+++ b/src/main/java/com/example/infinite/domain/raffle/repository/RaffleEntryRepository.java
@@ -2,6 +2,8 @@ package com.example.infinite.domain.raffle.repository;
 
 import com.example.infinite.domain.raffle.entity.RaffleEntry;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,7 @@ public interface RaffleEntryRepository extends JpaRepository<RaffleEntry, Long> 
     List<RaffleEntry> findByUserIdOrderByEnteredAtDesc(Long userId);
 
     boolean existsByRaffleIdAndUserId(Long raffleId, Long userId);
+
+    @Query("SELECT e.userId FROM RaffleEntry e WHERE e.raffleId = :raffleId")
+    List<Long> findUserIdsByRaffleId(@Param("raffleId") Long raffleId);
 }

--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleNotificationService.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleNotificationService.java
@@ -1,0 +1,122 @@
+package com.example.infinite.domain.raffle.service;
+
+import com.example.infinite.domain.raffle.dto.RaffleNotification;
+import com.example.infinite.domain.raffle.entity.Raffle;
+import com.example.infinite.domain.raffle.entity.RaffleSlotWinner;
+import com.example.infinite.domain.raffle.enums.RewardType;
+import com.example.infinite.domain.raffle.repository.RaffleEntryRepository;
+import com.example.infinite.domain.raffle.repository.RaffleSlotWinnerRepository;
+import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
+import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RaffleNotificationService {
+
+    private static final int MEMBERSHIP_EXTENSION_DAYS = 30;
+    private static final int JITTER_MAX_SECONDS = 5;
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final DmSubscriptionRepository dmSubscriptionRepository;
+    private final RaffleEntryRepository raffleEntryRepository;
+    private final RaffleSlotWinnerRepository raffleSlotWinnerRepository;
+
+    private final ScheduledExecutorService jitterExecutor = Executors.newScheduledThreadPool(1);
+
+    /**
+     * 당첨자에게 알림 전송 + DM 구독 연장 (MEMBERSHIP_EXTENSION 자동 이행).
+     * - reward_type이 MEMBERSHIP_EXTENSION이면: 구독 +30일 연장 + rewardStatus GRANTED
+     * - STOMP Push로 당첨 알림
+     */
+    @Transactional
+    public void handleWinner(Raffle raffle, RaffleSlotWinner winner) {
+        if (raffle.getRewardType() == RewardType.MEMBERSHIP_EXTENSION) {
+            extendDmSubscription(winner.getUserId(), raffle.getArtistId());
+            winner.grant();
+            log.info("DM 구독 연장 완료: userId={}, artistId={}, +{}일",
+                    winner.getUserId(), raffle.getArtistId(), MEMBERSHIP_EXTENSION_DAYS);
+        }
+
+        sendNotification(
+                winner.getUserId(),
+                RaffleNotification.win(raffle.getId(), raffle.getTitle())
+        );
+    }
+
+    /**
+     * 래플 완료 시 비당첨자에게 일괄 알림.
+     * - Jitter: 0~5초 랜덤 지연으로 STOMP 서버 부하 분산
+     * - 비동기: 래플 완료 트랜잭션을 블로킹하지 않음
+     */
+    public void notifyLosers(Raffle raffle) {
+        List<Long> allEntryUserIds = raffleEntryRepository.findUserIdsByRaffleId(raffle.getId());
+
+        Set<Long> winnerUserIds = raffleSlotWinnerRepository.findByRaffleId(raffle.getId())
+                .stream()
+                .map(RaffleSlotWinner::getUserId)
+                .collect(Collectors.toSet());
+
+        List<Long> loserUserIds = allEntryUserIds.stream()
+                .filter(userId -> !winnerUserIds.contains(userId))
+                .toList();
+
+        if (loserUserIds.isEmpty()) {
+            return;
+        }
+
+        RaffleNotification notification = RaffleNotification.lose(raffle.getId(), raffle.getTitle());
+
+        for (Long userId : loserUserIds) {
+            long delaySec = ThreadLocalRandom.current().nextLong(0, JITTER_MAX_SECONDS + 1);
+            jitterExecutor.schedule(
+                    () -> sendNotification(userId, notification),
+                    delaySec,
+                    TimeUnit.SECONDS
+            );
+        }
+
+        log.info("비당첨자 알림 예약: raffleId={}, losers={}, jitter=0~{}s",
+                raffle.getId(), loserUserIds.size(), JITTER_MAX_SECONDS);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        jitterExecutor.shutdown();
+    }
+
+    private void sendNotification(Long userId, RaffleNotification notification) {
+        try {
+            messagingTemplate.convertAndSend(
+                    "/sub/user/" + userId + "/notifications",
+                    notification
+            );
+        } catch (Exception e) {
+            log.warn("래플 알림 전송 실패: userId={}, type={}, error={}",
+                    userId, notification.type(), e.getMessage());
+        }
+    }
+
+    private void extendDmSubscription(Long userId, Long artistId) {
+        dmSubscriptionRepository
+                .findByUserIdAndArtistIdAndStatus(userId, artistId, SubscriptionStatus.ACTIVE)
+                .ifPresentOrElse(
+                        subscription -> subscription.extendExpiry(MEMBERSHIP_EXTENSION_DAYS),
+                        () -> log.warn("활성 DM 구독 없음 — 연장 불가: userId={}, artistId={}", userId, artistId)
+                );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
@@ -44,6 +44,7 @@ public class RaffleService {
     private final ReservoirSampler reservoirSampler;
     private final RaffleSchedulerService schedulerService;
     private final StringRedisTemplate stringRedisTemplate;
+    private final RaffleNotificationService raffleNotificationService;
 
     private static final String META_KEY_FORMAT = "raffle:%d:meta";
     private static final Duration META_TTL_AFTER_COMPLETE = Duration.ofMinutes(5);
@@ -157,6 +158,8 @@ public class RaffleService {
             raffleSlotWinnerRepository.save(winner);
             currentSlot.complete();
             log.info("슬롯 당첨자 확정: raffleId={}, slot={}, winner={}", raffleId, slotIndex, winnerId);
+
+            raffleNotificationService.handleWinner(raffle, winner);
         } else {
             currentSlot.markEmpty(currentSlot.getTargetWinnerCount());
             log.info("슬롯 빈 종료: raffleId={}, slot={}, carryOver={}", raffleId, slotIndex, currentSlot.getTargetWinnerCount());

--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
@@ -196,6 +196,8 @@ public class RaffleService {
         }
 
         log.info("래플 완료: id={}", raffle.getId());
+
+        raffleNotificationService.notifyLosers(raffle);
     }
 
     // ─── Redis 메타 초기화 ───

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/DmSubscription.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/entity/DmSubscription.java
@@ -65,4 +65,12 @@ public class DmSubscription extends BaseEntity {
         return this.status == SubscriptionStatus.ACTIVE
                 && LocalDateTime.now().isBefore(this.expiredAt);
     }
+
+    /**
+     * 만료일을 지정 일수만큼 연장한다.
+     * 래플 당첨 보상(MEMBERSHIP_EXTENSION) 등에서 사용.
+     */
+    public void extendExpiry(int days) {
+        this.expiredAt = this.expiredAt.plusDays(days);
+    }
 }


### PR DESCRIPTION
## Summary
- 래플 슬롯 종료 시 당첨자 STOMP Push 및 MEMBERSHIP_EXTENSION 보상 자동 이행(DM 구독 +30일, GRANTED 처리)
- 래플 완료 시 비당첨자 일괄 알림 — `ScheduledExecutor` + 0~5초 Jitter로 트랜잭션 비블로킹
- DM 도메인 공개 API `DmService.hasUserSentMessageAfter()` 추가 — 결제 환불 검증에서 `DmMessageRepository` 직접 참조 없이 호출 가능

## 변경 파일
**신규**
- `domain/raffle/dto/RaffleNotification.java`
- `domain/raffle/service/RaffleNotificationService.java`

**수정 (래플)**
- `domain/raffle/service/RaffleService.java` — `closeSlot`/`completeRaffle`에서 알림 서비스 호출
- `domain/raffle/repository/RaffleEntryRepository.java` — `findUserIdsByRaffleId` 추가

**수정 (DM)**
- `domain/dm/repository/DmMessageRepository.java` — exists 네이밍 쿼리 추가
- `domain/dm/service/DmService.java` — `hasUserSentMessageAfter` 공개 메서드 추가

**수정 (구독)**
- `domain/subscriptionmembership/entity/DmSubscription.java` — `extendExpiry(days)` 추가

## 설계 노트
- **보상 자동 이행**: `MEMBERSHIP_EXTENSION`은 시스템이 자동 이행 가능하므로 `closeSlot()` 트랜잭션 내에서 구독 연장 + GRANTED를 원자적으로 처리. 기존 `updateRewardStatus()` API는 수동 보상/실패 복구용으로 유지.
- **Jitter 비동기**: 비당첨자 알림은 `ScheduledExecutorService` + `ThreadLocalRandom`로 0~5초 분산. `@PreDestroy`로 graceful shutdown.
- **도메인 경계**: 결제 도메인이 `DmMessageRepository`를 직접 주입하지 않고 `DmService` 메서드만 호출하도록 설계.

## Test plan
- [ ] 래플 응모 → 슬롯 종료 → 당첨자에게 `/sub/user/{userId}/notifications`로 `RAFFLE_WIN` 수신 확인
- [ ] 당첨자의 활성 DM 구독 `expiredAt`이 +30일 연장되었는지 확인
- [ ] `raffle_slot_winners.reward_status = GRANTED`, `granted_at` 기록 확인
- [ ] 활성 DM 구독이 없는 당첨자의 경우 WARN 로그만 남고 트랜잭션 정상 커밋되는지 확인
- [ ] 래플 완료 시 비당첨자가 `RAFFLE_LOSE` 알림을 0~5초 내에 수신하는지 확인
- [ ] `completeRaffle()` 응답이 비당첨자 알림 발송을 기다리지 않고 즉시 반환하는지 확인
- [ ] `dmService.hasUserSentMessageAfter(userId, artistId, after)` 호출 시 USER 메시지 존재 여부 정상 반환
- [ ] 기존 단위/통합 테스트 통과 + 컴파일 에러 없음

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)