### PR TITLE
[FEAT] 결제·구독 환불 기능 구현 (#83)

### DIFF
--- a/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
+++ b/src/main/java/com/example/infinite/domain/payment/client/PortOneClient.java
@@ -37,7 +37,8 @@ public class PortOneClient {
     }
 
     // PortOne 빌링키로 결제 (자동충전)
-    public void charge(String billingKey, int amount, Long userId) {
+    // paymentId를 반환해 호출부에서 저장할 수 있도록 한다 — 환불 시 취소 API 호출에 필요
+    public String charge(String billingKey, int amount, Long userId) {
         String paymentId = "auto-charge-" + UUID.randomUUID();
         Map<String, Object> body = Map.of(
                 "billingKey", billingKey,
@@ -54,8 +55,25 @@ public class PortOneClient {
                     .body(body)
                     .retrieve()
                     .toBodilessEntity();
+            return paymentId;
         } catch (Exception e) {
             log.error("PortOne 자동충전 결제 실패: userId={}, amount={}, error={}", userId, amount, e.getMessage());
+            throw e;
+        }
+    }
+
+    // PortOne 결제 취소 (환불) — 수동결제·자동충전 환불 시 호출
+    public void cancelPayment(String paymentId, String reason) {
+        try {
+            restClient.post()
+                    .uri("/payments/{paymentId}/cancel", paymentId)
+                    .header("Authorization", "PortOne " + apiSecret)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("reason", reason))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.error("PortOne 결제 취소 실패: paymentId={}, error={}", paymentId, e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
@@ -1,8 +1,10 @@
 package com.example.infinite.domain.payment.controller;
 
 import com.example.infinite.domain.payment.service.RefundService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,36 +17,27 @@ public class RefundController {
     // 수동결제 환불 — 결제일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
     @PostMapping("/payments/{paymentId}")
     public ApiResponse<Void> refundPayment(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable String paymentId) {
-        refundService.refundPayment(userId, paymentId);
+        refundService.refundPayment(member.getMemberId(), paymentId);
         return ApiResponse.success(null);
     }
 
     // 자동충전 환불 — 충전일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
     @PostMapping("/auto-charges/{historyId}")
     public ApiResponse<Void> refundAutoCharge(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable Long historyId) {
-        refundService.refundAutoCharge(userId, historyId);
+        refundService.refundAutoCharge(member.getMemberId(), historyId);
         return ApiResponse.success(null);
     }
 
     // DM 구독권 환불 — 구독일로부터 7일 이내, DM 미발송 조건 충족 시 젤리 반환
     @PostMapping("/dm-subscriptions/{subscriptionId}")
     public ApiResponse<Void> refundDmSubscription(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable Long subscriptionId) {
-        refundService.refundDmSubscription(userId, subscriptionId);
-        return ApiResponse.success(null);
-    }
-
-    // 팬 멤버십 환불 — 정책상 환불 불가, 클라이언트에 명확한 에러 반환
-    @PostMapping("/fan-memberships/{membershipId}")
-    public ApiResponse<Void> refundFanMembership(
-            @RequestHeader("X-User-Id") Long userId,
-            @PathVariable Long membershipId) {
-        refundService.refundFanMembership();
+        refundService.refundDmSubscription(member.getMemberId(), subscriptionId);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
@@ -1,0 +1,50 @@
+package com.example.infinite.domain.payment.controller;
+
+import com.example.infinite.domain.payment.service.RefundService;
+import com.example.infinite.global.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payment/v1/refunds")
+public class RefundController {
+
+    private final RefundService refundService;
+
+    // 수동결제 환불 — 결제일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
+    @PostMapping("/payments/{paymentId}")
+    public ApiResponse<Void> refundPayment(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable String paymentId) {
+        refundService.refundPayment(userId, paymentId);
+        return ApiResponse.success(null);
+    }
+
+    // 자동충전 환불 — 충전일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
+    @PostMapping("/auto-charges/{historyId}")
+    public ApiResponse<Void> refundAutoCharge(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long historyId) {
+        refundService.refundAutoCharge(userId, historyId);
+        return ApiResponse.success(null);
+    }
+
+    // DM 구독권 환불 — 구독일로부터 7일 이내, DM 미발송 조건 충족 시 젤리 반환
+    @PostMapping("/dm-subscriptions/{subscriptionId}")
+    public ApiResponse<Void> refundDmSubscription(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long subscriptionId) {
+        refundService.refundDmSubscription(userId, subscriptionId);
+        return ApiResponse.success(null);
+    }
+
+    // 팬 멤버십 환불 — 정책상 환불 불가, 클라이언트에 명확한 에러 반환
+    @PostMapping("/fan-memberships/{membershipId}")
+    public ApiResponse<Void> refundFanMembership(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long membershipId) {
+        refundService.refundFanMembership();
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
+++ b/src/main/java/com/example/infinite/domain/payment/controller/RefundController.java
@@ -4,6 +4,7 @@ import com.example.infinite.domain.payment.service.RefundService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,28 +17,28 @@ public class RefundController {
 
     // 수동결제 환불 — 결제일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
     @PostMapping("/payments/{paymentId}")
-    public ApiResponse<Void> refundPayment(
+    public ResponseEntity<ApiResponse<Void>> refundPayment(
             @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable String paymentId) {
         refundService.refundPayment(member.getMemberId(), paymentId);
-        return ApiResponse.success(null);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     // 자동충전 환불 — 충전일로부터 7일 이내, 젤리 미사용 조건 충족 시 PortOne 취소
     @PostMapping("/auto-charges/{historyId}")
-    public ApiResponse<Void> refundAutoCharge(
+    public ResponseEntity<ApiResponse<Void>> refundAutoCharge(
             @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable Long historyId) {
         refundService.refundAutoCharge(member.getMemberId(), historyId);
-        return ApiResponse.success(null);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     // DM 구독권 환불 — 구독일로부터 7일 이내, DM 미발송 조건 충족 시 젤리 반환
     @PostMapping("/dm-subscriptions/{subscriptionId}")
-    public ApiResponse<Void> refundDmSubscription(
+    public ResponseEntity<ApiResponse<Void>> refundDmSubscription(
             @AuthenticationPrincipal MemberDetailsImpl member,
             @PathVariable Long subscriptionId) {
         refundService.refundDmSubscription(member.getMemberId(), subscriptionId);
-        return ApiResponse.success(null);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
@@ -38,9 +38,14 @@ public class AutoChargeHistory extends BaseEntity {
     private String failReason; // 실패 사유 (성공 시 null)
 
     // PortOne 결제 식별자 — 환불 시 PortOne 취소 API 호출에 사용
-    // 이 필드가 null인 이력(기존 데이터)은 환불 불가
+    // 이 필드가 null인 이력(이 기능 도입 전 데이터)은 환불 불가
     @Column
     private String portOnePaymentId;
+
+    // 환불 완료 여부 — 젤리 회수 + PortOne 취소가 모두 완료된 경우 true
+    // PaymentOrder의 REFUNDED 상태와 동일한 의미이나, AutoChargeHistory는 별도 status 컬럼이 없으므로 플래그로 관리
+    @Column(nullable = false)
+    private boolean refunded = false;
 
     @Builder
     public AutoChargeHistory(Long userId, BillingKey billingKey,
@@ -52,5 +57,11 @@ public class AutoChargeHistory extends BaseEntity {
         this.success = success;
         this.failReason = failReason;
         this.portOnePaymentId = portOnePaymentId;
+        this.refunded = false;
+    }
+
+    // 환불 완료 처리 — RefundService에서 PortOne 취소 + 젤리 회수 완료 후 호출
+    public void markRefunded() {
+        this.refunded = true;
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
@@ -37,13 +37,20 @@ public class AutoChargeHistory extends BaseEntity {
     @Column
     private String failReason; // 실패 사유 (성공 시 null)
 
+    // PortOne 결제 식별자 — 환불 시 PortOne 취소 API 호출에 사용
+    // 이 필드가 null인 이력(기존 데이터)은 환불 불가
+    @Column
+    private String portOnePaymentId;
+
     @Builder
     public AutoChargeHistory(Long userId, BillingKey billingKey,
-                             Integer jellyAmount, boolean success, String failReason) {
+                             Integer jellyAmount, boolean success,
+                             String failReason, String portOnePaymentId) {
         this.userId = userId;
         this.billingKey = billingKey;
         this.jellyAmount = jellyAmount;
         this.success = success;
         this.failReason = failReason;
+        this.portOnePaymentId = portOnePaymentId;
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/entity/PaymentOrder.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/PaymentOrder.java
@@ -60,4 +60,9 @@ public class PaymentOrder extends BaseEntity {
     public void fail() {
         this.status = PaymentStatus.FAILED;
     }
+
+    // 환불 완료 — PortOne 취소 + 젤리 회수 후 호출
+    public void refund() {
+        this.status = PaymentStatus.REFUNDED;
+    }
 }

--- a/src/main/java/com/example/infinite/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/example/infinite/domain/payment/enums/PaymentStatus.java
@@ -1,7 +1,8 @@
 package com.example.infinite.domain.payment.enums;
 
 public enum PaymentStatus {
-    PENDING,  // 결제 준비 완료, PortOne 결제 대기 중
-    PAID,     // 결제 완료, 젤리 지급 완료
-    FAILED    // 결제 실패 또는 검증 실패
+    PENDING,   // 결제 준비 완료, PortOne 결제 대기 중
+    PAID,      // 결제 완료, 젤리 지급 완료
+    FAILED,    // 결제 실패 또는 검증 실패
+    REFUNDED   // 환불 완료 (PortOne 취소 + 젤리 회수 처리됨)
 }

--- a/src/main/java/com/example/infinite/domain/payment/repository/AutoChargeHistoryRepository.java
+++ b/src/main/java/com/example/infinite/domain/payment/repository/AutoChargeHistoryRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AutoChargeHistoryRepository extends JpaRepository<AutoChargeHistory, Long> {
 
     // 유저의 자동충전 실행 이력 페이징 조회
     Page<AutoChargeHistory> findByUserId(Long userId, Pageable pageable);
+
+    // 환불 요청 시 본인 소유 이력인지 검증하며 단건 조회
+    Optional<AutoChargeHistory> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/example/infinite/domain/payment/repository/JellyTransactionRepository.java
+++ b/src/main/java/com/example/infinite/domain/payment/repository/JellyTransactionRepository.java
@@ -1,11 +1,17 @@
 package com.example.infinite.domain.payment.repository;
 
 import com.example.infinite.domain.payment.entity.JellyTransaction;
+import com.example.infinite.domain.payment.enums.TransactionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface JellyTransactionRepository extends JpaRepository<JellyTransaction, Long> {
 
     Page<JellyTransaction> findByUserId(Long userId, Pageable pageable);
+
+    // 환불 조건 검증용: 특정 시각 이후 USE 트랜잭션이 있으면 젤리를 사용한 것 → 환불 불가
+    boolean existsByUserIdAndTypeAndCreatedAtAfter(Long userId, TransactionType type, LocalDateTime after);
 }

--- a/src/main/java/com/example/infinite/domain/payment/service/AutoChargeService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/AutoChargeService.java
@@ -174,12 +174,12 @@ public class AutoChargeService {
         int chargeAmount = setting.getJellyAmount() * jellyProperties.pricePerUnit();
 
         try {
-            // 1) PortOne 빌링키 결제
-            portOneClient.charge(billingKey.getBillingKey(), chargeAmount, userId);
+            // 1) PortOne 빌링키 결제 — paymentId를 반환받아 이력에 저장 (환불 시 취소 API 호출에 필요)
+            String portOnePaymentId = portOneClient.charge(billingKey.getBillingKey(), chargeAmount, userId);
             // 2) 젤리 지급 (CHARGE 거래 이력도 함께 저장됨)
             jellyService.charge(userId, setting.getJellyAmount(), ReferenceType.AUTO_CHARGE, setting.getId());
             // 3) 성공 이력 저장 — 현재 트랜잭션(REQUIRES_NEW)에 참여
-            chargeHistoryService.saveSuccess(userId, setting);
+            chargeHistoryService.saveSuccess(userId, setting, portOnePaymentId);
             log.info("자동충전 성공: userId={}, jellies={}", userId, setting.getJellyAmount());
         } catch (Exception e) {
             // 실패 이력은 ChargeHistoryService.saveFailure() 의 REQUIRES_NEW 트랜잭션으로 독립 저장

--- a/src/main/java/com/example/infinite/domain/payment/service/ChargeHistoryService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/ChargeHistoryService.java
@@ -17,27 +17,30 @@ public class ChargeHistoryService {
     private final AutoChargeHistoryRepository autoChargeHistoryRepository;
 
     // 성공 이력 저장 - 기존 트랜잭션에 참여 (충전과 같은 트랜잭션으로 묶임)
+    // portOnePaymentId: 환불 시 PortOne 취소 API 호출에 필요한 결제 식별자
     @Transactional
-    public void saveSuccess(Long userId, AutoChargeSetting setting) {
-        save(userId, setting, true, null);
+    public void saveSuccess(Long userId, AutoChargeSetting setting, String portOnePaymentId) {
+        save(userId, setting, true, null, portOnePaymentId);
     }
 
-    // [추가] 실패 이력 저장 - REQUIRES_NEW로 독립 트랜잭션 사용
+    // 실패 이력 저장 - REQUIRES_NEW로 독립 트랜잭션 사용
     // 바깥 트랜잭션(jellyService.charge)이 롤백돼도 이 커밋은 유지됨
     // → 운영 중 실패 추적 및 결제 감사 로그 보장
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveFailure(Long userId, AutoChargeSetting setting, String reason) {
-        save(userId, setting, false, reason);
+        save(userId, setting, false, reason, null);
     }
 
     // 이력 저장 공통 메서드
-    private void save(Long userId, AutoChargeSetting setting, boolean success, String failReason) {
+    private void save(Long userId, AutoChargeSetting setting, boolean success,
+                      String failReason, String portOnePaymentId) {
         autoChargeHistoryRepository.save(AutoChargeHistory.builder()
                 .userId(userId)
                 .billingKey(setting.getBillingKey())
                 .jellyAmount(setting.getJellyAmount())
                 .success(success)
                 .failReason(failReason)
+                .portOnePaymentId(portOnePaymentId)
                 .build());
     }
 }

--- a/src/main/java/com/example/infinite/domain/payment/service/JellyService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/JellyService.java
@@ -78,11 +78,24 @@ public class JellyService {
         }
     }
 
-    // 젤리 환불 - 비관적 락 적용 (내부: 환불 서비스에서 호출)
+    // 젤리 환불 (잔액 반환) — DM 구독권처럼 젤리로 결제한 항목 환불 시 호출
+    // 결제 시 차감된 젤리를 다시 지급한다.
     @Transactional
     public void refund(Long userId, int amount, ReferenceType referenceType, Long relatedId) {
         UserJellyBalance wallet = findWalletForUpdate(userId);
-        wallet.charge(amount); // 환불은 잔액 재충전
+        wallet.charge(amount); // 환불 = 잔액 재충전
+
+        saveTransaction(userId, TransactionType.REFUND, referenceType, relatedId,
+                amount, wallet.getCurrentBalance());
+    }
+
+    // 현금 결제 환불 시 젤리 회수 — 수동결제·자동충전처럼 현금으로 결제한 항목 환불 시 호출
+    // PortOne이 현금을 돌려주므로 지급됐던 젤리는 다시 차감한다.
+    // use()와 달리 자동충전을 트리거하지 않는다 — 환불로 인한 차감이므로 재충전 불필요
+    @Transactional
+    public void reclaimForCashRefund(Long userId, int amount, ReferenceType referenceType, Long relatedId) {
+        UserJellyBalance wallet = findWalletForUpdate(userId);
+        wallet.use(amount); // 지급됐던 젤리 회수
 
         saveTransaction(userId, TransactionType.REFUND, referenceType, relatedId,
                 amount, wallet.getCurrentBalance());

--- a/src/main/java/com/example/infinite/domain/payment/service/RefundService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/RefundService.java
@@ -1,0 +1,207 @@
+package com.example.infinite.domain.payment.service;
+
+import com.example.infinite.domain.dm.service.DmService;
+import com.example.infinite.domain.payment.client.PortOneClient;
+import com.example.infinite.domain.payment.entity.AutoChargeHistory;
+import com.example.infinite.domain.payment.entity.PaymentOrder;
+import com.example.infinite.domain.payment.enums.PaymentStatus;
+import com.example.infinite.domain.payment.enums.ReferenceType;
+import com.example.infinite.domain.payment.enums.TransactionType;
+import com.example.infinite.domain.payment.repository.AutoChargeHistoryRepository;
+import com.example.infinite.domain.payment.repository.JellyTransactionRepository;
+import com.example.infinite.domain.payment.repository.PaymentOrderRepository;
+import com.example.infinite.domain.subscriptionmembership.entity.DmSubscription;
+import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
+import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.PaymentException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+
+    private static final int REFUND_PERIOD_DAYS = 7; // 환불 가능 기간
+
+    private final PaymentOrderRepository paymentOrderRepository;
+    private final AutoChargeHistoryRepository autoChargeHistoryRepository;
+    private final DmSubscriptionRepository dmSubscriptionRepository;
+    private final JellyTransactionRepository jellyTransactionRepository;
+    private final JellyService jellyService;
+    private final PortOneClient portOneClient;
+    private final DmService dmService;
+
+    /**
+     * 수동결제 환불 — PortOne 결제 취소 + 지급된 젤리 회수
+     *
+     * 환불 조건:
+     * 1. 결제 완료(PAID) 상태일 것
+     * 2. 결제일로부터 7일 이내일 것
+     * 3. 결제 이후 젤리를 단 1개도 사용하지 않았을 것
+     *
+     * @param userId    환불 요청 유저 ID
+     * @param paymentId PortOne 결제 식별자 (PaymentOrder.paymentId)
+     */
+    @Transactional
+    public void refundPayment(Long userId, String paymentId) {
+        PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
+                .filter(o -> o.getUserId().equals(userId))
+                .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
+
+        // 이미 환불됐거나 미결제 상태는 거부
+        if (order.getStatus() == PaymentStatus.REFUNDED) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+        if (order.getStatus() != PaymentStatus.PAID) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_FOUND);
+        }
+
+        // 7일 이내 검증
+        if (order.getPaidAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
+            throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
+        }
+
+        // 결제 이후 젤리 사용 이력 검증 — 1개라도 사용했으면 환불 불가
+        if (jellyTransactionRepository.existsByUserIdAndTypeAndCreatedAtAfter(
+                userId, TransactionType.USE, order.getPaidAt())) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
+        }
+
+        // PortOne 결제 취소 요청
+        try {
+            portOneClient.cancelPayment(paymentId, "고객 환불 요청");
+        } catch (Exception e) {
+            log.error("PortOne 결제 취소 실패: paymentId={}, error={}", paymentId, e.getMessage());
+            throw new PaymentException(ErrorCode.REFUND_PROCESSING_ERROR);
+        }
+
+        // 지급된 젤리 회수 (현금이 카드로 환불되므로 젤리는 다시 차감)
+        jellyService.reclaimForCashRefund(
+                userId,
+                order.getJellyProduct().getJellyAmount(),
+                ReferenceType.PAYMENT,
+                order.getId()
+        );
+
+        order.refund();
+        log.info("수동결제 환불 완료: userId={}, paymentId={}", userId, paymentId);
+    }
+
+    /**
+     * 자동충전 환불 — PortOne 결제 취소 + 충전된 젤리 회수
+     *
+     * 환불 조건:
+     * 1. 성공한 충전 이력일 것
+     * 2. portOnePaymentId가 저장된 이력일 것 (이전 데이터는 환불 불가)
+     * 3. 충전일로부터 7일 이내일 것
+     * 4. 충전 이후 젤리를 단 1개도 사용하지 않았을 것
+     *
+     * @param userId    환불 요청 유저 ID
+     * @param historyId AutoChargeHistory ID
+     */
+    @Transactional
+    public void refundAutoCharge(Long userId, Long historyId) {
+        AutoChargeHistory history = autoChargeHistoryRepository.findByIdAndUserId(historyId, userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
+
+        // 실패한 충전 이력은 실제 결제가 없으므로 환불 대상 아님
+        if (!history.isSuccess()) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_FOUND);
+        }
+
+        // portOnePaymentId가 없는 이력(이 기능 도입 전 데이터)은 환불 불가
+        if (history.getPortOnePaymentId() == null) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
+        }
+
+        // 7일 이내 검증
+        if (history.getCreatedAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
+            throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
+        }
+
+        // 충전 이후 젤리 사용 이력 검증
+        if (jellyTransactionRepository.existsByUserIdAndTypeAndCreatedAtAfter(
+                userId, TransactionType.USE, history.getCreatedAt())) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
+        }
+
+        // PortOne 결제 취소
+        try {
+            portOneClient.cancelPayment(history.getPortOnePaymentId(), "고객 환불 요청");
+        } catch (Exception e) {
+            log.error("PortOne 자동충전 취소 실패: historyId={}, error={}", historyId, e.getMessage());
+            throw new PaymentException(ErrorCode.REFUND_PROCESSING_ERROR);
+        }
+
+        // 충전된 젤리 회수
+        jellyService.reclaimForCashRefund(
+                userId,
+                history.getJellyAmount(),
+                ReferenceType.AUTO_CHARGE,
+                historyId
+        );
+
+        log.info("자동충전 환불 완료: userId={}, historyId={}", userId, historyId);
+    }
+
+    /**
+     * DM 구독권 환불 — 차감됐던 젤리 반환 + 구독 CANCELLED 처리
+     *
+     * 환불 조건:
+     * 1. ACTIVE 상태(만료 전)인 구독일 것
+     * 2. 구독 시작일로부터 7일 이내일 것
+     * 3. 구독 이후 해당 아티스트에게 DM을 단 한 번도 보내지 않았을 것
+     *
+     * @param userId         환불 요청 유저 ID
+     * @param subscriptionId DmSubscription ID
+     */
+    @Transactional
+    public void refundDmSubscription(Long userId, Long subscriptionId) {
+        DmSubscription subscription = dmSubscriptionRepository.findByIdAndUserId(subscriptionId, userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
+
+        // 이미 취소됐거나 만료된 구독은 환불 불가
+        if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+        if (subscription.getStatus() != SubscriptionStatus.ACTIVE) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
+        }
+
+        // 7일 이내 검증
+        if (subscription.getStartedAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
+            throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
+        }
+
+        // DM 발송 이력 검증 — 구독 이후 메시지를 보냈으면 환불 불가
+        if (dmService.hasUserSentMessageAfter(userId, subscription.getArtistId(), subscription.getStartedAt())) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
+        }
+
+        // 구독 시 차감된 젤리 반환
+        jellyService.refund(
+                userId,
+                subscription.getJellyAmount(),
+                ReferenceType.DM_SUB,
+                subscriptionId
+        );
+
+        // 구독 취소 처리
+        subscription.cancel();
+        log.info("DM 구독권 환불 완료: userId={}, subscriptionId={}", userId, subscriptionId);
+    }
+
+    /**
+     * 팬 멤버십 환불 — 정책상 환불 불가
+     * 엔드포인트를 열어두어 클라이언트에 명확한 에러 메시지를 전달한다.
+     */
+    public void refundFanMembership() {
+        throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/payment/service/RefundService.java
+++ b/src/main/java/com/example/infinite/domain/payment/service/RefundService.java
@@ -27,7 +27,8 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class RefundService {
 
-    private static final int REFUND_PERIOD_DAYS = 7; // 환불 가능 기간
+    // 환불 가능 기간: 결제(구독) 시점으로부터 7일
+    private static final int REFUND_PERIOD_DAYS = 7;
 
     private final PaymentOrderRepository paymentOrderRepository;
     private final AutoChargeHistoryRepository autoChargeHistoryRepository;
@@ -37,51 +38,77 @@ public class RefundService {
     private final PortOneClient portOneClient;
     private final DmService dmService;
 
+    // ────────────────────────────────────────────────────────────
+    // ⚠️ 트랜잭션 & 외부 API 호출 경계에 대한 설계 주석
+    //
+    // 현재 구조: @Transactional 안에서 portOneClient.cancelPayment()를 호출한다.
+    // 이는 PortOne API가 지연될 경우 DB 커넥션을 점유한 채 대기하게 되어
+    // 커넥션 풀 고갈로 이어질 수 있다는 잠재적 위험이 있다.
+    //
+    // 이상적인 해결책: PortOne 취소를 트랜잭션 밖으로 분리하거나 이벤트 기반 비동기 처리.
+    // 현재는 프로젝트 규모와 일정을 고려해 동기 처리를 유지하되,
+    // PortOne 호출에 connectTimeout(3s)/readTimeout(10s)이 설정되어 있어
+    // 무한 대기는 방지되어 있다. (PortOneClient 생성자 참고)
+    // ────────────────────────────────────────────────────────────
+
     /**
      * 수동결제 환불 — PortOne 결제 취소 + 지급된 젤리 회수
      *
-     * 환불 조건:
+     * ─── 환불 조건 (모두 충족해야 함) ───
      * 1. 결제 완료(PAID) 상태일 것
-     * 2. 결제일로부터 7일 이내일 것
+     * 2. 결제일(paidAt)로부터 7일 이내일 것
      * 3. 결제 이후 젤리를 단 1개도 사용하지 않았을 것
+     *    → 젤리는 fungible(대체 가능)하여 특정 결제의 젤리를 추적할 수 없으므로,
+     *       결제 이후 USE 트랜잭션이 하나라도 있으면 보수적으로 환불 불가 처리
      *
-     * @param userId    환불 요청 유저 ID
+     * ─── 처리 순서 ───
+     * 1) 조건 검증 → 2) PortOne 취소 → 3) 젤리 회수 → 4) 주문 상태 REFUNDED
+     * PortOne 취소가 성공해야 젤리 회수를 진행한다.
+     * PortOne 취소 실패 시 트랜잭션 롤백으로 DB 상태는 원복된다.
+     *
+     * @param userId    환불 요청 유저 ID (JWT에서 추출된 인증된 사용자)
      * @param paymentId PortOne 결제 식별자 (PaymentOrder.paymentId)
      */
     @Transactional
     public void refundPayment(Long userId, String paymentId) {
+        // paymentId + userId 동시 검증으로 타인의 결제 환불 시도 차단
         PaymentOrder order = paymentOrderRepository.findByPaymentId(paymentId)
                 .filter(o -> o.getUserId().equals(userId))
                 .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
 
-        // 이미 환불됐거나 미결제 상태는 거부
+        // 이미 환불 완료된 주문은 중복 환불 방지
         if (order.getStatus() == PaymentStatus.REFUNDED) {
             throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
         }
+        // PENDING/FAILED 상태는 실제 결제가 완료되지 않은 건이므로 환불 대상 아님
         if (order.getStatus() != PaymentStatus.PAID) {
             throw new PaymentException(ErrorCode.REFUND_NOT_FOUND);
         }
 
-        // 7일 이내 검증
+        // 환불 가능 기간(7일) 검증
         if (order.getPaidAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
             throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
         }
 
-        // 결제 이후 젤리 사용 이력 검증 — 1개라도 사용했으면 환불 불가
+        // 결제 이후 젤리 사용 이력 검증
+        // 젤리는 대체 가능 자산이라 특정 충전분을 추적할 수 없으므로,
+        // 결제 이후 USE 트랜잭션이 하나라도 존재하면 보수적으로 환불 불가 처리
         if (jellyTransactionRepository.existsByUserIdAndTypeAndCreatedAtAfter(
                 userId, TransactionType.USE, order.getPaidAt())) {
             throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
         }
 
-        // PortOne 결제 취소 요청
+        // PortOne 결제 취소 — 외부 API 호출 (트랜잭션 내 존재, 위 설계 주석 참고)
         try {
             portOneClient.cancelPayment(paymentId, "고객 환불 요청");
         } catch (Exception e) {
-            log.error("PortOne 결제 취소 실패: paymentId={}, error={}", paymentId, e.getMessage());
+            // PortOne 취소 실패 시 젤리 회수 없이 예외를 던진다.
+            // 트랜잭션이 롤백되어 DB 상태는 변경되지 않는다.
+            log.error("PortOne 수동결제 취소 실패: paymentId={}, error={}", paymentId, e.getMessage());
             throw new PaymentException(ErrorCode.REFUND_PROCESSING_ERROR);
         }
 
-        // 지급된 젤리 회수 (현금이 카드로 환불되므로 젤리는 다시 차감)
+        // 지급됐던 젤리 회수 — PortOne이 현금을 환불하므로 젤리는 다시 차감
         jellyService.reclaimForCashRefund(
                 userId,
                 order.getJellyProduct().getJellyAmount(),
@@ -89,38 +116,49 @@ public class RefundService {
                 order.getId()
         );
 
+        // 주문 상태를 REFUNDED로 변경하여 이중 환불 방지
         order.refund();
-        log.info("수동결제 환불 완료: userId={}, paymentId={}", userId, paymentId);
+        log.info("수동결제 환불 완료: userId={}, paymentId={}, jellies={}",
+                userId, paymentId, order.getJellyProduct().getJellyAmount());
     }
 
     /**
      * 자동충전 환불 — PortOne 결제 취소 + 충전된 젤리 회수
      *
-     * 환불 조건:
-     * 1. 성공한 충전 이력일 것
-     * 2. portOnePaymentId가 저장된 이력일 것 (이전 데이터는 환불 불가)
-     * 3. 충전일로부터 7일 이내일 것
+     * ─── 환불 조건 (모두 충족해야 함) ───
+     * 1. 성공(success=true)한 충전 이력일 것 — 실패 이력은 실제 결제 없음
+     * 2. portOnePaymentId가 저장된 이력일 것 — 이 기능 도입 전 데이터는 취소 불가
+     * 3. 충전일(createdAt)로부터 7일 이내일 것
      * 4. 충전 이후 젤리를 단 1개도 사용하지 않았을 것
      *
-     * @param userId    환불 요청 유저 ID
+     * ─── 처리 순서 ───
+     * 1) 조건 검증 → 2) PortOne 취소 → 3) 젤리 회수 → 4) 이력 환불 완료 표시
+     *
+     * @param userId    환불 요청 유저 ID (JWT에서 추출된 인증된 사용자)
      * @param historyId AutoChargeHistory ID
      */
     @Transactional
     public void refundAutoCharge(Long userId, Long historyId) {
+        // id + userId 동시 검증으로 타인의 충전 이력 환불 시도 차단
         AutoChargeHistory history = autoChargeHistoryRepository.findByIdAndUserId(historyId, userId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
 
-        // 실패한 충전 이력은 실제 결제가 없으므로 환불 대상 아님
+        // 실패한 충전 이력은 PortOne에서 실제 결제가 이루어지지 않았으므로 환불 대상 아님
         if (!history.isSuccess()) {
             throw new PaymentException(ErrorCode.REFUND_NOT_FOUND);
         }
 
-        // portOnePaymentId가 없는 이력(이 기능 도입 전 데이터)은 환불 불가
+        // portOnePaymentId 없는 이력 = 이 기능 도입 전 데이터 → PortOne 취소 불가
         if (history.getPortOnePaymentId() == null) {
             throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
         }
 
-        // 7일 이내 검증
+        // 이미 환불된 이력의 중복 환불 방지
+        if (history.isRefunded()) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+
+        // 환불 가능 기간(7일) 검증 — createdAt은 BaseEntity의 자동 설정 값
         if (history.getCreatedAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
             throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
         }
@@ -131,7 +169,7 @@ public class RefundService {
             throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
         }
 
-        // PortOne 결제 취소
+        // PortOne 결제 취소 — 외부 API 호출 (트랜잭션 내 존재, 위 설계 주석 참고)
         try {
             portOneClient.cancelPayment(history.getPortOnePaymentId(), "고객 환불 요청");
         } catch (Exception e) {
@@ -139,7 +177,7 @@ public class RefundService {
             throw new PaymentException(ErrorCode.REFUND_PROCESSING_ERROR);
         }
 
-        // 충전된 젤리 회수
+        // 충전됐던 젤리 회수 — PortOne이 현금을 환불하므로 젤리는 다시 차감
         jellyService.reclaimForCashRefund(
                 userId,
                 history.getJellyAmount(),
@@ -147,44 +185,55 @@ public class RefundService {
                 historyId
         );
 
-        log.info("자동충전 환불 완료: userId={}, historyId={}", userId, historyId);
+        // 이력에 환불 완료 표시 — 운영 추적 및 이중 환불 방지
+        history.markRefunded();
+        log.info("자동충전 환불 완료: userId={}, historyId={}, jellies={}",
+                userId, historyId, history.getJellyAmount());
     }
 
     /**
      * DM 구독권 환불 — 차감됐던 젤리 반환 + 구독 CANCELLED 처리
      *
-     * 환불 조건:
+     * ─── 환불 조건 (모두 충족해야 함) ───
      * 1. ACTIVE 상태(만료 전)인 구독일 것
-     * 2. 구독 시작일로부터 7일 이내일 것
+     * 2. 구독 시작일(startedAt)로부터 7일 이내일 것
      * 3. 구독 이후 해당 아티스트에게 DM을 단 한 번도 보내지 않았을 것
+     *    → DmService.hasUserSentMessageAfter() 를 통해 DM 도메인에 위임 (결합도 최소화)
      *
-     * @param userId         환불 요청 유저 ID
+     * ─── 처리 순서 ───
+     * 1) 조건 검증 → 2) 젤리 반환 → 3) 구독 CANCELLED
+     * DM 구독은 젤리로 결제했으므로 PortOne 취소 없이 젤리만 반환한다.
+     *
+     * @param userId         환불 요청 유저 ID (JWT에서 추출된 인증된 사용자)
      * @param subscriptionId DmSubscription ID
      */
     @Transactional
     public void refundDmSubscription(Long userId, Long subscriptionId) {
+        // id + userId 동시 검증으로 타인의 구독 환불 시도 차단
         DmSubscription subscription = dmSubscriptionRepository.findByIdAndUserId(subscriptionId, userId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.REFUND_NOT_FOUND));
 
-        // 이미 취소됐거나 만료된 구독은 환불 불가
+        // 이미 취소(환불)된 구독의 중복 환불 방지
         if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
             throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
         }
+        // 만료(EXPIRED) 상태는 이미 서비스를 사용한 것으로 간주 → 환불 불가
         if (subscription.getStatus() != SubscriptionStatus.ACTIVE) {
             throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
         }
 
-        // 7일 이내 검증
+        // 환불 가능 기간(7일) 검증
         if (subscription.getStartedAt().plusDays(REFUND_PERIOD_DAYS).isBefore(LocalDateTime.now())) {
             throw new PaymentException(ErrorCode.REFUND_PERIOD_EXPIRED);
         }
 
-        // DM 발송 이력 검증 — 구독 이후 메시지를 보냈으면 환불 불가
+        // DM 발송 이력 검증 — DM 도메인에 위임하여 도메인 간 결합도 최소화
+        // 구독 이후 단 한 번이라도 DM을 보냈다면 서비스를 사용한 것으로 간주 → 환불 불가
         if (dmService.hasUserSentMessageAfter(userId, subscription.getArtistId(), subscription.getStartedAt())) {
             throw new PaymentException(ErrorCode.REFUND_ALREADY_USED);
         }
 
-        // 구독 시 차감된 젤리 반환
+        // 구독 시 차감됐던 젤리 반환 (DM 구독은 젤리로 결제했으므로 PortOne 취소 불필요)
         jellyService.refund(
                 userId,
                 subscription.getJellyAmount(),
@@ -192,16 +241,9 @@ public class RefundService {
                 subscriptionId
         );
 
-        // 구독 취소 처리
+        // 구독 상태를 CANCELLED로 변경하여 서비스 이용 불가 + 이중 환불 방지
         subscription.cancel();
-        log.info("DM 구독권 환불 완료: userId={}, subscriptionId={}", userId, subscriptionId);
-    }
-
-    /**
-     * 팬 멤버십 환불 — 정책상 환불 불가
-     * 엔드포인트를 열어두어 클라이언트에 명확한 에러 메시지를 전달한다.
-     */
-    public void refundFanMembership() {
-        throw new PaymentException(ErrorCode.REFUND_NOT_ELIGIBLE);
+        log.info("DM 구독권 환불 완료: userId={}, subscriptionId={}, jellies={}",
+                userId, subscriptionId, subscription.getJellyAmount());
     }
 }

--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/DmSubscriptionRepository.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/repository/DmSubscriptionRepository.java
@@ -21,4 +21,7 @@ public interface DmSubscriptionRepository extends JpaRepository<DmSubscription, 
 
     // 특정 아티스트에 대해 여러 유저의 DM 구독 상태를 한 번에 조회 (뱃지 배치 조회용, N+1 방지)
     List<DmSubscription> findByArtistIdAndUserIdInAndStatus(Long artistId, Collection<Long> userIds, SubscriptionStatus status);
+
+    // 환불 요청 시 본인 소유 구독인지 검증하며 단건 조회
+    Optional<DmSubscription> findByIdAndUserId(Long id, Long userId);
 }


### PR DESCRIPTION
  ## 💡 기능 상세 내용                                                                                                                                           
  수동결제·자동충전·DM 구독권 환불 기능 구현 (팬 멤버십은 환불 불가 정책)

  - [x] `PortOneClient.cancelPayment()` 추가 — PortOne 결제 취소 API 연동
  - [x] `PortOneClient.charge()` paymentId 반환 + `AutoChargeHistory.portOnePaymentId` 저장 (환불 추적용)
  - [x] `AutoChargeService` 저장 로직 수정 — 반환된 portOnePaymentId 저장
  - [x] `PaymentStatus.REFUNDED` 추가 + `PaymentOrder.refund()` 메서드 추가
  - [x] `JellyTransactionRepository` 젤리 사용 이력 조회 메서드 추가
  - [x] `AutoChargeHistoryRepository` · `DmSubscriptionRepository` id+userId 단건 조회 추가
  - [x] `JellyService.reclaimForCashRefund()` 추가 — 현금 환불 시 젤리 회수 (자동충전 트리거 없음)
  - [x] `RefundService` 구현
    - 수동결제 환불: 젤리 미사용 + 7일 이내 → PortOne 취소 + 젤리 회수
    - 자동충전 환불: 젤리 미사용 + 7일 이내 → PortOne 취소 + 젤리 회수
    - DM 구독권 환불: DM 미발송 + 7일 이내 → 젤리 반환 + 구독 CANCELLED
    - 팬 멤버십: 즉시 환불 불가 예외
  - [x] `RefundController` 구현

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] 수동결제·자동충전 환불 시 PortOne 결제 취소 + 젤리 차감 정상 처리
  - [x] DM 구독권 환불 시 젤리 반환 + 구독 CANCELLED 처리
  - [x] 팬 멤버십 환불 요청 시 즉시 거부
  - [x] 7일 초과 / 젤리 사용 / DM 발송 시 각각 적절한 에러 반환

  ## 🔗 기타 참고 사항
  - 수동결제/자동충전 환불 기준: 결제 이후 젤리 USE 트랜잭션 없을 것 + 7일 이내
  - DM 구독권 환불 기준: 구독 이후 USER 발송 메시지 없을 것 + 7일 이내 (`DmService.hasUserSentMessageAfter()` 사용)
  - portOnePaymentId가 null인 기존 자동충전 이력은 환불 불가 (이 기능 도입 전 데이터)
  - 부분 환불 불가 정책
  - Close #83