### PR TITLE
feat/팬레터 CRUD

### DIFF
--- a/FRONTEND_TEAM_VIBE_HANDOFF.md
+++ b/FRONTEND_TEAM_VIBE_HANDOFF.md
@@ -30,7 +30,7 @@
 지금 기준으로 상태를 한 줄로 요약하면 아래다.
 
 - 실구현 완료: 아티스트 검색, 인기 검색어, 아티스트 상세, ArtistMember 관리, FanPost CRUD, FanPost 좋아요, FanPost 댓글/대댓글 조회, Hashtag 추천, FanPost 미디어 업로드 구조
-- 부분 구현: ArtistPost 엔티티/리더/미디어 훅/댓글 경로 준비, FanLetter 엔티티, Follow 엔티티, 구독 배지 응답 필드 자리
+- 부분 구현: ArtistPost 엔티티/리더/미디어 훅/댓글 경로 준비, FanLetter 엔티티, Follow 엔티티
 - 미구현: ArtistPost 실API, ArtistPost 좋아요, FanLetter 실API, HOT 피드, Follow API, 메인 홈 대시보드 2종, 동시성 보강 및 검증 테스트
 
 ## 2. 가장 중요한 고정 정책
@@ -271,6 +271,7 @@ FanPost 댓글 현재 정책:
 - 삭제된 원댓글에 자식이 남아 있으면 `"삭제된 댓글입니다."` placeholder 유지
 - 자식 없는 원댓글은 soft delete 후 숨김
 - placeholder 부모의 마지막 대댓글도 사라지면 부모도 최종 삭제
+- 작성자 옆 구독 배지 boolean은 현재 실제 subscription 조회 결과가 내려온다
 
 프론트가 지금 바로 실연동 가능한 화면:
 
@@ -293,6 +294,8 @@ FanPost 댓글 현재 정책:
 - `writerId`
 - `writerNickname`
 - `writerProfileImageUrl`
+- `fanMembershipSubscribed`
+- `dmSubscribed`
 - `content`
 - `mentionedMember`
 - `replyCount`
@@ -428,15 +431,14 @@ FanPost 댓글 현재 정책:
 현재 실제 코드 상태:
 
 - FanPost 응답에 `fanMembershipSubscribed`, `dmSubscribed` 필드가 이미 있다
-- 하지만 현재 QueryDSL projection에서 둘 다 `false` 상수로 내려간다
-- 댓글 응답에는 아직 배지 필드가 아예 없다
-- 서비스 내부 TODO로 subscription 담당자 쿼리 연동 포인트가 명시돼 있다
+- 댓글 응답에도 `fanMembershipSubscribed`, `dmSubscribed` 필드가 추가되었다
+- 실제 값은 subscription 도메인 batch 조회 결과를 서비스에서 조립해 내려준다
 
 프론트 해석:
 
 - 배지 UI는 먼저 만들어도 된다
-- 실제 값은 아직 믿으면 안 된다
-- fallback 상태로 처리해야 한다
+- FanPost / 댓글 영역은 실제 값 기준으로 처리해도 된다
+- FanLetter 쪽은 별도 구현 시점에 다시 확인하면 된다
 
 ## 4-5. 메인 홈 대시보드 2종
 
@@ -460,33 +462,7 @@ Dashboard B:
 
 아래는 내가 다음으로 진행할 예정인 일이고, 프론트가 무엇을 준비해야 하는지도 같이 적는다.
 
-## 5-1. 미디어 검토
-
-백엔드 예정 작업:
-
-- 지금 추가된 미디어 구조를 다시 검토
-- S3/object storage 설정 전제 점검
-- FanPost 업로드/수정/교체/삭제 흐름 이상 여부 체크
-
-프론트 준비 포인트:
-
-- 업로드 UI는 FanPost 기준으로 먼저 사용
-- 실패 케이스를 분리해두는 것이 좋다
-- 형식 오류
-- 크기 초과
-- 혼합 업로드 금지
-- 저장소 미설정
-
-현재 바로 참고할 주요 에러 코드:
-
-- `M002` 지원하지 않는 파일 형식
-- `M003` 최대 용량 초과
-- `M006` 이미지 최대 10장 초과
-- `M007` 동영상 1개 초과
-- `M008` 이미지+동영상 혼합 금지
-- `M009` 미디어 저장소 설정 미준비
-
-## 5-2. ArtistPost
+## 5-1. ArtistPost
 
 백엔드 예정 작업:
 
@@ -524,7 +500,7 @@ Dashboard B:
 - `hashtags[]`
 - `createdAt`
 
-## 5-3. ArtistPost 좋아요
+## 5-2. ArtistPost 좋아요
 
 백엔드 예정 작업:
 
@@ -538,7 +514,7 @@ Dashboard B:
 - optimistic update를 너무 강하게 고정하지 말고 서버 count 재동기화가 가능한 구조가 좋다
 - 좋아요 애니메이션은 가능하지만 count는 최종적으로 서버 응답 기준으로 덮어쓰는 편이 안전하다
 
-## 5-4. FanLetter
+## 5-3. FanLetter
 
 백엔드 예정 작업:
 
@@ -569,7 +545,7 @@ Dashboard B:
 - `artistProfileImageUrl`
 - `createdAt`
 
-## 5-5. HOT 게시글 필터
+## 5-4. HOT 게시글 필터
 
 백엔드 예정 작업:
 
@@ -589,7 +565,7 @@ Dashboard B:
 - `최신` / `HOT 24h` 분리
 - FanPost 카드와 FanLetter 카드를 같은 피드에 섞을 수 있게 컴포넌트 분기
 
-## 5-6. 댓글/좋아요 카운터 동시성
+## 5-5. 댓글/좋아요 카운터 동시성
 
 백엔드 예정 작업:
 
@@ -776,7 +752,6 @@ mock 우선:
 
 앞으로 내가 구현할 핵심은 아래다.
 
-- 미디어 구조 재검토
 - ArtistPost
 - ArtistPost 좋아요 대용량 트래픽 대응
 - FanLetter

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
@@ -12,4 +12,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
     Optional<Comment> findByIdAndTargetTypeAndTargetId(Long commentId, PostType targetType, Long targetId);
 
     List<Comment> findByParentIdOrderByIdAsc(Long parentId);
+
+    boolean existsByParentId(Long parentId);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryImpl.java
@@ -11,8 +11,7 @@ import lombok.RequiredArgsConstructor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import static com.querydsl.core.group.GroupBy.groupBy;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class CommentRepositoryImpl implements CommentRepositoryCustom {
@@ -69,12 +68,20 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
         QComment comment = QComment.comment;
         QComment parent = new QComment("parent");
 
-        // 부모 댓글 여러 개의 대댓글 개수를 한 번에 계산해 목록 응답의 replyCount 조립에 재사용한다.
+        // Hibernate 7 환경에서는 QueryDSL groupBy(transform)가 내부 ScrollableResults 구현과 충돌할 수 있다.
+        // 여기서는 (parentId, count) 튜플만 조회한 뒤 Map으로 조립해 같은 배치 집계를 안정적으로 유지한다.
         return queryFactory
+                .select(parent.id, comment.id.count())
                 .from(comment)
                 .join(comment.parent, parent)
                 .where(parent.id.in(parentIds))
-                .transform(groupBy(parent.id).as(comment.id.count().intValue()));
+                .groupBy(parent.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(parent.id),
+                        tuple -> tuple.get(comment.id.count()).intValue()
+                ));
     }
 
     @Override

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
@@ -241,8 +241,7 @@ public class CommentService {
         commentMentionService.deleteMention(comment.getId());
 
         if (comment.isRootComment()) {
-            List<Comment> replies = commentRepository.findByParentIdOrderByIdAsc(comment.getId());
-            if (replies.isEmpty()) {
+            if (!commentRepository.existsByParentId(comment.getId())) {
                 // 자식이 없는 부모 댓글은 그대로 soft delete 해 목록에서 숨긴다.
                 comment.delete();
             } else {
@@ -258,8 +257,7 @@ public class CommentService {
 
         Comment parentComment = comment.getParent();
         if (parentComment != null && parentComment.isDeletedPlaceholder()) {
-            List<Comment> remainingReplies = commentRepository.findByParentIdOrderByIdAsc(parentComment.getId());
-            if (remainingReplies.isEmpty()) {
+            if (!commentRepository.existsByParentId(parentComment.getId())) {
                 // placeholder 부모에 달린 마지막 자식도 사라지면 부모를 실제 soft delete 로 마무리한다.
                 parentComment.delete();
             }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepository.java
@@ -5,6 +5,8 @@ import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface InteractionRepository extends JpaRepository<Reaction, Long>, InteractionRepositoryCustom {
@@ -28,6 +30,13 @@ public interface InteractionRepository extends JpaRepository<Reaction, Long>, In
     long countByTargetTypeAndTargetIdAndReactionType(
             PostType targetType,
             Long targetId,
+            ReactionType reactionType
+    );
+
+    // 팬레터 special-like 계산처럼 "여러 대상의 좋아요를 한 번에 읽어야 하는" 배치 조회에 사용한다.
+    List<Reaction> findByTargetTypeAndTargetIdInAndReactionType(
+            PostType targetType,
+            Collection<Long> targetIds,
             ReactionType reactionType
     );
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryCustom.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryCustom.java
@@ -1,4 +1,19 @@
 package com.example.infinite.domain.artistcontent.interaction.repository;
 
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+
+import java.util.Collection;
+import java.util.Set;
+
 public interface InteractionRepositoryCustom {
+
+    // 아티스트 소속 멤버가 반응한 targetId 집합만 바로 뽑아
+    // 서비스에서 전체 reaction row를 다시 필터링하지 않게 한다.
+    Set<Long> findTargetIdsReactedByArtistMembers(
+            Long artistId,
+            PostType targetType,
+            Collection<Long> targetIds,
+            ReactionType reactionType
+    );
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryImpl.java
@@ -1,10 +1,48 @@
 package com.example.infinite.domain.artistcontent.interaction.repository;
 
+import com.example.infinite.domain.artistcontent.interaction.entity.QReaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.member.artist.entity.QArtistMember;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class InteractionRepositoryImpl implements InteractionRepositoryCustom {
 
     protected final JPAQueryFactory queryFactory;
+
+    @Override
+    public Set<Long> findTargetIdsReactedByArtistMembers(
+            Long artistId,
+            PostType targetType,
+            Collection<Long> targetIds,
+            ReactionType reactionType
+    ) {
+        if (targetIds == null || targetIds.isEmpty()) {
+            return Set.of();
+        }
+
+        QReaction reaction = QReaction.reaction;
+        QArtistMember artistMember = QArtistMember.artistMember;
+
+        // fan-letter special-like 처럼 "아티스트 멤버가 반응한 target이 있는가"만 필요할 때
+        // reaction 전체를 가져오지 않고 targetId 집합만 바로 조회한다.
+        return new LinkedHashSet<>(queryFactory
+                .select(reaction.targetId)
+                .distinct()
+                .from(reaction)
+                .join(artistMember).on(artistMember.member.id.eq(reaction.memberId))
+                .where(
+                        artistMember.artist.id.eq(artistId),
+                        reaction.targetType.eq(targetType),
+                        reaction.reactionType.eq(reactionType),
+                        reaction.targetId.in(targetIds)
+                )
+                .fetch());
+    }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
@@ -6,6 +6,8 @@ import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
+import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
 import com.example.infinite.domain.member.member.entity.Member;
@@ -23,6 +25,7 @@ public class InteractionService {
 
     private final InteractionRepository interactionRepository;
     private final FanPostReader fanPostReader;
+    private final FanLetterReader fanLetterReader;
     private final MemberReader memberReader;
 
     @Transactional
@@ -39,6 +42,23 @@ public class InteractionService {
                 )
                 .map(existingReaction -> cancelLike(existingReaction, fanPost))
                 .orElseGet(() -> addLike(member.getId(), fanPost));
+    }
+
+    @Transactional
+    public InteractionResponse toggleFanLetterLike(MemberDetailsImpl memberDetails, Long artistId, Long fanLetterId) {
+        // 팬레터도 fan post 와 같은 reaction 테이블을 재사용한다.
+        // 차이는 targetType=FAN_LETTER 로 저장하고, likeCount 반영 대상이 FanLetter 라는 점뿐이다.
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        FanLetter fanLetter = fanLetterReader.findByIdAndArtistIdOrThrow(fanLetterId, artistId);
+
+        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.FAN_LETTER,
+                        fanLetterId,
+                        member.getId(),
+                        ReactionType.LIKE
+                )
+                .map(existingReaction -> cancelLike(existingReaction, fanLetter))
+                .orElseGet(() -> addLike(member.getId(), fanLetter));
     }
 
     private InteractionResponse addLike(Long memberId, FanPost fanPost) {
@@ -58,5 +78,24 @@ public class InteractionService {
         interactionRepository.delete(existingReaction);
         fanPost.changeLikeCountBy(-1);
         return InteractionResponse.of(fanPost.getId(), false, fanPost.getLikeCount());
+    }
+
+    private InteractionResponse addLike(Long memberId, FanLetter fanLetter) {
+        // special-like 표시는 별도 플래그를 저장하지 않고,
+        // 나중에 "좋아요를 누른 사람이 아티스트 소속 멤버인가"를 조회 단계에서 해석한다.
+        interactionRepository.save(Reaction.create(
+                PostType.FAN_LETTER,
+                fanLetter.getId(),
+                memberId,
+                ReactionType.LIKE
+        ));
+        fanLetter.changeLikeCountBy(1);
+        return InteractionResponse.of(fanLetter.getId(), true, fanLetter.getLikeCount());
+    }
+
+    private InteractionResponse cancelLike(Reaction existingReaction, FanLetter fanLetter) {
+        interactionRepository.delete(existingReaction);
+        fanLetter.changeLikeCountBy(-1);
+        return InteractionResponse.of(fanLetter.getId(), false, fanLetter.getLikeCount());
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/service/MediaService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/service/MediaService.java
@@ -10,6 +10,7 @@ import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPo
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,10 +65,9 @@ public class MediaService {
 
     @Transactional
     public void replaceFanPostMedia(Long artistId, FanPost fanPost, List<MultipartFile> files) {
-        // 현재 수정 정책은 append/부분교체가 아니라 "전체 교체"다.
-        // 그래서 기존 첨부를 모두 지우고 새 파일 집합을 다시 업로드한다.
-        deletePostMedia(PostType.FAN_POST, fanPost.getId(), fanPost::changeMediaCountBy);
-        attachFanPostMedia(artistId, fanPost, files);
+        // 전체 교체 정책은 유지하되,
+        // 새 첨부 저장 성공 전에는 기존 DB 참조를 지우지 않아야 업로드 실패 시 깨지지 않는다.
+        replacePostMedia(artistId, PostType.FAN_POST, fanPost.getId(), files, fanPost::changeMediaCountBy);
     }
 
     @Transactional
@@ -88,15 +88,36 @@ public class MediaService {
 
     @Transactional
     public void replaceArtistPostMedia(Long artistId, ArtistPost artistPost, List<MultipartFile> files) {
-        // ArtistPost 도 FanPost 와 같은 교체 정책을 유지하면
-        // 읽기 모델과 프론트 조립 규칙이 단순해진다.
-        deletePostMedia(PostType.ARTIST_POST, artistPost.getId(), artistPost::changeMediaCountBy);
-        attachArtistPostMedia(artistId, artistPost, files);
+        // ArtistPost 도 같은 전체 교체 정책을 따르되,
+        // 교체 실패 시 기존 첨부 참조가 살아 있도록 새 첨부를 먼저 확보한다.
+        replacePostMedia(artistId, PostType.ARTIST_POST, artistPost.getId(), files, artistPost::changeMediaCountBy);
     }
 
     @Transactional
     public void deleteArtistPostMedia(ArtistPost artistPost) {
         deletePostMedia(PostType.ARTIST_POST, artistPost.getId(), artistPost::changeMediaCountBy);
+    }
+
+    @Transactional
+    public void attachFanLetterMedia(Long artistId, FanLetter fanLetter, MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ArtistContentException(ArtistContentErrorCode.MEDIA_FAN_LETTER_IMAGE_ONLY);
+        }
+        // 팬레터는 사진 카드 1장을 본문처럼 쓰는 모델이라
+        // fan post 처럼 List<MultipartFile> 을 받지 않고 단일 파일만 받는다.
+        uploadFanLetterMedia(artistId, fanLetter.getId(), file);
+    }
+
+    @Transactional
+    public void replaceFanLetterMedia(Long artistId, FanLetter fanLetter, MultipartFile file) {
+        // 팬레터도 전체 교체지만, 새 이미지 확보 전에 기존 media row 를 지우면 실패 시 참조가 깨진다.
+        replaceFanLetterImage(artistId, fanLetter, file);
+    }
+
+    @Transactional
+    public void deleteFanLetterMedia(FanLetter fanLetter) {
+        deletePostMedia(PostType.FAN_LETTER, fanLetter.getId(), ignored -> {
+        });
     }
 
     private void uploadPostMedia(
@@ -163,6 +184,134 @@ public class MediaService {
         mediaRepository.deleteAllInBatch(existingMedia);
         mediaCountChanger.accept(-existingMedia.size());
         deleteObjectsQuietly(existingMedia);
+    }
+
+    private void replacePostMedia(
+            Long artistId,
+            PostType targetType,
+            Long targetId,
+            List<MultipartFile> files,
+            IntConsumer mediaCountChanger
+    ) {
+        List<Media> existingMedia = mediaRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(targetType, targetId);
+        if (files == null || files.isEmpty()) {
+            deletePostMedia(targetType, targetId, mediaCountChanger);
+            return;
+        }
+
+        // 전체 교체에서는 기존 첨부를 모두 버리고 새 집합으로 다시 만들기 때문에
+        // 정책 검증도 "새 파일 집합만 놓고 최종 상태가 유효한가"를 본다.
+        List<PreparedUploadFile> preparedFiles = prepareUploadFiles(List.of(), files);
+        List<UploadedObject> uploadedObjects = new ArrayList<>();
+
+        try {
+            List<Media> newMedia = new ArrayList<>();
+            for (int index = 0; index < preparedFiles.size(); index++) {
+                PreparedUploadFile preparedFile = preparedFiles.get(index);
+                String storageKey = buildStorageKey(artistId, targetType, targetId, preparedFile.extension());
+                UploadedObject uploadedObject = objectStorageClient.upload(preparedFile.file(), storageKey);
+                uploadedObjects.add(uploadedObject);
+
+                newMedia.add(Media.create(
+                        targetType,
+                        targetId,
+                        preparedFile.mediaType(),
+                        uploadedObject.key(),
+                        uploadedObject.url(),
+                        null,
+                        resolveOriginalFileName(preparedFile.file()),
+                        uploadedObject.contentType(),
+                        uploadedObject.size(),
+                        index
+                ));
+            }
+
+            mediaRepository.saveAll(newMedia);
+            mediaRepository.deleteAllInBatch(existingMedia);
+            mediaCountChanger.accept(newMedia.size() - existingMedia.size());
+            deleteObjectsQuietly(existingMedia);
+        } catch (RuntimeException e) {
+            cleanupUploadedObjects(uploadedObjects);
+            throw e;
+        }
+    }
+
+    private void uploadFanLetterMedia(Long artistId, Long fanLetterId, MultipartFile file) {
+        List<Media> existingMedia = mediaRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(PostType.FAN_LETTER, fanLetterId);
+        if (!existingMedia.isEmpty()) {
+            throw new ArtistContentException(ArtistContentErrorCode.MEDIA_FAN_LETTER_IMAGE_ONLY);
+        }
+
+        // 정책상 팬레터는 비디오를 허용하지 않는다.
+        // prepareUploadFile 로 기본 검증을 통과한 뒤에도 IMAGE 타입인지 한 번 더 좁혀서 확인한다.
+        PreparedUploadFile preparedFile = prepareUploadFile(file);
+        if (preparedFile.mediaType() != MediaType.IMAGE) {
+            throw new ArtistContentException(ArtistContentErrorCode.MEDIA_FAN_LETTER_IMAGE_ONLY);
+        }
+
+        UploadedObject uploadedObject = objectStorageClient.upload(
+                preparedFile.file(),
+                buildStorageKey(artistId, PostType.FAN_LETTER, fanLetterId, preparedFile.extension())
+        );
+
+        try {
+            mediaRepository.save(Media.create(
+                    PostType.FAN_LETTER,
+                    fanLetterId,
+                    MediaType.IMAGE,
+                    uploadedObject.key(),
+                    uploadedObject.url(),
+                    null,
+                    resolveOriginalFileName(preparedFile.file()),
+                    uploadedObject.contentType(),
+                    uploadedObject.size(),
+                    0
+            ));
+        } catch (RuntimeException e) {
+            cleanupUploadedObjects(List.of(uploadedObject));
+            throw e;
+        }
+    }
+
+    private void replaceFanLetterImage(Long artistId, FanLetter fanLetter, MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ArtistContentException(ArtistContentErrorCode.MEDIA_FAN_LETTER_IMAGE_ONLY);
+        }
+
+        List<Media> existingMedia = mediaRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(
+                PostType.FAN_LETTER,
+                fanLetter.getId()
+        );
+
+        PreparedUploadFile preparedFile = prepareUploadFile(file);
+        if (preparedFile.mediaType() != MediaType.IMAGE) {
+            throw new ArtistContentException(ArtistContentErrorCode.MEDIA_FAN_LETTER_IMAGE_ONLY);
+        }
+
+        UploadedObject uploadedObject = objectStorageClient.upload(
+                preparedFile.file(),
+                buildStorageKey(artistId, PostType.FAN_LETTER, fanLetter.getId(), preparedFile.extension())
+        );
+
+        try {
+            mediaRepository.save(Media.create(
+                    PostType.FAN_LETTER,
+                    fanLetter.getId(),
+                    MediaType.IMAGE,
+                    uploadedObject.key(),
+                    uploadedObject.url(),
+                    null,
+                    resolveOriginalFileName(preparedFile.file()),
+                    uploadedObject.contentType(),
+                    uploadedObject.size(),
+                    0
+            ));
+            mediaRepository.deleteAllInBatch(existingMedia);
+            deleteObjectsQuietly(existingMedia);
+        } catch (RuntimeException e) {
+            cleanupUploadedObjects(List.of(uploadedObject));
+            throw e;
+        }
     }
 
     private List<PreparedUploadFile> prepareUploadFiles(List<Media> existingMedia, List<MultipartFile> files) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/error/ArtistContentErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/error/ArtistContentErrorCode.java
@@ -20,7 +20,8 @@ public enum ArtistContentErrorCode implements ErrorCodeType {
     MEDIA_MAX_IMAGE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "M006", "이미지는 최대 10장까지 업로드할 수 있습니다."),
     MEDIA_MAX_VIDEO_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "M007", "동영상은 한 개만 업로드할 수 있습니다."),
     MEDIA_MIXED_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "M008", "이미지와 동영상을 함께 업로드할 수 없습니다."),
-    MEDIA_STORAGE_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "M009", "미디어 저장소 설정이 준비되지 않았습니다.");
+    MEDIA_STORAGE_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "M009", "미디어 저장소 설정이 준비되지 않았습니다."),
+    MEDIA_FAN_LETTER_IMAGE_ONLY(HttpStatus.BAD_REQUEST, "M010", "팬레터는 이미지 한 장만 업로드할 수 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/controller/FanLetterController.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/controller/FanLetterController.java
@@ -1,4 +1,111 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.controller;
 
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.service.InteractionService;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterCreateRequest;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterUpdateRequest;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterCreateResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.service.FanLetterService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.dto.ApiResponse;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+// 팬레터는 multipart 기반이라 @RequestBody 대신 @ModelAttribute 로 받는다.
 public class FanLetterController {
+
+    private final FanLetterService fanLetterService;
+    private final InteractionService interactionService;
+
+    @PostMapping(
+            value = "/v1/artists/{artistId}/fan-letters",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ApiResponse<FanLetterCreateResponse>> createFanLetter(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @Valid @ModelAttribute FanLetterCreateRequest request
+    ) {
+        // 생성 응답은 식별자만 반환하고, 목록/상세 API가 카드 렌더링 정보를 책임진다.
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(fanLetterService.create(memberDetails, artistId, request)));
+    }
+
+    @GetMapping("/v1/artists/{artistId}/fan-letters")
+    public ResponseEntity<ApiResponse<CursorSliceResponse<FanLetterListResponse>>> getFanLetters(
+            @PathVariable Long artistId,
+            @RequestParam(required = false) Long cursor
+    ) {
+        // 목록은 카드 렌더링에 필요한 최소 정보만 내려준다.
+        return ResponseEntity.ok(ApiResponse.success(fanLetterService.getFanLetters(artistId, cursor)));
+    }
+
+    @GetMapping("/v1/artists/{artistId}/fan-letters/{fanLetterId}")
+    public ResponseEntity<ApiResponse<FanLetterResponse>> getFanLetter(
+            @PathVariable Long artistId,
+            @PathVariable Long fanLetterId
+    ) {
+        // 상세는 목록 카드 정보에 더해 작성자 프로필/배지까지 포함해 내려준다.
+        return ResponseEntity.ok(ApiResponse.success(fanLetterService.getFanLetter(artistId, fanLetterId)));
+    }
+
+    @PatchMapping(
+            value = "/v1/artists/{artistId}/fan-letters/{fanLetterId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ApiResponse<FanLetterResponse>> updateFanLetter(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long fanLetterId,
+            @Valid @ModelAttribute FanLetterUpdateRequest request
+    ) {
+        // 수정도 생성과 같은 multipart 계약을 유지해 프론트가 같은 form-data 흐름을 재사용할 수 있게 한다.
+        return ResponseEntity.ok(ApiResponse.success(
+                fanLetterService.update(memberDetails, artistId, fanLetterId, request)
+        ));
+    }
+
+    @DeleteMapping("/v1/artists/{artistId}/fan-letters/{fanLetterId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFanLetter(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long fanLetterId
+    ) {
+        // soft delete 와 media 정리는 service 에 위임하고, 컨트롤러는 HTTP 계약만 유지한다.
+        fanLetterService.delete(memberDetails, artistId, fanLetterId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/v1/artists/{artistId}/fan-letters/{fanLetterId}/likes/toggle")
+    public ResponseEntity<ApiResponse<InteractionResponse>> toggleFanLetterLike(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long fanLetterId
+    ) {
+        // 일반 좋아요 토글은 공통 interaction service를 재사용하되,
+        // fan letter 전용 target type 검증은 service 쪽에서 수행한다.
+        return ResponseEntity.ok(ApiResponse.success(
+                interactionService.toggleFanLetterLike(memberDetails, artistId, fanLetterId)
+        ));
+    }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterCreateRequest.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterCreateRequest.java
@@ -1,0 +1,26 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.request;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+// multipart/form-data 로 받는 팬레터 생성 요청이다.
+// 텍스트 본문 대신 "수신 대상 + 이미지 한 장"만 받는다.
+public class FanLetterCreateRequest {
+
+    // 그룹 전체에게 보낼지, 특정 artist-member 에게 보낼지 선택한다.
+    @NotNull
+    private FanLetterRecipientType recipientType;
+
+    // recipientType=ARTIST_MEMBER 일 때만 필요하다.
+    private Long recipientArtistMemberId;
+
+    // 팬레터는 반드시 이미지 한 장만 업로드한다.
+    private MultipartFile image;
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterRequest.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterRequest.java
@@ -1,4 +1,0 @@
-package com.example.infinite.domain.artistcontent.post.fanletter.dto.request;
-
-public class FanLetterRequest {
-}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterUpdateRequest.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/request/FanLetterUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.request;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+// 팬레터 수정은 부분 변경 방식이다.
+// null 로 들어온 값은 기존 상태를 유지하고, image 가 오면 기존 이미지를 통째로 교체한다.
+public class FanLetterUpdateRequest {
+
+    // 수정은 부분 변경이므로 null 이면 기존 수신 대상을 유지한다.
+    private FanLetterRecipientType recipientType;
+
+    // recipientType=ARTIST_MEMBER 로 바꿀 때 대상 artist-member 를 함께 보낸다.
+    private Long recipientArtistMemberId;
+
+    // 이미지를 보내면 기존 팬레터 이미지를 전체 교체한다.
+    private MultipartFile image;
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterCreateResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterCreateResponse.java
@@ -1,0 +1,13 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
+
+public record FanLetterCreateResponse(
+        Long fanLetterId
+) {
+    public static FanLetterCreateResponse from(FanLetter fanLetter) {
+        // 생성 직후에는 상세 payload 전체보다 식별자만 돌려주고,
+        // 이후 목록/상세 조회에서 카드 렌더링 정보를 조립해 내려준다.
+        return new FanLetterCreateResponse(fanLetter.getId());
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterImageResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterImageResponse.java
@@ -1,0 +1,19 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
+
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+
+public record FanLetterImageResponse(
+        Long mediaId,
+        String imageUrl,
+        String thumbnailUrl
+) {
+    public static FanLetterImageResponse from(Media media) {
+        // 팬레터는 이미지 1장만 쓰지만, media 도메인 구조를 재사용하므로
+        // 프론트에는 팬레터 전용 응답 형태로 다시 감싸서 내려준다.
+        return new FanLetterImageResponse(
+                media.getId(),
+                media.getFileUrl(),
+                media.getThumbnailUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterListResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterListResponse.java
@@ -1,54 +1,37 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
 
 import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
-import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
 
 import java.time.LocalDateTime;
 
-public record FanLetterResponse(
+// 팬레터 목록 카드 전용 응답이다.
+// 목록에서는 작성자 프로필/배지를 숨기고, 이미지/수신자/special-like 정보만 내려준다.
+public record FanLetterListResponse(
         Long fanLetterId,
-        Long artistId,
-        Long writerId,
-        String writerNickname,
-        String writerProfileImageUrl,
-        boolean fanMembershipSubscribed,
-        boolean dmSubscribed,
-        // 프론트에서 "To.아티스트" / "To.아티스트멤버" UI 를 구분하는 기준값이다.
         FanLetterRecipientType recipientType,
-        // recipientType=ARTIST_MEMBER 일 때만 내려간다.
         Long recipientArtistMemberId,
         String recipientDisplayName,
         String recipientProfileImageUrl,
         FanLetterImageResponse image,
-        long likeCount,
-        // 우하단 아티스트 하트 오버레이 노출 여부와 표기 정보를 담는다.
         boolean artistLiked,
         String artistLikeDisplayName,
         String artistLikeProfileImageUrl,
         LocalDateTime createdAt
 ) {
-    public static FanLetterResponse from(
-            FanLetterReadRow row,
+    public static FanLetterListResponse from(
+            FanLetterListRow row,
             FanLetterImageResponse image,
-            WriterSubscriptionBadge writerBadge,
             boolean artistLiked,
             String artistLikeDisplayName,
             String artistLikeProfileImageUrl
     ) {
-        return new FanLetterResponse(
+        return new FanLetterListResponse(
                 row.fanLetterId(),
-                row.artistId(),
-                row.writerId(),
-                row.writerNickname(),
-                row.writerProfileImageUrl(),
-                writerBadge.fanMembershipSubscribed(),
-                writerBadge.dmSubscribed(),
                 row.recipientType(),
                 row.recipientArtistMemberId(),
                 row.recipientDisplayName(),
                 row.recipientProfileImageUrl(),
                 image,
-                row.likeCount() == null ? 0L : row.likeCount(),
                 artistLiked,
                 artistLikeDisplayName,
                 artistLikeProfileImageUrl,

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterListRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterListRow.java
@@ -1,0 +1,19 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+
+import java.time.LocalDateTime;
+
+// 팬레터 목록 카드에 필요한 최소 조인 결과만 담는 projection row 다.
+// 목록에서는 작성자/배지 대신 수신자 정보와 special-like용 artist 정보만 사용한다.
+public record FanLetterListRow(
+        Long fanLetterId,
+        FanLetterRecipientType recipientType,
+        Long recipientArtistMemberId,
+        String recipientDisplayName,
+        String recipientProfileImageUrl,
+        String artistDisplayName,
+        String artistProfileImageUrl,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterReadRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterReadRow.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+
+import java.time.LocalDateTime;
+
+// 팬레터 목록/상세 조인 결과를 응답 조립 전 단계에서 받는 projection row 다.
+// 수신자 표시용 정보와 special-like 오버레이용 artist 정보만 같이 들고 간다.
+public record FanLetterReadRow(
+        Long fanLetterId,
+        Long artistId,
+        Long writerId,
+        String writerNickname,
+        String writerProfileImageUrl,
+        FanLetterRecipientType recipientType,
+        Long recipientArtistMemberId,
+        String recipientDisplayName,
+        String recipientProfileImageUrl,
+        String artistDisplayName,
+        String artistProfileImageUrl,
+        Long likeCount,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/entity/FanLetter.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/entity/FanLetter.java
@@ -1,6 +1,8 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.entity;
 
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
 import com.example.infinite.domain.member.artist.entity.Artist;
+import com.example.infinite.domain.member.artist.entity.ArtistMember;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -16,6 +18,8 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE fan_letter SET deleted_at = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
+// 팬레터는 일반 게시글처럼 본문/댓글 중심 모델이 아니라
+// "작성자 + 수신 대상 + 이미지 1장 + 좋아요"에 집중된 가벼운 도메인이다.
 public class FanLetter extends BaseEntity {
 
     @Id
@@ -30,8 +34,41 @@ public class FanLetter extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member writer;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recipient_type", nullable = false, length = 30)
+    private FanLetterRecipientType recipientType;
+
+    // recipientType=ARTIST_MEMBER 일 때만 값이 있고,
+    // ARTIST 인 경우에는 null 로 두고 artist 자체를 수신 대상으로 해석한다.
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_artist_member_id")
+    private ArtistMember recipientArtistMember;
+
     @Column(nullable = false)
     private long likeCount = 0L;
+
+    private FanLetter(Artist artist, Member writer, FanLetterRecipientType recipientType, ArtistMember recipientArtistMember) {
+        this.artist = artist;
+        this.writer = writer;
+        this.recipientType = recipientType;
+        this.recipientArtistMember = recipientArtistMember;
+    }
+
+    public static FanLetter create(
+            Artist artist,
+            Member writer,
+            FanLetterRecipientType recipientType,
+            ArtistMember recipientArtistMember
+    ) {
+        // 팬레터는 본문 텍스트 없이 "누구에게 보내는가 + 이미지 한 장"을 중심으로 저장한다.
+        return new FanLetter(artist, writer, recipientType, recipientArtistMember);
+    }
+
+    public void updateRecipient(FanLetterRecipientType recipientType, ArtistMember recipientArtistMember) {
+        // 수정 시에도 recipientType 과 recipientArtistMember 를 항상 함께 정규화해서 맞춘다.
+        this.recipientType = recipientType;
+        this.recipientArtistMember = recipientArtistMember;
+    }
 
     public void changeLikeCountBy(int delta) {
         this.likeCount = Math.max(0, this.likeCount + delta);

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/enums/FanLetterRecipientType.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/enums/FanLetterRecipientType.java
@@ -1,0 +1,9 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.enums;
+
+// 팬레터 수신 대상은 그룹(artist) 자체이거나, 특정 artist-member 둘 중 하나다.
+public enum FanLetterRecipientType {
+    // To.세븐틴 같이 아티스트 전체에게 보내는 팬레터
+    ARTIST,
+    // To.민규 같이 특정 artist-member 에게 보내는 팬레터
+    ARTIST_MEMBER
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
@@ -3,5 +3,11 @@ package com.example.infinite.domain.artistcontent.post.fanletter.repository;
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FanLetterRepository extends JpaRepository<FanLetter, Long>, FanLetterRepositoryCustom {
+
+    // 팬레터 상세/수정/삭제는 항상 artist 범위 안에서 조회해야
+    // 다른 아티스트의 팬레터를 잘못 건드리지 않는다.
+    Optional<FanLetter> findByIdAndArtistId(Long fanLetterId, Long artistId);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryCustom.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryCustom.java
@@ -1,4 +1,16 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.repository;
 
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterReadRow;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListRow;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface FanLetterRepositoryCustom {
+
+    // 카드형 목록에 필요한 조인 결과를 cursor pagination 으로 조회한다.
+    List<FanLetterListRow> findSliceRowsByArtistId(Long artistId, Long cursor, int limit);
+
+    // 상세도 목록과 같은 projection 을 재사용해 응답 조립 규칙을 맞춘다.
+    Optional<FanLetterReadRow> findDetailRowByArtistIdAndFanLetterId(Long artistId, Long fanLetterId);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryImpl.java
@@ -1,10 +1,128 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.repository;
 
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterReadRow;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListRow;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.QFanLetter;
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import com.example.infinite.domain.member.artist.entity.QArtist;
+import com.example.infinite.domain.member.artist.entity.QArtistMember;
+import com.example.infinite.domain.member.member.entity.QMember;
+import com.example.infinite.global.common.util.querydsl.CursorSliceUtils;
+import com.example.infinite.global.common.util.querydsl.QuerydslUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class FanLetterRepositoryImpl implements FanLetterRepositoryCustom {
 
     protected final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<FanLetterListRow> findSliceRowsByArtistId(Long artistId, Long cursor, int limit) {
+        QFanLetter fanLetter = QFanLetter.fanLetter;
+        QArtist artist = QArtist.artist;
+        QArtistMember recipientArtistMember = new QArtistMember("recipientArtistMember");
+        QMember recipientMember = new QMember("recipientMember");
+
+        return queryFactory
+                .select(listProjection(fanLetter, artist, recipientArtistMember, recipientMember))
+                .from(fanLetter)
+                .join(fanLetter.artist, artist)
+                .leftJoin(fanLetter.recipientArtistMember, recipientArtistMember)
+                .leftJoin(recipientArtistMember.member, recipientMember)
+                .where(
+                        QuerydslUtils.eq(artist.id, artistId),
+                        CursorSliceUtils.ltCursor(fanLetter.id, cursor)
+                )
+                .orderBy(CursorSliceUtils.orderByIdDesc(fanLetter.id))
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public Optional<FanLetterReadRow> findDetailRowByArtistIdAndFanLetterId(Long artistId, Long fanLetterId) {
+        QFanLetter fanLetter = QFanLetter.fanLetter;
+        QArtist artist = QArtist.artist;
+        QMember writer = new QMember("writer");
+        QArtistMember recipientArtistMember = new QArtistMember("recipientArtistMember");
+        QMember recipientMember = new QMember("recipientMember");
+
+        return Optional.ofNullable(queryFactory
+                .select(detailProjection(fanLetter, artist, writer, recipientArtistMember, recipientMember))
+                .from(fanLetter)
+                .join(fanLetter.artist, artist)
+                .join(fanLetter.writer, writer)
+                .leftJoin(fanLetter.recipientArtistMember, recipientArtistMember)
+                .leftJoin(recipientArtistMember.member, recipientMember)
+                .where(
+                        QuerydslUtils.eq(artist.id, artistId),
+                        QuerydslUtils.eq(fanLetter.id, fanLetterId)
+                )
+                .fetchOne());
+    }
+
+    private com.querydsl.core.types.ConstructorExpression<FanLetterListRow> listProjection(
+            QFanLetter fanLetter,
+            QArtist artist,
+            QArtistMember recipientArtistMember,
+            QMember recipientMember
+    ) {
+        // 목록에서는 작성자 정보가 필요 없으므로
+        // 수신자 표시와 special-like 오버레이용 artist 정보만 읽는다.
+        return Projections.constructor(
+                FanLetterListRow.class,
+                fanLetter.id,
+                fanLetter.recipientType,
+                recipientArtistMember.id,
+                new CaseBuilder()
+                        .when(fanLetter.recipientType.eq(FanLetterRecipientType.ARTIST_MEMBER))
+                        .then(recipientArtistMember.stageName)
+                        .otherwise(artist.name),
+                new CaseBuilder()
+                        .when(fanLetter.recipientType.eq(FanLetterRecipientType.ARTIST_MEMBER))
+                        .then(recipientArtistMember.profileImageUrl)
+                        .otherwise(artist.profileImageUrl),
+                artist.name,
+                artist.profileImageUrl,
+                fanLetter.createdAt
+        );
+    }
+
+    private com.querydsl.core.types.ConstructorExpression<FanLetterReadRow> detailProjection(
+            QFanLetter fanLetter,
+            QArtist artist,
+            QMember writer,
+            QArtistMember recipientArtistMember,
+            QMember recipientMember
+    ) {
+        // 상세는 작성자 기본 정보와 likeCount 까지 함께 읽는다.
+        // 수신자 표시용 이름/프로필 분기는 projection 에서 미리 정리해 service 조립을 단순화한다.
+        return Projections.constructor(
+                FanLetterReadRow.class,
+                fanLetter.id,
+                artist.id,
+                writer.id,
+                writer.nickname,
+                writer.profileImageUrl,
+                fanLetter.recipientType,
+                recipientArtistMember.id,
+                new CaseBuilder()
+                        .when(fanLetter.recipientType.eq(FanLetterRecipientType.ARTIST_MEMBER))
+                        .then(recipientArtistMember.stageName)
+                        .otherwise(artist.name),
+                new CaseBuilder()
+                        .when(fanLetter.recipientType.eq(FanLetterRecipientType.ARTIST_MEMBER))
+                        .then(recipientArtistMember.profileImageUrl)
+                        .otherwise(artist.profileImageUrl),
+                artist.name,
+                artist.profileImageUrl,
+                fanLetter.likeCount,
+                fanLetter.createdAt
+        );
+    }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
@@ -1,4 +1,346 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.service;
 
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.media.service.MediaService;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterCreateRequest;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterUpdateRequest;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterCreateResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterImageResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListRow;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterReadRow;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterResponse;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
+import com.example.infinite.domain.member.artist.entity.Artist;
+import com.example.infinite.domain.member.artist.entity.ArtistMember;
+import com.example.infinite.domain.member.artist.support.ArtistReader;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.support.MemberInputSupport;
+import com.example.infinite.domain.member.member.support.MemberReader;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
+import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import com.example.infinite.global.error.ErrorCode;
+import com.example.infinite.global.error.SubscriptionMembershipException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FanLetterService {
+
+    private static final int FAN_LETTER_SLICE_SIZE = 10;
+
+    private final FanLetterRepository fanLetterRepository;
+    private final FanLetterReader fanLetterReader;
+    private final ArtistReader artistReader;
+    private final MemberReader memberReader;
+    private final MediaRepository mediaRepository;
+    private final MediaService mediaService;
+    private final InteractionRepository interactionRepository;
+    private final SubscriptionMembershipService subscriptionMembershipService;
+
+    @Transactional
+    public FanLetterCreateResponse create(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            FanLetterCreateRequest request
+    ) {
+        // 팬레터는 팬 멤버십이 있는 사용자만 작성 가능하다.
+        // 생성 시점에 누구에게 보내는 편지인지(아티스트 전체 / 특정 멤버)를 먼저 확정한 뒤
+        // 본문 역할을 하는 이미지 한 장을 media 도메인에 위임해 저장한다.
+        Member writer = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        Artist artist = artistReader.findArtistByIdOrThrow(artistId);
+        validateWritePermission(artistId, writer.getId());
+        // 수신 대상은 "아티스트 전체" 또는 "특정 아티스트 멤버" 둘 중 하나로 정규화한다.
+        ResolvedRecipient resolvedRecipient = resolveRecipient(
+                artistId,
+                request.getRecipientType(),
+                request.getRecipientArtistMemberId()
+        );
+
+        FanLetter fanLetter = fanLetterRepository.save(FanLetter.create(
+                artist,
+                writer,
+                resolvedRecipient.recipientType(),
+                resolvedRecipient.recipientArtistMember()
+        ));
+        // 팬레터 본문 역할을 하는 이미지 1장은 media 서비스가 storage 와 DB 메타데이터를 함께 처리한다.
+        mediaService.attachFanLetterMedia(artistId, fanLetter, request.getImage());
+        return FanLetterCreateResponse.from(fanLetter);
+    }
+
+    public CursorSliceResponse<FanLetterListResponse> getFanLetters(Long artistId, Long cursor) {
+        artistReader.findArtistByIdOrThrow(artistId);
+
+        // 팬레터 목록은 사진 카드 렌더링에 필요한 최소 정보만 읽는다.
+        // 작성자 프로필/배지는 상세에서만 내려주고, 목록은 이미지/수신자/special-like만 조립한다.
+        List<FanLetterListRow> rows = fanLetterRepository.findSliceRowsByArtistId(
+                artistId,
+                cursor,
+                FAN_LETTER_SLICE_SIZE + 1
+        );
+        boolean hasNext = rows.size() > FAN_LETTER_SLICE_SIZE;
+        List<FanLetterListRow> visibleRows = hasNext ? rows.subList(0, FAN_LETTER_SLICE_SIZE) : rows;
+        if (visibleRows.isEmpty()) {
+            return new CursorSliceResponse<>(List.of(), null, false, FAN_LETTER_SLICE_SIZE);
+        }
+
+        return toCursorSliceResponse(artistId, visibleRows, hasNext);
+    }
+
+    public FanLetterResponse getFanLetter(Long artistId, Long fanLetterId) {
+        artistReader.findArtistByIdOrThrow(artistId);
+        FanLetterReadRow row = fanLetterRepository.findDetailRowByArtistIdAndFanLetterId(artistId, fanLetterId)
+                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
+
+        // 상세는 작성자 프로필/배지까지 보여주므로 목록보다 더 많은 정보를 조립한다.
+        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(List.of(fanLetterId));
+        WriterSubscriptionBadge writerBadge = loadWriterBadges(artistId, List.of(row.writerId()))
+                .getOrDefault(row.writerId(), WriterSubscriptionBadge.empty(row.writerId()));
+        SpecialLikeInfo specialLikeInfo = loadSpecialLikeInfo(
+                artistId,
+                List.of(row),
+                FanLetterReadRow::fanLetterId,
+                FanLetterReadRow::artistDisplayName,
+                FanLetterReadRow::artistProfileImageUrl
+        )
+                .getOrDefault(fanLetterId, SpecialLikeInfo.empty());
+
+        return FanLetterResponse.from(
+                row,
+                imageByLetterId.get(fanLetterId),
+                writerBadge,
+                specialLikeInfo.artistLiked(),
+                specialLikeInfo.artistLikeDisplayName(),
+                specialLikeInfo.artistLikeProfileImageUrl()
+        );
+    }
+
+    @Transactional
+    public FanLetterResponse update(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long fanLetterId,
+            FanLetterUpdateRequest request
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        FanLetter fanLetter = findOwnedFanLetter(member.getId(), artistId, fanLetterId);
+
+        // 수신 대상을 바꾸는 경우에는 "아티스트 전체" / "특정 멤버" 규칙을 다시 검증한다.
+        // recipientType=ARTIST 로 바꾸면 recipientArtistMember 는 null 이어야 하므로 resolveRecipient 에서 정규화한다.
+        if (request.getRecipientType() != null || request.getRecipientArtistMemberId() != null) {
+            FanLetterRecipientType resolvedRecipientType =
+                    request.getRecipientType() != null ? request.getRecipientType() : fanLetter.getRecipientType();
+            Long resolvedRecipientArtistMemberId = null;
+
+            if (resolvedRecipientType != FanLetterRecipientType.ARTIST) {
+                if (request.getRecipientArtistMemberId() != null) {
+                    resolvedRecipientArtistMemberId = request.getRecipientArtistMemberId();
+                } else if (fanLetter.getRecipientArtistMember() != null) {
+                    resolvedRecipientArtistMemberId = fanLetter.getRecipientArtistMember().getId();
+                }
+            }
+
+            ResolvedRecipient resolvedRecipient = resolveRecipient(
+                    artistId,
+                    resolvedRecipientType,
+                    resolvedRecipientArtistMemberId
+            );
+            fanLetter.updateRecipient(resolvedRecipient.recipientType(), resolvedRecipient.recipientArtistMember());
+        }
+
+        if (request.getImage() != null && !request.getImage().isEmpty()) {
+            // 팬레터는 이미지 1장만 유지하므로 수정도 append 가 아니라 교체 정책으로 처리한다.
+            mediaService.replaceFanLetterMedia(artistId, fanLetter, request.getImage());
+        }
+
+        return getFanLetter(artistId, fanLetterId);
+    }
+
+    @Transactional
+    public void delete(MemberDetailsImpl memberDetails, Long artistId, Long fanLetterId) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        FanLetter fanLetter = findOwnedFanLetter(member.getId(), artistId, fanLetterId);
+        mediaService.deleteFanLetterMedia(fanLetter);
+        fanLetter.delete();
+    }
+
+    private FanLetter findOwnedFanLetter(Long memberId, Long artistId, Long fanLetterId) {
+        FanLetter fanLetter = fanLetterReader.findByIdAndArtistIdOrThrow(fanLetterId, artistId);
+        if (!fanLetter.getWriter().getId().equals(memberId)) {
+            throw new ArtistContentException(ArtistContentErrorCode.POST_PERMISSION_DENIED);
+        }
+        return fanLetter;
+    }
+
+    private void validateWritePermission(Long artistId, Long memberId) {
+        if (!subscriptionMembershipService.checkFanLetterPermission(artistId, memberId).allowed()) {
+            throw new SubscriptionMembershipException(ErrorCode.FAN_LETTER_PERMISSION_REQUIRED);
+        }
+    }
+
+    private ResolvedRecipient resolveRecipient(Long artistId, FanLetterRecipientType recipientType, Long recipientArtistMemberId) {
+        if (recipientType == null) {
+            throw new IllegalArgumentException("팬레터 수신 대상은 필수입니다.");
+        }
+
+        if (recipientType == FanLetterRecipientType.ARTIST) {
+            // To.세븐틴 같은 케이스다.
+            // 별도 recipientArtistMember 를 저장하지 않고 artist 자체를 수신자로 해석한다.
+            return new ResolvedRecipient(recipientType, null);
+        }
+
+        if (recipientArtistMemberId == null) {
+            throw new IllegalArgumentException("아티스트 멤버에게 보내는 팬레터는 수신 멤버 선택이 필요합니다.");
+        }
+
+        // To.민규 같은 케이스다.
+        // fan letter 와 artistMember 를 직접 연결해 두면
+        // 상세 응답에서 stageName / profileImageUrl / special-like 판단을 안정적으로 재사용할 수 있다.
+        ArtistMember recipientArtistMember = artistReader.findArtistMemberByIdAndArtistIdOrThrow(recipientArtistMemberId, artistId);
+        return new ResolvedRecipient(recipientType, recipientArtistMember);
+    }
+
+    private CursorSliceResponse<FanLetterListResponse> toCursorSliceResponse(
+            Long artistId,
+            List<FanLetterListRow> visibleRows,
+            boolean hasNext
+    ) {
+        List<Long> fanLetterIds = visibleRows.stream()
+                .map(FanLetterListRow::fanLetterId)
+                .toList();
+        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(fanLetterIds);
+        Map<Long, SpecialLikeInfo> specialLikeInfoByLetterId = loadSpecialLikeInfo(
+                artistId,
+                visibleRows,
+                FanLetterListRow::fanLetterId,
+                FanLetterListRow::artistDisplayName,
+                FanLetterListRow::artistProfileImageUrl
+        );
+
+        List<FanLetterListResponse> responses = visibleRows.stream()
+                .map(row -> FanLetterListResponse.from(
+                        row,
+                        imageByLetterId.get(row.fanLetterId()),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLiked(),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeDisplayName(),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeProfileImageUrl()
+                ))
+                .toList();
+
+        Long nextCursor = hasNext && !visibleRows.isEmpty()
+                ? visibleRows.get(visibleRows.size() - 1).fanLetterId()
+                : null;
+        return new CursorSliceResponse<>(responses, nextCursor, hasNext, FAN_LETTER_SLICE_SIZE);
+    }
+
+    private Map<Long, FanLetterImageResponse> loadImageMap(Collection<Long> fanLetterIds) {
+        if (fanLetterIds.isEmpty()) {
+            return Map.of();
+        }
+
+        // 팬레터는 이미지 한 장만 허용하므로 targetId 당 첫 번째 media row 만 응답에 매핑한다.
+        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.FAN_LETTER, fanLetterIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        Media::getTargetId,
+                        FanLetterImageResponse::from,
+                        (left, right) -> left
+                ));
+    }
+
+    private Map<Long, WriterSubscriptionBadge> loadWriterBadges(Long artistId, List<Long> writerIds) {
+        if (writerIds.isEmpty()) {
+            return Map.of();
+        }
+        // 팬포스트와 같은 배지 계약을 그대로 재사용해
+        // 팬레터 작성자 옆에도 멤버십/DM 배지를 동일한 방식으로 붙인다.
+        return subscriptionMembershipService.getWriterBadges(artistId, writerIds);
+    }
+
+    private <T> Map<Long, SpecialLikeInfo> loadSpecialLikeInfo(
+            Long artistId,
+            List<T> rows,
+            Function<T, Long> fanLetterIdExtractor,
+            Function<T, String> artistDisplayNameExtractor,
+            Function<T, String> artistProfileImageUrlExtractor
+    ) {
+        if (rows.isEmpty()) {
+            return Map.of();
+        }
+
+        // special-like 에 필요한 건 "아티스트 멤버가 좋아요한 fanLetterId 존재 여부"뿐이라
+        // reaction 전체를 가져오지 않고 targetId 집합만 바로 조회한다.
+        var likedFanLetterIds = interactionRepository.findTargetIdsReactedByArtistMembers(
+                artistId,
+                PostType.FAN_LETTER,
+                rows.stream().map(fanLetterIdExtractor).toList(),
+                ReactionType.LIKE
+        );
+
+        return rows.stream()
+                .collect(Collectors.toMap(
+                        fanLetterIdExtractor,
+                        row -> resolveSpecialLikeInfo(
+                                artistDisplayNameExtractor.apply(row),
+                                artistProfileImageUrlExtractor.apply(row),
+                                likedFanLetterIds.contains(fanLetterIdExtractor.apply(row))
+                        )
+                ));
+    }
+
+    private SpecialLikeInfo resolveSpecialLikeInfo(
+            String artistDisplayName,
+            String artistProfileImageUrl,
+            boolean artistReacted
+    ) {
+        if (!artistReacted) {
+            return SpecialLikeInfo.empty();
+        }
+
+        // 팬레터의 special-like 는 "아티스트 팀이 반응했는가"만 본다.
+        // 따라서 수신 대상이 그룹이든 특정 멤버든 상관없이,
+        // 아티스트 소속 멤버 중 한 명이라도 좋아요하면 artist 프로필 기준 오버레이를 켠다.
+        return new SpecialLikeInfo(true, artistDisplayName, artistProfileImageUrl);
+    }
+
+    private record ResolvedRecipient(
+            FanLetterRecipientType recipientType,
+            ArtistMember recipientArtistMember
+    ) {
+        // recipientType 과 연결된 artistMember 를 한 덩어리로 다뤄
+        // create/update 모두 같은 정규화 로직을 재사용한다.
+    }
+
+    private record SpecialLikeInfo(
+            boolean artistLiked,
+            String artistLikeDisplayName,
+            String artistLikeProfileImageUrl
+    ) {
+        private static SpecialLikeInfo empty() {
+            // 아티스트 측 반응이 아직 없으면 오버레이 관련 필드는 모두 비운다.
+            return new SpecialLikeInfo(false, null, null);
+        }
+    }
+
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/support/FanLetterReader.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/support/FanLetterReader.java
@@ -1,0 +1,21 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.support;
+
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FanLetterReader {
+
+    private final FanLetterRepository fanLetterRepository;
+
+    public FanLetter findByIdAndArtistIdOrThrow(Long fanLetterId, Long artistId) {
+        // 팬레터도 artist scope 안에서 읽어야 URL 상의 artistId 와 실제 데이터가 일치한다.
+        return fanLetterRepository.findByIdAndArtistId(fanLetterId, artistId)
+                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -104,6 +104,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/post/v1/artists/*/fan-posts/*").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/fan-posts/*").authenticated()
+                        .requestMatchers("/api/post/v1/artists/*/fan-letters/**").authenticated()
                         .requestMatchers("/api/post/v1/fan-posts").authenticated()
 
                         // 좋아요, 댓글
@@ -113,9 +114,6 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/artist-posts/*/comments").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/artist-posts/*/comments/*").authenticated()
                         .requestMatchers("/api/post/v1/comments/**", "/api/post/v1/*/likes/toggle").authenticated()
-
-                        // 팬레터 (구독 검증은 서비스 레이어에서 수행)
-                        .requestMatchers("/api/post/v1/fan-letters/**").authenticated()
 
                         // DM (구독 검증은 서비스 레이어에서 수행)
                         .requestMatchers("/api/v1/dm/**").authenticated()

--- a/src/main/java/com/example/infinite/global/error/ErrorCode.java
+++ b/src/main/java/com/example/infinite/global/error/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode implements ErrorCodeType {
     SUB_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "S001", "이미 활성화된 멤버십 또는 구독권을 보유하고 있습니다."),
     SUB_ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "S002", "구독하려는 아티스트 정보를 찾을 수 없습니다."),
     SUB_EXPIRED(HttpStatus.FORBIDDEN, "S003", "구독 기간이 만료되어 권한이 회수되었습니다."),
+    FAN_LETTER_PERMISSION_REQUIRED(HttpStatus.FORBIDDEN, "S004", "팬레터 작성은 팬 멤버십 보유자만 가능합니다."),
 
     // 5. Refund (환불)
     REFUND_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "R001", "환불 가능 기간이 초과되었습니다."),


### PR DESCRIPTION
#12 

## 작업 배경
FanLetter 기능을 실제로 사용할 수 있도록 API를 구현했습니다.

기존에 비어 있던 FanLetter 영역을
- 생성 / 목록 조회 / 상세 조회 / 수정 / 삭제
- 좋아요 토글
- 이미지 업로드
까지 하나의 흐름으로 연결했고,

같이 작업하면서
- 미디어 교체 시 기존 파일을 먼저 지우지 않도록 안정성 보강
- 댓글/좋아요 조회 쿼리 최적화
- 팬레터 전용 권한 및 보안 경로 정리
도 함께 반영했습니다.

## 주요 변경 사항

### 1. FanLetter API 구현
- FanLetterController 추가
- 아래 엔드포인트 구현
  - `POST /api/post/v1/artists/{artistId}/fan-letters`
  - `GET /api/post/v1/artists/{artistId}/fan-letters`
  - `GET /api/post/v1/artists/{artistId}/fan-letters/{fanLetterId}`
  - `PATCH /api/post/v1/artists/{artistId}/fan-letters/{fanLetterId}`
  - `DELETE /api/post/v1/artists/{artistId}/fan-letters/{fanLetterId}`
  - `POST /api/post/v1/artists/{artistId}/fan-letters/{fanLetterId}/likes/toggle`

### 2. FanLetter 도메인 확장
- `FanLetterRecipientType` 추가
  - `ARTIST`
  - `ARTIST_MEMBER`
- 팬레터가
  - 아티스트 전체에게 보내는 편지인지
  - 특정 아티스트 멤버에게 보내는 편지인지
  구분할 수 있도록 모델 확장
- `recipientArtistMember` 연관관계 추가
- `likeCount` 반영

### 3. FanLetter 요청/응답 구조 추가
- 생성/수정 요청을 `multipart/form-data` 기반으로 받도록 변경
- 요청 DTO 추가
  - `FanLetterCreateRequest`
  - `FanLetterUpdateRequest`
- 응답 DTO 추가
  - `FanLetterCreateResponse`
  - `FanLetterImageResponse`
  - `FanLetterListResponse`
  - `FanLetterListRow`
  - `FanLetterReadRow`
  - `FanLetterResponse`

### 4. FanLetter 이미지 업로드 정책 적용
- FanLetter는 이미지 1장만 허용
- 비디오 업로드 불가
- 생성 시 이미지 필수
- 수정 시 새 이미지를 보내면 기존 이미지를 전체 교체
- 팬레터 전용 에러 코드 추가
  - `M010: 팬레터는 이미지 한 장만 업로드할 수 있습니다.`

### 5. 미디어 교체 로직 안정화
- 기존 FanPost / ArtistPost 수정 로직은
  기존 미디어를 먼저 지운 뒤 새 파일을 올리는 흐름이었는데,
  업로드 실패 시 참조가 깨질 수 있어서
  **새 미디어 저장 성공 후 기존 미디어를 삭제**하는 방식으로 변경했습니다.
- 같은 정책을 FanLetter에도 적용했습니다.

### 6. FanLetter 좋아요 토글 추가
- 기존 reaction 테이블 구조를 재사용해서
  `targetType = FAN_LETTER` 기준 좋아요 토글 구현
- likeCount 반영까지 같은 트랜잭션 안에서 처리

### 7. FanLetter special-like 표시용 조회 추가
- “아티스트 팀이 좋아요를 눌렀는지” 확인하기 위해
  reaction 전체를 다시 읽지 않고
  아티스트 소속 멤버가 반응한 targetId 집합만 배치 조회하도록 구현
- 목록/상세 응답에서
  - `artistLiked`
  - `artistLikeDisplayName`
  - `artistLikeProfileImageUrl`
  조립 가능하게 했습니다.

### 8. 작성자 구독 배지 연동
- FanLetter 상세 응답에 작성자 기준
  - `fanMembershipSubscribed`
  - `dmSubscribed`
  값이 포함되도록 했습니다.
- FanPost에서 쓰던 writer badge 조립 방식을 재사용했습니다.

### 9. 댓글 삭제/집계 로직 보강
- 댓글 삭제 시 자식 댓글 존재 여부를
  `findByParentIdOrderByIdAsc()` 대신 `existsByParentId()`로 판단하도록 단순화
- replyCount 집계는 Hibernate 7 환경 충돌을 피하기 위해
  QueryDSL `groupBy(transform)` 대신
  groupBy + fetch + Map 조립 방식으로 변경

### 10. 보안 경로 정리
- FanLetter 경로를
  `/api/post/v1/artists/*/fan-letters/**`
  기준으로 인증 처리하도록 SecurityConfig 반영

### 11. 프론트 핸드오프 문서 업데이트
- FanPost 쪽 배지 상태 설명 최신화
- FanLetter / ArtistPost 관련 남은 작업 우선순위 문구 정리

## 리뷰 포인트
- FanLetter 생성/수정이 multipart 계약으로 문제없이 붙는지
- recipientType 이 `ARTIST` / `ARTIST_MEMBER` 일 때 recipient 처리 정규화가 맞는지
- FanLetter 이미지 1장 정책과 `M010` 에러 처리 방식이 프론트 계약과 맞는지
- 기존 미디어를 먼저 지우지 않는 교체 로직이 FanPost / ArtistPost / FanLetter 모두에서 의도대로 동작하는지
- special-like 표시가 “아티스트 멤버 중 한 명이라도 좋아요한 경우” 기준으로 잘 조립되는지
- 댓글 replyCount 집계 변경이 Hibernate 7 환경 이슈 회피에 적절한지

