### PR TITLE
feat: ArtistPost 댓글 동시성 처리(v2) 및 비동기 큐 응답 도입

### DIFF
--- a/FRONTEND_TEAM_VIBE_HANDOFF.md
+++ b/FRONTEND_TEAM_VIBE_HANDOFF.md
@@ -282,6 +282,8 @@ FanPost 댓글 현재 정책:
 - 자식 없는 원댓글은 soft delete 후 숨김
 - placeholder 부모의 마지막 대댓글도 사라지면 부모도 최종 삭제
 - 작성자 옆 구독 배지 boolean은 현재 실제 subscription 조회 결과가 내려온다
+- FanPost는 별도 상위 버전 route가 없으므로 현재 route가 곧 최신 구현이다
+- 내부적으로는 백엔드가 Redisson 락/atomic update 구조로 바뀌었지만 응답 계약은 그대로다
 
 프론트가 지금 바로 실연동 가능한 화면:
 
@@ -400,6 +402,10 @@ FanPost 댓글 현재 정책:
 - `POST /api/post/v1/artists/{artistId}/artist-posts/{artistPostId}/comments`
 - `DELETE /api/post/v1/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}`
 - `GET /api/post/v1/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}/replies`
+- 추가 비동기 버전 API도 생김:
+- `POST /api/post/v3/artists/{artistId}/artist-posts/{artistPostId}/likes/toggle`
+- `POST /api/post/v2/artists/{artistId}/artist-posts/{artistPostId}/comments`
+- `DELETE /api/post/v2/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}`
 
 즉 현재 해석은 아래가 맞다.
 
@@ -411,6 +417,16 @@ FanPost 댓글 현재 정책:
 - 권한은 아티스트 계정이면서 해당 artist 소속 artist member인 경우만 허용된다
 - ArtistPost 리스트의 `media[]`도 FanPost와 동일하게 앞 `6개` preview만 내려오고, 전체 개수는 `mediaCount`로 본다
 - ArtistPost 상세에서는 전체 `media[]`가 내려온다
+- 버전 선택 규칙은 고정:
+  - `v3`가 있으면 `v3`
+  - `v3`는 없고 `v2`까지만 있으면 `v2`
+- 따라서 ArtistPost 기준 최신 사용 버전은:
+  - 좋아요 = `v3`
+  - 댓글 생성/삭제 = `v2`
+- `v1` 동기 API는 형태만 남아 있고 실제 사용 경로가 아니다
+- 새 `v2/v3`는 비동기 command enqueue 용도라 `202 Accepted` + queued metadata를 반환한다
+- ArtistPost 댓글 생성/삭제는 반드시 `v2`를 기준으로 붙여야 한다
+- ArtistPost 댓글 `v1`은 레거시 호환용으로만 남아 있다
 
 프론트가 지금 해두면 좋은 것:
 

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/controller/CommentController.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.example.infinite.domain.artistcontent.comment.controller;
 
 import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.ArtistPostCommentQueuedResponse;
 import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
 import com.example.infinite.domain.artistcontent.comment.service.CommentService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
@@ -48,11 +49,29 @@ public class CommentController {
             @PathVariable Long artistPostId,
             @Valid @RequestBody CommentCreateRequest request
     ) {
-        // 아티스트 게시글도 댓글 정책은 같고, URL만 게시글 종류에 맞춰 분리한다.
+        // legacy compatibility route.
+        // ArtistPost 댓글의 실제 최신 사용 경로는 v2이며, v1은 형태 보존용으로만 남겨둔다.
+        // 새 연동/수정은 이 경로 기준으로 진행하지 않는다.
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(
                         commentService.createArtistPostComment(memberDetails, artistId, artistPostId, request)
+                ));
+    }
+
+    @PostMapping("/v2/artists/{artistId}/artist-posts/{artistPostId}/comments")
+    public ResponseEntity<ApiResponse<ArtistPostCommentQueuedResponse>> createArtistPostCommentV2(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long artistPostId,
+            @Valid @RequestBody CommentCreateRequest request
+    ) {
+        // v2는 댓글 원본 저장을 worker가 처리하므로, API는 "접수됨"만 응답한다.
+        // ArtistPost 댓글의 실제 사용 경로는 이 v2다.
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(
+                        commentService.queueArtistPostCommentV2(memberDetails, artistId, artistPostId, request)
                 ));
     }
 
@@ -96,8 +115,25 @@ public class CommentController {
             @PathVariable Long artistPostId,
             @PathVariable Long commentId
     ) {
-        // 삭제 역시 artist-post 경로를 별도로 두되 서비스 공통 로직으로 위임한다.
+        // legacy compatibility route.
+        // ArtistPost 댓글 삭제의 실제 최신 사용 경로는 v2이며, v1 delete도 형태만 유지한다.
         commentService.deleteArtistPostComment(memberDetails, artistId, artistPostId, commentId);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/v2/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}")
+    public ResponseEntity<ApiResponse<ArtistPostCommentQueuedResponse>> deleteArtistPostCommentV2(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long artistPostId,
+            @PathVariable Long commentId
+    ) {
+        // ArtistPost 댓글 삭제의 실제 사용 경로는 이 v2다.
+        // 실제 delete/placeholder 전환은 consumer가 thread lock 안에서 수행한다.
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(
+                        commentService.queueDeleteArtistPostCommentV2(memberDetails, artistId, artistPostId, commentId)
+                ));
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/dto/response/ArtistPostCommentQueuedResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/dto/response/ArtistPostCommentQueuedResponse.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.artistcontent.comment.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ArtistPostCommentQueuedResponse(
+        String requestId,
+        String commandType,
+        Long artistPostId,
+        Long parentCommentId,
+        Long commentId,
+        LocalDateTime queuedAt
+) {
+    // v2 댓글 API는 worker 처리 전이라 CommentResponse를 바로 줄 수 없으므로 queued 메타정보만 반환한다.
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/dto/response/CommentResponse.java
@@ -15,6 +15,7 @@ public record CommentResponse(
         boolean fanMembershipSubscribed,
         boolean dmSubscribed,
         String content,
+        long likeCount,
         // 현재 정책상 대댓글 멘션은 최대 1명만 해석한다.
         CommentMentionResponse mentionedMember,
         int replyCount,
@@ -40,6 +41,7 @@ public record CommentResponse(
                 fanMembershipSubscribed,
                 dmSubscribed,
                 comment.getContent(),
+                comment.getLikeCount(),
                 mentionedMember,
                 replyCount,
                 replies,

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/entity/Comment.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/entity/Comment.java
@@ -14,6 +14,9 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @Table(
         name = "comments",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_comments_command_request_id", columnNames = "command_request_id")
+        },
         indexes = {
                 @Index(name = "idx_comments_target", columnList = "target_type, target_id, id"),
                 @Index(name = "idx_comments_parent", columnList = "parent_id, id")
@@ -54,22 +57,41 @@ public class Comment extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(nullable = false)
+    private long likeCount;
+
+    @Column(name = "command_request_id", length = 64)
+    private String commandRequestId;
+
     @Column(name = "deleted_placeholder", nullable = false)
     private boolean deletedPlaceholder;
 
-    private Comment(PostType targetType, Long targetId, Comment parent, int depth, Member writer, String content) {
+    private Comment(PostType targetType, Long targetId, Comment parent, int depth, Member writer, String content, String commandRequestId) {
         this.targetType = targetType;
         this.targetId = targetId;
         this.parent = parent;
         this.depth = depth;
         this.writer = writer;
         this.content = content;
+        this.likeCount = 0L;
+        this.commandRequestId = commandRequestId;
         this.deletedPlaceholder = false;
     }
 
     public static Comment create(PostType targetType, Long targetId, Member writer, String content, Comment parent) {
+        return create(targetType, targetId, writer, content, parent, null);
+    }
+
+    public static Comment create(
+            PostType targetType,
+            Long targetId,
+            Member writer,
+            String content,
+            Comment parent,
+            String commandRequestId
+    ) {
         // 원댓글은 depth 1, 대댓글은 depth 2로만 생성해 3-depth 이상이 들어오지 않게 서비스와 규칙을 맞춘다.
-        return new Comment(targetType, targetId, parent, parent == null ? 1 : 2, writer, content);
+        return new Comment(targetType, targetId, parent, parent == null ? 1 : 2, writer, content, commandRequestId);
     }
 
     public boolean isRootComment() {
@@ -83,6 +105,10 @@ public class Comment extends BaseEntity {
     public void markDeletedPlaceholder() {
         this.content = DELETED_PLACEHOLDER_CONTENT;
         this.deletedPlaceholder = true;
+    }
+
+    public void changeLikeCountBy(int delta) {
+        this.likeCount = Math.max(0L, this.likeCount + delta);
     }
 
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/error/CommentErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/error/CommentErrorCode.java
@@ -13,7 +13,8 @@ public enum CommentErrorCode implements ErrorCodeType {
     COMMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "C002", "해당 댓글을 수정 또는 삭제할 권한이 없습니다."),
     COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "C003", "댓글은 2뎁스까지만 작성할 수 있습니다."),
     INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "C004", "현재 게시글에 속한 원댓글만 부모로 지정할 수 있습니다."),
-    INVALID_MENTION_SCOPE(HttpStatus.BAD_REQUEST, "C005", "멘션은 부모 댓글과 같은 스레드의 닉네임만 사용할 수 있습니다.");
+    INVALID_MENTION_SCOPE(HttpStatus.BAD_REQUEST, "C005", "멘션은 부모 댓글과 같은 스레드의 닉네임만 사용할 수 있습니다."),
+    COMMENT_REQUEST_IN_PROGRESS(HttpStatus.CONFLICT, "C006", "댓글 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
@@ -3,6 +3,9 @@ package com.example.infinite.domain.artistcontent.comment.repository;
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +14,24 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     Optional<Comment> findByIdAndTargetTypeAndTargetId(Long commentId, PostType targetType, Long targetId);
 
+    Optional<Comment> findByCommandRequestId(String commandRequestId);
+
     List<Comment> findByParentIdOrderByIdAsc(Long parentId);
 
     boolean existsByParentId(Long parentId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Comment comment
+               set comment.likeCount =
+                   case
+                       when comment.likeCount + :delta < 0 then 0
+                       else comment.likeCount + :delta
+                   end
+             where comment.id = :commentId
+            """)
+    int changeLikeCountBy(@Param("commentId") Long commentId, @Param("delta") long delta);
+
+    @Query("select comment.likeCount from Comment comment where comment.id = :commentId")
+    Optional<Long> findLikeCountById(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
@@ -1,12 +1,15 @@
 package com.example.infinite.domain.artistcontent.comment.service;
 
 import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.ArtistPostCommentQueuedResponse;
 import com.example.infinite.domain.artistcontent.comment.dto.response.CommentMentionResponse;
 import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
 import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
 import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
+import com.example.infinite.domain.artistcontent.comment.service.fanpost.FanPostCommentRedissonService;
+import com.example.infinite.domain.artistcontent.comment.service.artistpoststream.ArtistPostCommentStreamV2Service;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
@@ -23,6 +26,7 @@ import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashSet;
@@ -47,15 +51,19 @@ public class CommentService {
     private final CommentMentionService commentMentionService;
     private final MemberReader memberReader;
     private final SubscriptionMembershipService subscriptionMembershipService;
+    private final FanPostCommentRedissonService fanPostCommentRedissonService;
+    private final ArtistPostCommentStreamV2Service artistPostCommentStreamV2Service;
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CommentResponse createFanPostComment(
             MemberDetailsImpl memberDetails,
             Long artistId,
             Long fanPostId,
             CommentCreateRequest request
     ) {
-        return createComment(memberDetails, artistId, fanPostId, request, PostType.FAN_POST);
+        // FanPost 댓글도 락 안에서 실제 write 트랜잭션이 열리게 해야
+        // "락은 풀렸지만 아직 커밋 전" 상태를 다른 요청이 다시 읽는 문제를 막을 수 있다.
+        return fanPostCommentRedissonService.create(memberDetails, artistId, fanPostId, request);
     }
 
     @Transactional
@@ -65,8 +73,22 @@ public class CommentService {
             Long artistPostId,
             CommentCreateRequest request
     ) {
-        // 아티스트 게시글 댓글도 같은 댓글 정책을 재사용하되 targetType만 다르게 태운다.
+        // legacy compatibility path.
+        // ArtistPost 댓글의 실사용 최신 경로는 queueArtistPostCommentV2이고,
+        // 이 동기 경로는 기존 형태를 깨지 않기 위해서만 남겨둔다.
         return createComment(memberDetails, artistId, artistPostId, request, PostType.ARTIST_POST);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public ArtistPostCommentQueuedResponse queueArtistPostCommentV2(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId,
+            CommentCreateRequest request
+    ) {
+        // ArtistPost 댓글의 실제 사용 경로.
+        // worker가 DB 반영을 맡는 비동기 계약이며, 최신 클라이언트는 이 경로만 사용한다.
+        return artistPostCommentStreamV2Service.queueCreate(memberDetails, artistId, artistPostId, request);
     }
 
     public CursorSliceResponse<CommentResponse> getFanPostComments(Long artistId, Long fanPostId, Long cursor) {
@@ -89,15 +111,14 @@ public class CommentService {
         return getReplies(PostType.ARTIST_POST, artistId, artistPostId, parentCommentId);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void deleteFanPostComment(
             MemberDetailsImpl memberDetails,
             Long artistId,
             Long fanPostId,
             Long commentId
     ) {
-        // 삭제 정책도 생성과 동일하게 공통 로직에 FAN_POST 타입만 주입한다.
-        deleteComment(memberDetails, artistId, fanPostId, commentId, PostType.FAN_POST);
+        fanPostCommentRedissonService.delete(memberDetails, artistId, fanPostId, commentId);
     }
 
     @Transactional
@@ -107,8 +128,21 @@ public class CommentService {
             Long artistPostId,
             Long commentId
     ) {
-        // 아티스트 게시글 댓글 삭제도 targetType 기반 공통 로직으로 처리한다.
+        // legacy compatibility path.
+        // ArtistPost 댓글 삭제의 실사용 최신 경로는 queueDeleteArtistPostCommentV2다.
         deleteComment(memberDetails, artistId, artistPostId, commentId, PostType.ARTIST_POST);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public ArtistPostCommentQueuedResponse queueDeleteArtistPostCommentV2(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId,
+            Long commentId
+    ) {
+        // ArtistPost 댓글 삭제의 실제 사용 경로.
+        // v2에서는 stream command 적재까지만 동기 처리한다.
+        return artistPostCommentStreamV2Service.queueDelete(memberDetails, artistId, artistPostId, commentId);
     }
 
     private CommentResponse createComment(

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCommandType.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCommandType.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+public enum ArtistPostCommentCommandType {
+    CREATE_ROOT,
+    CREATE_REPLY,
+    DELETE
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
@@ -1,0 +1,176 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
+import com.example.infinite.domain.artistcontent.comment.service.CommentMentionService;
+import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
+import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.support.MemberReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistPostCommentCoreService {
+
+    private final CommentRepository commentRepository;
+    private final CommentReader commentReader;
+    private final ArtistPostReader artistPostReader;
+    private final CommentMentionService commentMentionService;
+    private final MemberReader memberReader;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    /**
+     * 댓글 원본 create/delete 비즈니스만 담당한다.
+     *
+     * 락과 stream 소비는 바깥 레이어가 맡고,
+     * 여기서는 "DB에 댓글을 어떻게 기록/삭제할지"와 "count delta를 언제 발행할지"만 처리한다.
+     */
+    @Transactional
+    public void createRoot(ArtistPostCommentStreamCommand command) {
+        if (commentRepository.findByCommandRequestId(command.requestId()).isPresent()) {
+            // stream 재처리로 같은 requestId가 다시 들어와도 중복 댓글을 만들지 않기 위한 idempotency check다.
+            return;
+        }
+
+        artistPostReader.findByIdAndArtistIdOrThrow(command.artistPostId(), command.artistId());
+        Member member = memberReader.findByIdOrThrow(command.memberId());
+
+        Comment comment = commentRepository.save(Comment.create(
+                PostType.ARTIST_POST,
+                command.artistPostId(),
+                member,
+                command.content(),
+                null,
+                command.requestId()
+        ));
+        commentMentionService.syncMention(comment, null);
+        publishDelta(command.artistPostId(), 1L);
+    }
+
+    @Transactional
+    public void createReply(ArtistPostCommentStreamCommand command) {
+        if (commentRepository.findByCommandRequestId(command.requestId()).isPresent()) {
+            return;
+        }
+
+        artistPostReader.findByIdAndArtistIdOrThrow(command.artistPostId(), command.artistId());
+        Member member = memberReader.findByIdOrThrow(command.memberId());
+        Comment parentComment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(
+                command.parentCommentId(),
+                PostType.ARTIST_POST,
+                command.artistPostId()
+        );
+        if (!parentComment.isRootComment()) {
+            log.warn("ArtistPost comment reply skipped: parent is not root, requestId={}", command.requestId());
+            return;
+        }
+
+        String mentionNickname = resolveMentionNickname(command.content(), command.artistPostId(), parentComment);
+        Comment comment = commentRepository.save(Comment.create(
+                PostType.ARTIST_POST,
+                command.artistPostId(),
+                member,
+                command.content(),
+                parentComment,
+                command.requestId()
+        ));
+        commentMentionService.syncMention(comment, mentionNickname);
+        publishDelta(command.artistPostId(), 1L);
+    }
+
+    @Transactional
+    public void delete(ArtistPostCommentStreamCommand command) {
+        // delete는 idempotent하게 설계한다.
+        // 이미 삭제됐거나 찾을 수 없는 댓글이면 no-op로 끝내 stream 재시도에도 버티게 한다.
+        artistPostReader.findByIdAndArtistIdOrThrow(command.artistPostId(), command.artistId());
+        Comment comment = commentRepository.findByIdAndTargetTypeAndTargetId(
+                        command.commentId(),
+                        PostType.ARTIST_POST,
+                        command.artistPostId()
+                )
+                .orElse(null);
+        if (comment == null) {
+            return;
+        }
+        if (!comment.isOwnedBy(command.memberId())) {
+            log.warn("ArtistPost comment delete skipped: owner mismatch, commentId={}, memberId={}",
+                    command.commentId(), command.memberId());
+            return;
+        }
+        if (comment.isDeletedPlaceholder()) {
+            return;
+        }
+
+        commentMentionService.deleteMention(comment.getId());
+
+        if (comment.isRootComment()) {
+            if (!commentRepository.existsByParentId(comment.getId())) {
+                comment.delete();
+            } else {
+                comment.markDeletedPlaceholder();
+            }
+            publishDelta(command.artistPostId(), -1L);
+            return;
+        }
+
+        comment.delete();
+        publishDelta(command.artistPostId(), -1L);
+
+        Comment parentComment = comment.getParent();
+        if (parentComment != null && parentComment.isDeletedPlaceholder() && !commentRepository.existsByParentId(parentComment.getId())) {
+            parentComment.delete();
+        }
+    }
+
+    public Long resolveRootCommentIdForDelete(Long artistPostId, Long commentId) {
+        // 댓글 삭제 락 키는 root comment 기준이므로, reply 삭제도 먼저 root id를 계산해 thread lock을 맞춘다.
+        Comment comment = commentRepository.findByIdAndTargetTypeAndTargetId(commentId, PostType.ARTIST_POST, artistPostId)
+                .orElse(null);
+        if (comment == null) {
+            return null;
+        }
+        return comment.isRootComment() ? comment.getId() : comment.getParent().getId();
+    }
+
+    private void publishDelta(Long artistPostId, long delta) {
+        applicationEventPublisher.publishEvent(new ArtistPostCommentDeltaEvent(artistPostId, delta));
+    }
+
+    private String resolveMentionNickname(String content, Long targetId, Comment parentComment) {
+        // 기존 동기 댓글 정책과 동일하게 "같은 thread 참여자 중 첫 번째 유효 멘션 1건"만 해석한다.
+        List<String> mentionedNicknames = MentionParser.extractMentionedNicknames(content);
+        if (mentionedNicknames.isEmpty()) {
+            return null;
+        }
+
+        List<Comment> threadComments = commentRepository.findThreadCommentsByRootCommentId(
+                PostType.ARTIST_POST,
+                targetId,
+                parentComment.getId()
+        );
+        Set<String> allowedNicknames = threadComments.stream()
+                .map(comment -> comment.getWriter().getNickname())
+                .map(nickname -> nickname.strip().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return mentionedNicknames.stream()
+                .filter(allowedNicknames::contains)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCountFlushScheduler.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCountFlushScheduler.java
@@ -1,0 +1,48 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistPostCommentCountFlushScheduler {
+
+    private final ArtistPostCommentDeltaBuffer artistPostCommentDeltaBuffer;
+    private final ArtistPostRepository artistPostRepository;
+
+    /**
+     * 댓글 수 1차 반영 배치.
+     * 변경된 post만 반영하므로 자주 돌아도 전체 재집계보다 부담이 훨씬 낮다.
+     */
+    @Scheduled(fixedDelayString = "${artist-post.comment-count.flush-delay-ms:3000}")
+    @Transactional
+    public void flush() {
+        List<ArtistPostCommentDelta> deltas = artistPostCommentDeltaBuffer.drainAll();
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        for (ArtistPostCommentDelta delta : deltas) {
+            // commentCount는 요청 경로 대신 flush 배치가 주기적으로 반영한다.
+            artistPostRepository.changeCommentCountBy(delta.artistPostId(), delta.delta());
+        }
+    }
+
+    /**
+     * 댓글 수 2차 보정 배치.
+     * placeholder 규칙까지 포함한 실제 comments 원본 기준으로 comment_count를 다시 맞춘다.
+     */
+    @Scheduled(cron = "${artist-post.comment-count.reconcile-cron:0 10 4 * * *}")
+    @Transactional
+    public void reconcileAll() {
+        int updatedRows = artistPostRepository.reconcileAllCommentCounts();
+        log.info("ArtistPost commentCount full reconcile completed: updatedRows={}", updatedRows);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDelta.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDelta.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+public record ArtistPostCommentDelta(
+        Long artistPostId,
+        long delta
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaBuffer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaBuffer.java
@@ -1,0 +1,67 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostCommentDeltaBuffer {
+
+    private static final String ARTIST_POST_COMMENT_DELTA_KEY = "artist-post:comment:delta";
+    private static final DefaultRedisScript<Long> DRAIN_HASH_FIELD_SCRIPT;
+
+    static {
+        DRAIN_HASH_FIELD_SCRIPT = new DefaultRedisScript<>();
+        DRAIN_HASH_FIELD_SCRIPT.setScriptText("""
+                local current = redis.call('HGET', KEYS[1], ARGV[1])
+                if not current then
+                    return 0
+                end
+                redis.call('HDEL', KEYS[1], ARGV[1])
+                return tonumber(current)
+                """);
+        DRAIN_HASH_FIELD_SCRIPT.setResultType(Long.class);
+    }
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void accumulate(Long artistPostId, long delta) {
+        stringRedisTemplate.opsForHash().increment(
+                ARTIST_POST_COMMENT_DELTA_KEY,
+                artistPostId.toString(),
+                delta
+        );
+    }
+
+    public List<ArtistPostCommentDelta> drainAll() {
+        Set<Object> artistPostIds = stringRedisTemplate.opsForHash().keys(ARTIST_POST_COMMENT_DELTA_KEY);
+        if (artistPostIds == null || artistPostIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ArtistPostCommentDelta> deltas = new ArrayList<>();
+        for (Object artistPostIdField : artistPostIds) {
+            Long artistPostId = Long.valueOf(artistPostIdField.toString());
+            long delta = drainOne(artistPostId);
+            if (delta != 0L) {
+                deltas.add(new ArtistPostCommentDelta(artistPostId, delta));
+            }
+        }
+        return deltas;
+    }
+
+    private long drainOne(Long artistPostId) {
+        Long delta = stringRedisTemplate.execute(
+                DRAIN_HASH_FIELD_SCRIPT,
+                List.of(ARTIST_POST_COMMENT_DELTA_KEY),
+                artistPostId.toString()
+        );
+        return delta == null ? 0L : delta;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEvent.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEvent.java
@@ -1,0 +1,7 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+public record ArtistPostCommentDeltaEvent(
+        Long artistPostId,
+        long delta
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEventListener.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEventListener.java
@@ -1,0 +1,19 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostCommentDeltaEventListener {
+
+    private final ArtistPostCommentDeltaBuffer artistPostCommentDeltaBuffer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ArtistPostCommentDeltaEvent event) {
+        // 댓글 row 트랜잭션이 실제로 커밋된 뒤에만 commentCount delta를 누적한다.
+        artistPostCommentDeltaBuffer.accumulate(event.artistPostId(), event.delta());
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamCommand.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamCommand.java
@@ -1,0 +1,78 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record ArtistPostCommentStreamCommand(
+        String requestId,
+        ArtistPostCommentCommandType commandType,
+        Long artistId,
+        Long artistPostId,
+        Long memberId,
+        Long parentCommentId,
+        Long commentId,
+        String content,
+        String queuedAt
+) {
+    public static ArtistPostCommentStreamCommand create(
+            String requestId,
+            ArtistPostCommentCommandType commandType,
+            Long artistId,
+            Long artistPostId,
+            Long memberId,
+            Long parentCommentId,
+            Long commentId,
+            String content
+    ) {
+        return new ArtistPostCommentStreamCommand(
+                requestId,
+                commandType,
+                artistId,
+                artistPostId,
+                memberId,
+                parentCommentId,
+                commentId,
+                content,
+                Instant.now().toString()
+        );
+    }
+
+    public MapRecord<String, String, String> toRecord(String streamKey) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("requestId", requestId);
+        fields.put("commandType", commandType.name());
+        fields.put("artistId", artistId.toString());
+        fields.put("artistPostId", artistPostId.toString());
+        fields.put("memberId", memberId.toString());
+        fields.put("queuedAt", queuedAt);
+        if (parentCommentId != null) {
+            fields.put("parentCommentId", parentCommentId.toString());
+        }
+        if (commentId != null) {
+            fields.put("commentId", commentId.toString());
+        }
+        if (content != null) {
+            fields.put("content", content);
+        }
+        return StreamRecords.newRecord().in(streamKey).ofMap(fields);
+    }
+
+    public static ArtistPostCommentStreamCommand from(MapRecord<String, Object, Object> record) {
+        Map<Object, Object> fields = record.getValue();
+        return new ArtistPostCommentStreamCommand(
+                fields.get("requestId").toString(),
+                ArtistPostCommentCommandType.valueOf(fields.get("commandType").toString()),
+                Long.valueOf(fields.get("artistId").toString()),
+                Long.valueOf(fields.get("artistPostId").toString()),
+                Long.valueOf(fields.get("memberId").toString()),
+                fields.get("parentCommentId") == null ? null : Long.valueOf(fields.get("parentCommentId").toString()),
+                fields.get("commentId") == null ? null : Long.valueOf(fields.get("commentId").toString()),
+                fields.get("content") == null ? null : fields.get("content").toString(),
+                fields.get("queuedAt").toString()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamConsumer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamConsumer.java
@@ -1,0 +1,104 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistPostCommentStreamConsumer {
+
+    private static final String CONSUMER_NAME = "artist-post-comment-v2-consumer";
+    private static final int BATCH_SIZE = 100;
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ArtistPostCommentStreamProcessor processor;
+
+    /**
+     * 댓글 v2 consumer.
+     *
+     * 댓글은 좋아요보다 복잡해서 stream 소비 이후에도 root thread lock이 필요하다.
+     * 그래서 consumer는 command type에 따라
+     * - root create
+     * - reply create with thread lock
+     * - delete with thread lock
+     * 으로 분기한다.
+     */
+    @Scheduled(fixedDelayString = "${artist-post.comment-v2.consumer-delay-ms:300}")
+    public void consume() {
+        if (consumeRecords(readPendingRecords())) {
+            return;
+        }
+
+        consumeRecords(readNewRecords());
+    }
+
+    private List<MapRecord<String, Object, Object>> readPendingRecords() {
+        try {
+            return stringRedisTemplate.opsForStream().read(
+                    Consumer.from(ArtistPostCommentStreamProducer.CONSUMER_GROUP, CONSUMER_NAME),
+                    StreamReadOptions.empty().count(BATCH_SIZE),
+                    StreamOffset.create(ArtistPostCommentStreamProducer.STREAM_KEY, ReadOffset.from("0"))
+            );
+        } catch (Exception e) {
+            log.warn("ArtistPost comment pending stream read failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<MapRecord<String, Object, Object>> readNewRecords() {
+        try {
+            return stringRedisTemplate.opsForStream().read(
+                    Consumer.from(ArtistPostCommentStreamProducer.CONSUMER_GROUP, CONSUMER_NAME),
+                    StreamReadOptions.empty().count(BATCH_SIZE).block(Duration.ofMillis(100)),
+                    StreamOffset.create(ArtistPostCommentStreamProducer.STREAM_KEY, ReadOffset.lastConsumed())
+            );
+        } catch (Exception e) {
+            log.warn("ArtistPost comment stream read failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private boolean consumeRecords(List<MapRecord<String, Object, Object>> records) {
+        if (records == null || records.isEmpty()) {
+            return false;
+        }
+
+        for (MapRecord<String, Object, Object> record : records) {
+            Map<Object, Object> fields = record.getValue();
+            if (fields.containsKey("__bootstrap__")) {
+                acknowledge(record);
+                continue;
+            }
+
+            try {
+                processor.process(ArtistPostCommentStreamCommand.from(record));
+                acknowledge(record);
+            } catch (Exception e) {
+                log.error("ArtistPost comment stream process failed: recordId={}, error={}", record.getId(), e.getMessage(), e);
+            }
+        }
+
+        return true;
+    }
+
+    private void acknowledge(MapRecord<String, Object, Object> record) {
+        stringRedisTemplate.opsForStream().acknowledge(
+                ArtistPostCommentStreamProducer.STREAM_KEY,
+                ArtistPostCommentStreamProducer.CONSUMER_GROUP,
+                record.getId()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProcessor.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProcessor.java
@@ -1,0 +1,37 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostCommentStreamProcessor {
+
+    private final ArtistPostCommentCoreService artistPostCommentCoreService;
+    private final ArtistPostCommentThreadLockedService artistPostCommentThreadLockedService;
+
+    /**
+     * 댓글 command type에 따라 어떤 처리 경로를 탈지 결정하는 dispatcher다.
+     *
+     * 규칙:
+     * - root create: 락 불필요
+     * - reply create: root thread lock 필요
+     * - delete: 대상 comment가 root인지 reply인지 확인 후 root thread lock 필요
+     */
+    public void process(ArtistPostCommentStreamCommand command) {
+        switch (command.commandType()) {
+            case CREATE_ROOT -> artistPostCommentCoreService.createRoot(command);
+            case CREATE_REPLY -> artistPostCommentThreadLockedService.createReplyWithLock(command, command.parentCommentId());
+            case DELETE -> {
+                Long rootCommentId = artistPostCommentCoreService.resolveRootCommentIdForDelete(
+                        command.artistPostId(),
+                        command.commentId()
+                );
+                if (rootCommentId == null) {
+                    return;
+                }
+                artistPostCommentThreadLockedService.deleteWithLock(command, rootCommentId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProducer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProducer.java
@@ -1,0 +1,23 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import com.example.infinite.global.common.redis.RedisStreamGroupHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostCommentStreamProducer {
+
+    public static final String STREAM_KEY = "artist-post:comment:v2:commands";
+    public static final String CONSUMER_GROUP = "artist-post-comment-v2-group";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisStreamGroupHelper redisStreamGroupHelper;
+
+    public void enqueue(ArtistPostCommentStreamCommand command) {
+        // 댓글 v2도 좋아요 v3와 같은 패턴으로 "HTTP 요청 수신"과 "DB 댓글 쓰기"를 분리한다.
+        redisStreamGroupHelper.ensureGroup(STREAM_KEY, CONSUMER_GROUP);
+        stringRedisTemplate.opsForStream().add(command.toRecord(STREAM_KEY));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamV2Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamV2Service.java
@@ -1,0 +1,120 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.ArtistPostCommentQueuedResponse;
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
+import com.example.infinite.domain.artistcontent.comment.error.CommentException;
+import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.support.MemberInputSupport;
+import com.example.infinite.domain.member.member.support.MemberReader;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostCommentStreamV2Service {
+
+    private final MemberReader memberReader;
+    private final ArtistPostReader artistPostReader;
+    private final CommentReader commentReader;
+    private final ArtistPostCommentStreamProducer streamProducer;
+
+    /**
+     * 댓글 생성 요청을 stream에 적재한다.
+     *
+     * producer 단계에서는 "완전히 틀린 요청"만 빠르게 걸러내고,
+     * 최종 상태 검증과 실제 DB 쓰기는 consumer가 담당한다.
+     */
+    public ArtistPostCommentQueuedResponse queueCreate(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId,
+            CommentCreateRequest request
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
+
+        ArtistPostCommentCommandType commandType = request.parentId() == null
+                ? ArtistPostCommentCommandType.CREATE_ROOT
+                : ArtistPostCommentCommandType.CREATE_REPLY;
+
+        if (request.parentId() != null) {
+            Comment parentComment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(
+                    request.parentId(),
+                    PostType.ARTIST_POST,
+                    artistPostId
+            );
+            if (!parentComment.isRootComment()) {
+                throw new CommentException(CommentErrorCode.COMMENT_DEPTH_EXCEEDED);
+            }
+        }
+
+        String requestId = UUID.randomUUID().toString();
+        streamProducer.enqueue(ArtistPostCommentStreamCommand.create(
+                requestId,
+                commandType,
+                artistId,
+                artistPostId,
+                member.getId(),
+                request.parentId(),
+                null,
+                request.content()
+        ));
+
+        return new ArtistPostCommentQueuedResponse(
+                requestId,
+                commandType.name(),
+                artistPostId,
+                request.parentId(),
+                null,
+                LocalDateTime.now()
+        );
+    }
+
+    /**
+     * 삭제도 즉시 DB에서 지우지 않고 delete command를 stream에 적재한다.
+     * 응답은 202 Accepted이며, 실제 삭제/placeholder 전환은 worker가 처리한다.
+     */
+    public ArtistPostCommentQueuedResponse queueDelete(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId,
+            Long commentId
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
+        Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, PostType.ARTIST_POST, artistPostId);
+        if (!comment.isOwnedBy(member.getId())) {
+            throw new CommentException(CommentErrorCode.COMMENT_PERMISSION_DENIED);
+        }
+
+        String requestId = UUID.randomUUID().toString();
+        streamProducer.enqueue(ArtistPostCommentStreamCommand.create(
+                requestId,
+                ArtistPostCommentCommandType.DELETE,
+                artistId,
+                artistPostId,
+                member.getId(),
+                null,
+                commentId,
+                null
+        ));
+
+        return new ArtistPostCommentQueuedResponse(
+                requestId,
+                ArtistPostCommentCommandType.DELETE.name(),
+                artistPostId,
+                null,
+                commentId,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentThreadLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentThreadLockedService.java
@@ -1,0 +1,40 @@
+package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
+
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostCommentThreadLockedService {
+
+    private final ArtistPostCommentCoreService artistPostCommentCoreService;
+
+    /**
+     * 댓글에서 락이 필요한 지점은 post 전체가 아니라 root thread다.
+     * 서로 다른 루트 댓글 스레드는 병렬 허용하고, 같은 스레드 안의 생성/삭제 충돌만 직렬화한다.
+     */
+    @RedisLock(
+            key = "'artist-post:comment-thread:' + #rootCommentId",
+            waitTime = 1,
+            leaseTime = 5,
+            timeUnit = TimeUnit.SECONDS
+    )
+    public void createReplyWithLock(ArtistPostCommentStreamCommand command, Long rootCommentId) {
+        // 대댓글 생성은 같은 스레드 안의 삭제/placeholder 처리와 충돌할 수 있어 root thread 단위로 잠근다.
+        artistPostCommentCoreService.createReply(command);
+    }
+
+    @RedisLock(
+            key = "'artist-post:comment-thread:' + #rootCommentId",
+            waitTime = 1,
+            leaseTime = 5,
+            timeUnit = TimeUnit.SECONDS
+    )
+    public void deleteWithLock(ArtistPostCommentStreamCommand command, Long rootCommentId) {
+        // 삭제도 root thread 단위로 직렬화해야 자식 존재 여부 판단과 placeholder 정리가 꼬이지 않는다.
+        artistPostCommentCoreService.delete(command);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
@@ -1,0 +1,157 @@
+package com.example.infinite.domain.artistcontent.comment.service.fanpost;
+
+import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentMentionResponse;
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
+import com.example.infinite.domain.artistcontent.comment.error.CommentException;
+import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
+import com.example.infinite.domain.artistcontent.comment.service.CommentMentionService;
+import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
+import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
+import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.support.MemberInputSupport;
+import com.example.infinite.domain.member.member.support.MemberReader;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
+import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FanPostCommentCoreService {
+
+    private final CommentRepository commentRepository;
+    private final CommentReader commentReader;
+    private final FanPostReader fanPostReader;
+    private final FanPostRepository fanPostRepository;
+    private final CommentMentionService commentMentionService;
+    private final MemberReader memberReader;
+    private final SubscriptionMembershipService subscriptionMembershipService;
+
+    /**
+     * FanPost 댓글은 기존 동기 계약을 유지하되, count 갱신은 atomic update로 바꾼다.
+     * 락은 reply 생성/삭제처럼 thread 충돌이 있는 지점에서만 바깥 서비스가 담당한다.
+     */
+    @Transactional
+    public CommentResponse create(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId, CommentCreateRequest request) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
+
+        Comment parentComment = resolveParentComment(request.parentId(), fanPostId);
+        String mentionNickname = resolveMentionNickname(request.content(), fanPostId, parentComment);
+
+        Comment comment = commentRepository.save(Comment.create(
+                PostType.FAN_POST,
+                fanPostId,
+                member,
+                request.content(),
+                parentComment
+        ));
+        fanPostRepository.changeCommentCountBy(fanPostId, 1L);
+
+        CommentMentionResponse mentionedMember = commentMentionService.syncMention(comment, mentionNickname);
+        WriterSubscriptionBadge writerBadge = loadSingleWriterBadge(artistId, member.getId());
+        return CommentResponse.from(
+                comment,
+                writerBadge.fanMembershipSubscribed(),
+                writerBadge.dmSubscribed(),
+                mentionedMember
+        );
+    }
+
+    @Transactional
+    public void delete(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId, Long commentId) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
+        Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, PostType.FAN_POST, fanPostId);
+
+        if (!comment.isOwnedBy(member.getId())) {
+            throw new CommentException(CommentErrorCode.COMMENT_PERMISSION_DENIED);
+        }
+        if (comment.isDeletedPlaceholder()) {
+            return;
+        }
+
+        commentMentionService.deleteMention(comment.getId());
+
+        if (comment.isRootComment()) {
+            if (!commentRepository.existsByParentId(comment.getId())) {
+                comment.delete();
+            } else {
+                comment.markDeletedPlaceholder();
+            }
+            fanPostRepository.changeCommentCountBy(fanPostId, -1L);
+            return;
+        }
+
+        comment.delete();
+        fanPostRepository.changeCommentCountBy(fanPostId, -1L);
+
+        Comment parentComment = comment.getParent();
+        if (parentComment != null && parentComment.isDeletedPlaceholder() && !commentRepository.existsByParentId(parentComment.getId())) {
+            parentComment.delete();
+        }
+    }
+
+    public Long resolveRootCommentId(Long fanPostId, Long commentId) {
+        Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, PostType.FAN_POST, fanPostId);
+        return comment.isRootComment() ? comment.getId() : comment.getParent().getId();
+    }
+
+    public Long resolveReplyRootCommentId(Long fanPostId, Long parentCommentId) {
+        return resolveParentComment(parentCommentId, fanPostId).getId();
+    }
+
+    private Comment resolveParentComment(Long parentId, Long fanPostId) {
+        if (parentId == null) {
+            return null;
+        }
+
+        Comment parentComment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(parentId, PostType.FAN_POST, fanPostId);
+        if (!parentComment.isRootComment()) {
+            throw new CommentException(CommentErrorCode.COMMENT_DEPTH_EXCEEDED);
+        }
+        return parentComment;
+    }
+
+    private String resolveMentionNickname(String content, Long fanPostId, Comment parentComment) {
+        List<String> mentionedNicknames = MentionParser.extractMentionedNicknames(content);
+        if (mentionedNicknames.isEmpty() || parentComment == null) {
+            return null;
+        }
+
+        List<Comment> threadComments = commentRepository.findThreadCommentsByRootCommentId(
+                PostType.FAN_POST,
+                fanPostId,
+                parentComment.getId()
+        );
+        Set<String> allowedNicknames = threadComments.stream()
+                .map(comment -> comment.getWriter().getNickname())
+                .map(nickname -> nickname.strip().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        return mentionedNicknames.stream()
+                .filter(allowedNicknames::contains)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private WriterSubscriptionBadge loadSingleWriterBadge(Long artistId, Long writerId) {
+        return subscriptionMembershipService.getWriterBadges(artistId, List.of(writerId))
+                .getOrDefault(writerId, WriterSubscriptionBadge.empty(writerId));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonLockedService.java
@@ -1,0 +1,49 @@
+package com.example.infinite.domain.artistcontent.comment.service.fanpost;
+
+import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class FanPostCommentRedissonLockedService {
+
+    private final FanPostCommentCoreService fanPostCommentCoreService;
+
+    @RedisLock(
+            key = "'fan-post:comment-thread:' + #rootCommentId",
+            waitTime = 1,
+            leaseTime = 5,
+            timeUnit = TimeUnit.SECONDS
+    )
+    public CommentResponse createReplyWithLock(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long fanPostId,
+            CommentCreateRequest request,
+            Long rootCommentId
+    ) {
+        return fanPostCommentCoreService.create(memberDetails, artistId, fanPostId, request);
+    }
+
+    @RedisLock(
+            key = "'fan-post:comment-thread:' + #rootCommentId",
+            waitTime = 1,
+            leaseTime = 5,
+            timeUnit = TimeUnit.SECONDS
+    )
+    public void deleteWithLock(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long fanPostId,
+            Long commentId,
+            Long rootCommentId
+    ) {
+        fanPostCommentCoreService.delete(memberDetails, artistId, fanPostId, commentId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonService.java
@@ -1,0 +1,58 @@
+package com.example.infinite.domain.artistcontent.comment.service.fanpost;
+
+import com.example.infinite.domain.artistcontent.comment.dto.request.CommentCreateRequest;
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
+import com.example.infinite.domain.artistcontent.comment.error.CommentException;
+import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FanPostCommentRedissonService {
+
+    private final FanPostCommentCoreService fanPostCommentCoreService;
+    private final FanPostCommentRedissonLockedService fanPostCommentRedissonLockedService;
+
+    /**
+     * FanPost 댓글은 기존 v1 동기 API 계약을 유지한다.
+     * 다만 reply 생성/삭제처럼 같은 root thread에서 충돌 가능한 구간만 Redisson 락으로 감싼다.
+     */
+    public CommentResponse create(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId, CommentCreateRequest request) {
+        if (request.parentId() == null) {
+            // root comment는 post 전체 락 없이도 병렬 생성 가능하다.
+            return fanPostCommentCoreService.create(memberDetails, artistId, fanPostId, request);
+        }
+
+        Long rootCommentId = fanPostCommentCoreService.resolveReplyRootCommentId(fanPostId, request.parentId());
+        try {
+            return fanPostCommentRedissonLockedService.createReplyWithLock(
+                    memberDetails,
+                    artistId,
+                    fanPostId,
+                    request,
+                    rootCommentId
+            );
+        } catch (LockException e) {
+            throw new CommentException(CommentErrorCode.COMMENT_REQUEST_IN_PROGRESS);
+        }
+    }
+
+    public void delete(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId, Long commentId) {
+        // root/reply 삭제 모두 최종적으로는 rootComment thread 하나에 영향을 주므로 같은 락 키로 정렬한다.
+        Long rootCommentId = fanPostCommentCoreService.resolveRootCommentId(fanPostId, commentId);
+        try {
+            fanPostCommentRedissonLockedService.deleteWithLock(
+                    memberDetails,
+                    artistId,
+                    fanPostId,
+                    commentId,
+                    rootCommentId
+            );
+        } catch (LockException e) {
+            throw new CommentException(CommentErrorCode.COMMENT_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/hashtag/service/HashtagService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/hashtag/service/HashtagService.java
@@ -83,20 +83,17 @@ public class HashtagService {
         if (targetIds == null || targetIds.isEmpty()) {
             return Map.of();
         }
-
         // targetId 묶음 IN 조회 한 번으로 여러 게시글의 해시태그 이름을 배치 로딩한다.
         List<ContentHashtag> contentHashtags = contentHashtagRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscIdAsc(
                 targetType,
                 targetIds
         );
-
         // 서비스 응답 조립에서 바로 쓸 수 있도록 targetId -> hashtagNames 구조로 메모리 그룹핑한다.
         Map<Long, List<ContentHashtag>> groupedByTargetId = new LinkedHashMap<>();
         for (ContentHashtag contentHashtag : contentHashtags) {
             groupedByTargetId.computeIfAbsent(contentHashtag.getTargetId(), key -> new java.util.ArrayList<>())
                     .add(contentHashtag);
         }
-
         Map<Long, List<String>> result = new LinkedHashMap<>();
         for (Long targetId : targetIds) {
             // 입력 순서를 유지해 feed/detail 응답 조립 순서와 어긋나지 않게 한다.

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/controller/InteractionController.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/controller/InteractionController.java
@@ -1,10 +1,12 @@
 package com.example.infinite.domain.artistcontent.interaction.controller;
 
 import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.dto.response.ArtistPostLikeQueuedResponse;
 import com.example.infinite.domain.artistcontent.interaction.service.InteractionService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,6 +42,45 @@ public class InteractionController {
         // ArtistPost도 FanPost와 같은 toggle 계약을 사용해 프론트가 동일한 좋아요 버튼 로직을 재사용하게 한다.
         return ResponseEntity.ok(ApiResponse.success(
                 interactionService.toggleArtistPostLike(memberDetails, artistId, artistPostId)
+        ));
+    }
+
+    @PostMapping("/v3/artists/{artistId}/artist-posts/{artistPostId}/likes/toggle")
+    public ResponseEntity<ApiResponse<ArtistPostLikeQueuedResponse>> toggleArtistPostLikeV3(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long artistPostId
+    ) {
+        // v3는 "요청 즉시 DB 반영" 대신 "명령 enqueue 후 비동기 처리" 계약이다.
+        // 그래서 200 OK가 아니라 202 Accepted를 반환해 아직 worker 처리 전임을 명확히 한다.
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(
+                        interactionService.queueArtistPostLikeV3(memberDetails, artistId, artistPostId)
+                ));
+    }
+
+    @PostMapping("/v1/artists/{artistId}/fan-posts/{fanPostId}/comments/{commentId}/likes/toggle")
+    public ResponseEntity<ApiResponse<InteractionResponse>> toggleFanPostCommentLike(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long fanPostId,
+            @PathVariable Long commentId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                interactionService.toggleFanPostCommentLike(memberDetails, artistId, fanPostId, commentId)
+        ));
+    }
+
+    @PostMapping("/v1/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}/likes/toggle")
+    public ResponseEntity<ApiResponse<InteractionResponse>> toggleArtistPostCommentLike(
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
+            @PathVariable Long artistId,
+            @PathVariable Long artistPostId,
+            @PathVariable Long commentId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                interactionService.toggleArtistPostCommentLike(memberDetails, artistId, artistPostId, commentId)
         ));
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/dto/response/ArtistPostLikeQueuedResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/dto/response/ArtistPostLikeQueuedResponse.java
@@ -1,0 +1,12 @@
+package com.example.infinite.domain.artistcontent.interaction.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ArtistPostLikeQueuedResponse(
+        String requestId,
+        Long artistPostId,
+        boolean expectedReacted,
+        LocalDateTime queuedAt
+) {
+    // queued 응답은 "지금 DB에 반영된 최종 상태"가 아니라 "요청자가 의도한 다음 상태"를 알려준다.
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/error/InteractionErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/error/InteractionErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum InteractionErrorCode implements ErrorCodeType {
 
     COMMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "B003", "댓글 작성 권한이 없는 유저입니다."),
-    REACTION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "B004", "이미 리액션을 표시한 게시물입니다.");
+    REACTION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "B004", "이미 리액션을 표시한 게시물입니다."),
+    LIKE_REQUEST_IN_PROGRESS(HttpStatus.CONFLICT, "B005", "좋아요 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
@@ -1,12 +1,18 @@
 package com.example.infinite.domain.artistcontent.interaction.service;
 
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
+import com.example.infinite.domain.artistcontent.interaction.dto.response.ArtistPostLikeQueuedResponse;
 import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
 import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
-import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.service.commentlike.CommentLikeRedissonService;
 import com.example.infinite.domain.artistcontent.post.eunms.PostType;
-import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
+import com.example.infinite.domain.artistcontent.interaction.service.fanletterlike.FanLetterLikeRedissonService;
+import com.example.infinite.domain.artistcontent.interaction.service.fanpostlike.FanPostLikeRedissonService;
+import com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.ArtistPostLikeRedissonV2Service;
+import com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream.ArtistPostLikeStreamV3Service;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
@@ -18,6 +24,7 @@ import com.example.infinite.domain.member.member.support.MemberReader;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -29,109 +36,86 @@ public class InteractionService {
     private final FanPostReader fanPostReader;
     private final ArtistPostReader artistPostReader;
     private final FanLetterReader fanLetterReader;
+    private final CommentReader commentReader;
     private final MemberReader memberReader;
+    private final FanPostLikeRedissonService fanPostLikeRedissonService;
+    private final FanLetterLikeRedissonService fanLetterLikeRedissonService;
+    private final ArtistPostLikeRedissonV2Service artistPostLikeRedissonV2Service;
+    private final ArtistPostLikeStreamV3Service artistPostLikeStreamV3Service;
+    private final CommentLikeRedissonService commentLikeRedissonService;
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public InteractionResponse toggleFanPostLike(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId) {
-        // 좋아요 토글은 로그인 principal을 Member로 확정한 뒤 대상 팬포스트를 조회한다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
-        FanPost fanPost = fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
-
-        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
-                        PostType.FAN_POST,
-                        fanPostId,
-                        member.getId(),
-                        ReactionType.LIKE
-                )
-                .map(existingReaction -> cancelLike(existingReaction, fanPost))
-                .orElseGet(() -> addLike(member.getId(), fanPost));
+        // 여기서 outer transaction을 열어두면 "락 해제 후 커밋" 순서가 되어
+        // 같은 member-target 요청이 미커밋 상태를 다시 읽는 레이스가 생길 수 있다.
+        // 그래서 진입점은 비트랜잭션으로 두고, 락 안쪽 core service가 실제 write 트랜잭션을 시작한다.
+        return fanPostLikeRedissonService.toggle(member.getId(), artistId, fanPostId);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public InteractionResponse toggleArtistPostLike(MemberDetailsImpl memberDetails, Long artistId, Long artistPostId) {
-        // 아티스트 게시글 좋아요도 공통 reaction 테이블을 재사용하고 targetType만 ARTIST_POST로 구분한다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
-        ArtistPost artistPost = artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
-
-        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
-                        PostType.ARTIST_POST,
-                        artistPostId,
-                        member.getId(),
-                        ReactionType.LIKE
-                )
-                .map(existingReaction -> cancelLike(existingReaction, artistPost))
-                .orElseGet(() -> addLike(member.getId(), artistPost));
+        // ArtistPost 좋아요는 다른 좋아요와 달리 고트래픽 후보라서 별도 서비스로 분리했다.
+        // 실제 운영 경로는 Redisson 기반 V2를 사용하고, Lettuce V1은 비교/과제 설명용 구현으로만 남긴다.
+        //
+        // 이렇게 분리한 이유:
+        // 1) InteractionService 안에서 락, 토글, delta 집계까지 모두 처리하면 책임이 너무 커진다.
+        // 2) Redisson AOP 락은 별도 빈을 통해 호출해야 정상 적용된다(self-invocation 회피).
+        // 3) 나중에 V1/Lettuce와 V2/Redisson을 비교 설명하기도 쉬워진다.
+        return artistPostLikeRedissonV2Service.toggle(member.getId(), artistId, artistPostId);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public ArtistPostLikeQueuedResponse queueArtistPostLikeV3(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        // V3는 stream 기반 비동기 처리 진입점이다. 실사용 동기 경로(V2)와 계약이 다르므로 메서드를 분리한다.
+        return artistPostLikeStreamV3Service.queue(member.getId(), artistId, artistPostId);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public InteractionResponse toggleFanLetterLike(MemberDetailsImpl memberDetails, Long artistId, Long fanLetterId) {
-        // 팬레터도 fan post 와 같은 reaction 테이블을 재사용한다.
-        // 차이는 targetType=FAN_LETTER 로 저장하고, likeCount 반영 대상이 FanLetter 라는 점뿐이다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
-        FanLetter fanLetter = fanLetterReader.findByIdAndArtistIdOrThrow(fanLetterId, artistId);
-
-        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
-                        PostType.FAN_LETTER,
-                        fanLetterId,
-                        member.getId(),
-                        ReactionType.LIKE
-                )
-                .map(existingReaction -> cancelLike(existingReaction, fanLetter))
-                .orElseGet(() -> addLike(member.getId(), fanLetter));
+        return fanLetterLikeRedissonService.toggle(member.getId(), artistId, fanLetterId);
     }
 
-    private InteractionResponse addLike(Long memberId, FanPost fanPost) {
-        // 반응 저장과 비정규화 likeCount 증감을 한 트랜잭션 안에서 같이 처리한다.
-        interactionRepository.save(Reaction.create(
-                PostType.FAN_POST,
-                fanPost.getId(),
-                memberId,
-                ReactionType.LIKE
-        ));
-        fanPost.changeLikeCountBy(1);
-        return InteractionResponse.of(fanPost.getId(), true, fanPost.getLikeCount());
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public InteractionResponse toggleFanPostCommentLike(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long fanPostId,
+            Long commentId
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        // 댓글 좋아요도 이제 member + comment 단위 Redisson 락 안에서 처리한다.
+        // 그렇지 않으면 같은 댓글에 대한 연타나 동시 요청에서 Reaction/likeCount 정합성이 깨질 수 있다.
+        return commentLikeRedissonService.toggle(
+                member.getId(),
+                artistId,
+                fanPostId,
+                commentId,
+                PostType.FAN_POST
+        );
     }
 
-    private InteractionResponse cancelLike(Reaction existingReaction, FanPost fanPost) {
-        // 토글 해제는 기존 반응 삭제 후 likeCount를 내려 조회 응답과 일치시킨다.
-        interactionRepository.delete(existingReaction);
-        fanPost.changeLikeCountBy(-1);
-        return InteractionResponse.of(fanPost.getId(), false, fanPost.getLikeCount());
-    }
-
-    private InteractionResponse addLike(Long memberId, ArtistPost artistPost) {
-        interactionRepository.save(Reaction.create(
-                PostType.ARTIST_POST,
-                artistPost.getId(),
-                memberId,
-                ReactionType.LIKE
-        ));
-        artistPost.changeLikeCountBy(1);
-        return InteractionResponse.of(artistPost.getId(), true, artistPost.getLikeCount());
-    }
-
-    private InteractionResponse cancelLike(Reaction existingReaction, ArtistPost artistPost) {
-        interactionRepository.delete(existingReaction);
-        artistPost.changeLikeCountBy(-1);
-        return InteractionResponse.of(artistPost.getId(), false, artistPost.getLikeCount());
-    }
-
-    private InteractionResponse addLike(Long memberId, FanLetter fanLetter) {
-        // special-like 표시는 별도 플래그를 저장하지 않고,
-        // 나중에 "좋아요를 누른 사람이 아티스트 소속 멤버인가"를 조회 단계에서 해석한다.
-        interactionRepository.save(Reaction.create(
-                PostType.FAN_LETTER,
-                fanLetter.getId(),
-                memberId,
-                ReactionType.LIKE
-        ));
-        fanLetter.changeLikeCountBy(1);
-        return InteractionResponse.of(fanLetter.getId(), true, fanLetter.getLikeCount());
-    }
-
-    private InteractionResponse cancelLike(Reaction existingReaction, FanLetter fanLetter) {
-        interactionRepository.delete(existingReaction);
-        fanLetter.changeLikeCountBy(-1);
-        return InteractionResponse.of(fanLetter.getId(), false, fanLetter.getLikeCount());
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public InteractionResponse toggleArtistPostCommentLike(
+            MemberDetailsImpl memberDetails,
+            Long artistId,
+            Long artistPostId,
+            Long commentId
+    ) {
+        Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
+        return commentLikeRedissonService.toggle(
+                member.getId(),
+                artistId,
+                artistPostId,
+                commentId,
+                PostType.ARTIST_POST
+        );
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeCoreService.java
@@ -1,0 +1,90 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
+import com.example.infinite.domain.artistcontent.post.artistpost.service.likecount.ArtistPostLikeDeltaEvent;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistPostLikeCoreService {
+
+    private final InteractionRepository interactionRepository;
+    private final ArtistPostReader artistPostReader;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    /**
+     * ArtistPost 좋아요의 "핵심 비즈니스"만 담당한다.
+     *
+     * 이 서비스가 하는 일:
+     * - 대상 ArtistPost 검증
+     * - Reaction insert/delete
+     * - after-commit delta 이벤트 발행
+     *
+     * 이 서비스가 하지 않는 일:
+     * - 어떤 락 구현을 쓸지 결정
+     * - Lettuce/Redisson 같은 인프라 세부사항 처리
+     *
+     * 이렇게 분리한 이유는 락 전략(V1, V2)이 바뀌어도 실제 좋아요 비즈니스는
+     * 한 군데에서 유지되게 하려는 것이다.
+     */
+    @Transactional
+    public InteractionResponse toggle(Long memberId, Long artistId, Long artistPostId) {
+        ArtistPost artistPost = artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
+
+        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.ARTIST_POST,
+                        artistPostId,
+                        memberId,
+                        ReactionType.LIKE
+                )
+                .map(existingReaction -> cancelLike(existingReaction, artistPost))
+                .orElseGet(() -> addLike(memberId, artistPost));
+    }
+
+    private InteractionResponse addLike(Long memberId, ArtistPost artistPost) {
+        // "좋아요를 눌렀다"는 원본 사실은 Reaction 테이블에 즉시 저장한다.
+        // 반면 artist_posts.like_count는 파생 집계값이므로 여기서 직접 증가시키지 않는다.
+        //
+        // 이유:
+        // - 고트래픽 글에서는 like_count 한 row를 요청마다 갱신하면 row hotspot이 생긴다.
+        // - 원본과 집계값을 분리하면 "요청 처리 속도"와 "화면 집계값 정합성"을 따로 관리할 수 있다.
+        interactionRepository.save(Reaction.create(
+                PostType.ARTIST_POST,
+                artistPost.getId(),
+                memberId,
+                ReactionType.LIKE
+        ));
+        publishArtistPostLikeDelta(artistPost.getId(), 1L);
+        return InteractionResponse.of(artistPost.getId(), true, estimateArtistPostLikeCount(artistPost, 1L));
+    }
+
+    private InteractionResponse cancelLike(Reaction existingReaction, ArtistPost artistPost) {
+        // 좋아요 취소도 addLike와 동일한 원리다.
+        // 원본 Reaction만 즉시 지우고, likeCount 감소는 delta 이벤트로 넘긴다.
+        interactionRepository.delete(existingReaction);
+        publishArtistPostLikeDelta(artistPost.getId(), -1L);
+        return InteractionResponse.of(artistPost.getId(), false, estimateArtistPostLikeCount(artistPost, -1L));
+    }
+
+    private void publishArtistPostLikeDelta(Long artistPostId, long delta) {
+        // 이벤트는 "트랜잭션 안에서" 발행하지만,
+        // 실제 Redis 누적은 AFTER_COMMIT 리스너가 처리한다.
+        // 즉 DB 저장이 롤백되면 delta도 집계되지 않는다.
+        applicationEventPublisher.publishEvent(new ArtistPostLikeDeltaEvent(artistPostId, delta));
+    }
+
+    private long estimateArtistPostLikeCount(ArtistPost artistPost, long delta) {
+        // 응답은 사용자의 직전 토글 효과만 반영한 추정치로 반환하고, 최종 count는 flush/reconcile 배치가 맞춘다.
+        return Math.max(0L, artistPost.getLikeCount() + delta);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeLettuceV1Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeLettuceV1Service.java
@@ -1,0 +1,65 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.global.lock.LockException;
+import com.example.infinite.global.lock.lettuce.LettuceLockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeLettuceV1Service {
+
+    private static final long ARTIST_POST_LIKE_LOCK_WAIT_MS = 700L;
+    private static final long ARTIST_POST_LIKE_LOCK_LEASE_MS = 3_000L;
+
+    private final LettuceLockService lettuceLockService;
+    private final ArtistPostLikeCoreService artistPostLikeCoreService;
+
+    /**
+     * V1: Lettuce 기반 수동 락 버전.
+     *
+     * 현재 실사용 경로는 아니고, 아래 목적을 위해 유지한다.
+     * - 과제 발표에서 "Lettuce로 직접 락을 구현한 버전" 설명
+     * - Redisson V2와의 비교 기준
+     * - 필요 시 AOP 없이도 락을 명시적으로 제어하는 예시
+     *
+     * 락 범위를 memberId + artistPostId로 잡은 이유:
+     * - 같은 유저가 같은 글에 중복 토글하는 것만 직렬화하면 된다.
+     * - post 전체를 잠그면 인기 글에서 모든 요청이 일렬로 서서 병목이 된다.
+     */
+    public InteractionResponse toggle(Long memberId, Long artistId, Long artistPostId) {
+        String lockKey = buildLockKey(artistPostId, memberId);
+        boolean locked = false;
+
+        try {
+            // waitTime 동안 스핀락으로 재시도하고, leaseTime 동안만 락을 점유한다.
+            // 서버 장애나 예외로 unlock이 누락돼도 TTL이 지나면 자동 해제되게 한 구조다.
+            lettuceLockService.lock(
+                    lockKey,
+                    ARTIST_POST_LIKE_LOCK_WAIT_MS,
+                    ARTIST_POST_LIKE_LOCK_LEASE_MS,
+                    TimeUnit.MILLISECONDS
+            );
+            locked = true;
+            return artistPostLikeCoreService.toggle(memberId, artistId, artistPostId);
+        } catch (LockException e) {
+            // 락 대기 시간 안에 못 잡았으면 "처리 중" 에러로 빠르게 실패시킨다.
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        } finally {
+            if (locked) {
+                // 직접 락을 다루는 버전이라 성공한 경우에만 명시적으로 해제한다.
+                lettuceLockService.unlock(lockKey);
+            }
+        }
+    }
+
+    private String buildLockKey(Long artistPostId, Long memberId) {
+        // member + target 단위로 잘게 쪼개야 서로 다른 유저 요청은 병렬로 흘러간다.
+        return "artist-post:like:" + artistPostId + ":member:" + memberId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeRedissonV2LockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeRedissonV2LockedService.java
@@ -1,0 +1,38 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeRedissonV2LockedService {
+
+    private final ArtistPostLikeCoreService artistPostLikeCoreService;
+
+    /**
+     * V2 실사용 락 구간.
+     *
+     * 왜 별도 클래스로 분리했는가?
+     * - @RedisLock는 AOP 기반이라 "다른 스프링 빈을 통해" 호출돼야 적용된다.
+     * - 같은 클래스 내부 메서드 호출(self-invocation)로는 프록시를 거치지 않아 락이 안 걸릴 수 있다.
+     *
+     * 왜 키가 memberId + artistPostId 인가?
+     * - 같은 유저의 중복 토글만 직렬화하면 충분하다.
+     * - 유저 1만 명이 동시에 같은 글을 눌러도 락 키는 전부 달라 병렬 처리된다.
+     */
+    @RedisLock(
+            key = "'artist-post:like:' + #artistPostId + ':member:' + #memberId",
+            waitTime = 700,
+            leaseTime = 3000,
+            timeUnit = TimeUnit.MILLISECONDS
+    )
+    public InteractionResponse toggleWithLock(Long memberId, Long artistId, Long artistPostId) {
+        // 락을 잡은 상태에서만 core 비즈니스를 실행한다.
+        // 락 구현은 Redisson/AOP에 맡기고, 실제 토글 로직은 core service가 담당한다.
+        return artistPostLikeCoreService.toggle(memberId, artistId, artistPostId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeRedissonV2Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeRedissonV2Service.java
@@ -1,0 +1,33 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeRedissonV2Service {
+
+    private final ArtistPostLikeRedissonV2LockedService artistPostLikeRedissonV2LockedService;
+
+    /**
+     * V2 실사용 facade.
+     *
+     * 역할:
+     * - 실제 운영 경로에서 호출되는 진입점
+     * - Redisson 락 예외를 도메인 예외로 변환
+     *
+     * 락 구현 세부사항을 InteractionService가 몰라도 되게 하려고 한 겹 감싼다.
+     */
+    public InteractionResponse toggle(Long memberId, Long artistId, Long artistPostId) {
+        try {
+            return artistPostLikeRedissonV2LockedService.toggleWithLock(memberId, artistId, artistPostId);
+        } catch (LockException e) {
+            // 운영 레이어에서는 LockException 자체보다 "좋아요 처리 중"이라는 도메인 의미가 더 중요하다.
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikePendingStateRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikePendingStateRepository.java
@@ -1,0 +1,82 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikePendingStateRepository {
+
+    private static final Duration PENDING_STATE_TTL = Duration.ofMinutes(30);
+    private static final DefaultRedisScript<Long> CLEAR_IF_VERSION_MATCH_SCRIPT;
+
+    static {
+        CLEAR_IF_VERSION_MATCH_SCRIPT = new DefaultRedisScript<>();
+        CLEAR_IF_VERSION_MATCH_SCRIPT.setScriptText("""
+                if redis.call('get', KEYS[2]) == ARGV[1] then
+                    redis.call('del', KEYS[1])
+                    return 1
+                end
+                return 0
+                """);
+        CLEAR_IF_VERSION_MATCH_SCRIPT.setResultType(Long.class);
+    }
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * V3 요청 경로에서 아직 DB에 반영되지 않은 "유저의 최신 의도 상태"를 보관한다.
+     *
+     * 왜 필요한가:
+     * - V3는 좋아요를 stream에 넣고 나중에 consumer가 DB 반영한다
+     * - 따라서 같은 유저가 빠르게 두 번 누르면 DB 상태만 보고는 현재 토글 의도를 알 수 없다
+     * - pending state를 Redis에 두면 "소비되기 전 최신 상태"를 요청 경로에서 참고할 수 있다
+     */
+    public Optional<Boolean> findPendingDesiredState(Long artistPostId, Long memberId) {
+        String state = stringRedisTemplate.opsForValue().get(buildStateKey(artistPostId, memberId));
+        if (state == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Boolean.parseBoolean(state));
+    }
+
+    public long nextPendingVersion(Long artistPostId, Long memberId) {
+        // version은 "이 pending state가 몇 번째 요청까지 반영한 상태인지"를 구분하는 용도다.
+        // consumer가 오래된 명령을 처리할 때 더 최신 pending state를 잘못 지우지 않게 한다.
+        String versionKey = buildVersionKey(artistPostId, memberId);
+        Long nextVersion = stringRedisTemplate.opsForValue().increment(versionKey);
+        stringRedisTemplate.expire(versionKey, PENDING_STATE_TTL);
+        return nextVersion == null ? 1L : nextVersion;
+    }
+
+    public void savePendingDesiredState(Long artistPostId, Long memberId, boolean desiredReacted) {
+        stringRedisTemplate.opsForValue().set(
+                buildStateKey(artistPostId, memberId),
+                Boolean.toString(desiredReacted),
+                PENDING_STATE_TTL
+        );
+    }
+
+    public void clearPendingStateIfVersionMatches(Long artistPostId, Long memberId, long version) {
+        // 최신 요청이 이미 한 번 더 들어온 상태라면 version이 달라지므로 old consumer가 pending state를 지우지 못한다.
+        stringRedisTemplate.execute(
+                CLEAR_IF_VERSION_MATCH_SCRIPT,
+                List.of(buildStateKey(artistPostId, memberId), buildVersionKey(artistPostId, memberId)),
+                Long.toString(version)
+        );
+    }
+
+    private String buildStateKey(Long artistPostId, Long memberId) {
+        return "artist-post:like:pending:state:" + artistPostId + ":" + memberId;
+    }
+
+    private String buildVersionKey(Long artistPostId, Long memberId) {
+        return "artist-post:like:pending:version:" + artistPostId + ":" + memberId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeRedissonV3LockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeRedissonV3LockedService.java
@@ -1,0 +1,78 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.ArtistPostLikeQueuedResponse;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeRedissonV3LockedService {
+
+    private final ArtistPostReader artistPostReader;
+    private final InteractionRepository interactionRepository;
+    private final ArtistPostLikePendingStateRepository pendingStateRepository;
+    private final ArtistPostLikeStreamProducer streamProducer;
+
+    /**
+     * V3 요청 진입점.
+     *
+     * 흐름:
+     * 1. member + post 단위 락 획득
+     * 2. DB 상태 + pending state를 합쳐 "현재 유저의 실질 상태" 계산
+     * 3. desired state를 뒤집어 stream command 적재
+     * 4. 즉시 202 응답
+     *
+     * 락 범위를 member + post로 좁힌 이유는 V2와 동일하다.
+     * 인기 글 하나를 post 단위로 잠그면 1만 명 요청이 전부 직렬화되기 때문이다.
+     */
+    @RedisLock(
+            key = "'artist-post:like:v3:' + #artistPostId + ':member:' + #memberId",
+            waitTime = 700,
+            leaseTime = 3000,
+            timeUnit = TimeUnit.MILLISECONDS
+    )
+    public ArtistPostLikeQueuedResponse queueWithLock(Long memberId, Long artistId, Long artistPostId) {
+        // 같은 member-target 요청만 직렬화해 "현재 유저 의도 상태"를 안전하게 토글하고 stream에 적재한다.
+        artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
+
+        boolean effectiveReacted = pendingStateRepository.findPendingDesiredState(artistPostId, memberId)
+                .orElseGet(() -> interactionRepository.existsByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.ARTIST_POST,
+                        artistPostId,
+                        memberId,
+                        ReactionType.LIKE
+                ));
+        boolean desiredReacted = !effectiveReacted;
+        // pending state는 stream consumer가 DB 반영을 끝낼 때까지 요청 경로가 참고하는 "가상 최신 상태"다.
+        long pendingVersion = pendingStateRepository.nextPendingVersion(artistPostId, memberId);
+        String requestId = UUID.randomUUID().toString();
+        pendingStateRepository.savePendingDesiredState(artistPostId, memberId, desiredReacted);
+
+        try {
+            streamProducer.enqueue(ArtistPostLikeStreamCommand.create(
+                    requestId,
+                    artistId,
+                    artistPostId,
+                    memberId,
+                    desiredReacted,
+                    pendingVersion
+            ));
+        } catch (RuntimeException e) {
+            // pending state를 먼저 저장하는 구조라 enqueue 실패 시 정리를 해주지 않으면
+            // 실제 DB에는 반영되지 않았는데도 다음 요청이 "가상 최신 상태"를 계속 바라보게 된다.
+            pendingStateRepository.clearPendingStateIfVersionMatches(artistPostId, memberId, pendingVersion);
+            throw e;
+        }
+
+        return new ArtistPostLikeQueuedResponse(requestId, artistPostId, desiredReacted, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamCommand.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamCommand.java
@@ -1,0 +1,63 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ArtistPostLikeStreamCommand(
+        String requestId,
+        Long artistId,
+        Long artistPostId,
+        Long memberId,
+        boolean desiredReacted,
+        long pendingVersion,
+        String queuedAt
+) {
+    public static ArtistPostLikeStreamCommand create(
+            String requestId,
+            Long artistId,
+            Long artistPostId,
+            Long memberId,
+            boolean desiredReacted,
+            long pendingVersion
+    ) {
+        return new ArtistPostLikeStreamCommand(
+                requestId,
+                artistId,
+                artistPostId,
+                memberId,
+                desiredReacted,
+                pendingVersion,
+                Instant.now().toString()
+        );
+    }
+
+    public MapRecord<String, String, String> toRecord(String streamKey) {
+        return StreamRecords.newRecord()
+                .in(streamKey)
+                .ofMap(Map.of(
+                        "requestId", requestId,
+                        "artistId", artistId.toString(),
+                        "artistPostId", artistPostId.toString(),
+                        "memberId", memberId.toString(),
+                        "desiredReacted", Boolean.toString(desiredReacted),
+                        "pendingVersion", Long.toString(pendingVersion),
+                        "queuedAt", queuedAt
+                ));
+    }
+
+    public static ArtistPostLikeStreamCommand from(MapRecord<String, Object, Object> record) {
+        Map<Object, Object> fields = record.getValue();
+        return new ArtistPostLikeStreamCommand(
+                fields.get("requestId").toString(),
+                Long.valueOf(fields.get("artistId").toString()),
+                Long.valueOf(fields.get("artistPostId").toString()),
+                Long.valueOf(fields.get("memberId").toString()),
+                Boolean.parseBoolean(fields.get("desiredReacted").toString()),
+                Long.parseLong(fields.get("pendingVersion").toString()),
+                fields.get("queuedAt").toString()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamConsumer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamConsumer.java
@@ -1,0 +1,106 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikeStreamConsumer {
+
+    private static final String CONSUMER_NAME = "artist-post-like-v3-consumer";
+    private static final int BATCH_SIZE = 200;
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ArtistPostLikeStreamProcessor processor;
+
+    /**
+     * poll 기반 consumer.
+     *
+     * 장점:
+     * - 구조가 단순하고 Spring Scheduler만으로도 구현 가능
+     * - producer와 DB write를 분리해 burst를 Redis Stream이 먼저 흡수한다
+     *
+     * 현재는 단일 consumer 이름을 사용해 순서를 단순화했다.
+     * scale-out 시에는 consumer group 분산, pending 재처리 전략까지 추가 설계가 필요하다.
+     */
+    @Scheduled(fixedDelayString = "${artist-post.like-v3.consumer-delay-ms:300}")
+    public void consume() {
+        // 먼저 같은 consumer에 남아 있는 PEL(pending entries)을 재시도한다.
+        // 그렇지 않으면 한 번 실패한 메시지는 lastConsumed() 경로에서 다시 안 읽혀 영구 미처리 상태가 된다.
+        if (consumeRecords(readPendingRecords())) {
+            return;
+        }
+
+        consumeRecords(readNewRecords());
+    }
+
+    private List<MapRecord<String, Object, Object>> readPendingRecords() {
+        try {
+            return stringRedisTemplate.opsForStream().read(
+                    Consumer.from(ArtistPostLikeStreamProducer.CONSUMER_GROUP, CONSUMER_NAME),
+                    StreamReadOptions.empty().count(BATCH_SIZE),
+                    StreamOffset.create(ArtistPostLikeStreamProducer.STREAM_KEY, ReadOffset.from("0"))
+            );
+        } catch (Exception e) {
+            log.warn("ArtistPost like pending stream read failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<MapRecord<String, Object, Object>> readNewRecords() {
+        try {
+            return stringRedisTemplate.opsForStream().read(
+                    Consumer.from(ArtistPostLikeStreamProducer.CONSUMER_GROUP, CONSUMER_NAME),
+                    StreamReadOptions.empty().count(BATCH_SIZE).block(Duration.ofMillis(100)),
+                    StreamOffset.create(ArtistPostLikeStreamProducer.STREAM_KEY, ReadOffset.lastConsumed())
+            );
+        } catch (Exception e) {
+            log.warn("ArtistPost like stream read failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private boolean consumeRecords(List<MapRecord<String, Object, Object>> records) {
+        if (records == null || records.isEmpty()) {
+            return false;
+        }
+
+        for (MapRecord<String, Object, Object> record : records) {
+            Map<Object, Object> fields = record.getValue();
+            if (fields.containsKey("__bootstrap__")) {
+                acknowledge(record);
+                continue;
+            }
+
+            try {
+                processor.process(ArtistPostLikeStreamCommand.from(record));
+                acknowledge(record);
+            } catch (Exception e) {
+                log.error("ArtistPost like stream process failed: recordId={}, error={}", record.getId(), e.getMessage(), e);
+            }
+        }
+
+        return true;
+    }
+
+    private void acknowledge(MapRecord<String, Object, Object> record) {
+        stringRedisTemplate.opsForStream().acknowledge(
+                ArtistPostLikeStreamProducer.STREAM_KEY,
+                ArtistPostLikeStreamProducer.CONSUMER_GROUP,
+                record.getId()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProcessor.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProcessor.java
@@ -1,0 +1,86 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.artistpost.service.likecount.ArtistPostLikeDeltaEvent;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeStreamProcessor {
+
+    private final InteractionRepository interactionRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ArtistPostLikePendingStateRepository pendingStateRepository;
+    private final ArtistPostReader artistPostReader;
+
+    /**
+     * stream consumer가 실제 DB side-effect를 수행하는 곳이다.
+     *
+     * 요청 경로에서는 command만 적재하고,
+     * 진짜 Reaction insert/delete 및 likeCount delta 발행은 여기서 일어난다.
+     */
+    @Transactional
+    public void process(ArtistPostLikeStreamCommand command) {
+        try {
+            // queue 이후 게시글이 삭제될 수 있으므로, consumer에서도 대상 post를 다시 확인한다.
+            // 이 검증이 없으면 soft delete 된 post에 orphan reaction row가 생길 수 있다.
+            artistPostReader.findByIdAndArtistIdOrThrow(command.artistPostId(), command.artistId());
+        } catch (ArtistContentException e) {
+            log.warn("ArtistPost like stream command skipped: target post not found, requestId={}, artistPostId={}",
+                    command.requestId(), command.artistPostId());
+            pendingStateRepository.clearPendingStateIfVersionMatches(
+                    command.artistPostId(),
+                    command.memberId(),
+                    command.pendingVersion()
+            );
+            return;
+        }
+
+        // desired state 명령은 재시도돼도 "이미 원하는 상태인지"를 다시 검사하면 중복 delta를 막을 수 있다.
+        boolean alreadyReacted = interactionRepository.existsByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                PostType.ARTIST_POST,
+                command.artistPostId(),
+                command.memberId(),
+                ReactionType.LIKE
+        );
+
+        if (command.desiredReacted() && !alreadyReacted) {
+            interactionRepository.save(Reaction.create(
+                    PostType.ARTIST_POST,
+                    command.artistPostId(),
+                    command.memberId(),
+                    ReactionType.LIKE
+            ));
+            applicationEventPublisher.publishEvent(new ArtistPostLikeDeltaEvent(command.artistPostId(), 1L));
+        } else if (!command.desiredReacted() && alreadyReacted) {
+            interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                            PostType.ARTIST_POST,
+                            command.artistPostId(),
+                            command.memberId(),
+                            ReactionType.LIKE
+                    )
+                    .ifPresent(interactionRepository::delete);
+            applicationEventPublisher.publishEvent(new ArtistPostLikeDeltaEvent(command.artistPostId(), -1L));
+        } else {
+            // 재처리나 중복 명령이 와도 desired state와 현재 DB 상태가 같으면 조용히 no-op 처리한다.
+            log.debug("ArtistPost like stream command no-op: requestId={}, desiredReacted={}",
+                    command.requestId(), command.desiredReacted());
+        }
+
+        pendingStateRepository.clearPendingStateIfVersionMatches(
+                command.artistPostId(),
+                command.memberId(),
+                command.pendingVersion()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProducer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProducer.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import com.example.infinite.global.common.redis.RedisStreamGroupHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikeStreamProducer {
+
+    public static final String STREAM_KEY = "artist-post:like:v3:commands";
+    public static final String CONSUMER_GROUP = "artist-post-like-v3-group";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisStreamGroupHelper redisStreamGroupHelper;
+
+    public void enqueue(ArtistPostLikeStreamCommand command) {
+        // group을 보장한 뒤 stream에 적재해야 첫 burst에서도 메시지 유실 없이 consumer가 이어받는다.
+        // 여기서는 DB connection을 쓰지 않고 Redis append만 수행하므로 burst 흡수력이 훨씬 좋다.
+        redisStreamGroupHelper.ensureGroup(STREAM_KEY, CONSUMER_GROUP);
+        stringRedisTemplate.opsForStream().add(command.toRecord(STREAM_KEY));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamV3Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamV3Service.java
@@ -1,0 +1,23 @@
+package com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.ArtistPostLikeQueuedResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistPostLikeStreamV3Service {
+
+    private final ArtistPostLikeRedissonV3LockedService artistPostLikeRedissonV3LockedService;
+
+    public ArtistPostLikeQueuedResponse queue(Long memberId, Long artistId, Long artistPostId) {
+        try {
+            return artistPostLikeRedissonV3LockedService.queueWithLock(memberId, artistId, artistPostId);
+        } catch (LockException e) {
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
@@ -1,0 +1,78 @@
+package com.example.infinite.domain.artistcontent.interaction.service.commentlike;
+
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
+import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentLikeCoreService {
+
+    private final InteractionRepository interactionRepository;
+    private final CommentRepository commentRepository;
+    private final CommentReader commentReader;
+    private final FanPostReader fanPostReader;
+    private final ArtistPostReader artistPostReader;
+
+    /**
+     * 댓글 좋아요는 target post와 comment를 먼저 검증하고,
+     * 실제 count 반영은 엔티티 ++ 대신 DB atomic update로 처리한다.
+     *
+     * 댓글도 좋아요 수가 몰릴 수 있어서 in-memory increment로 두면
+     * lost update가 다시 발생한다.
+     */
+    @Transactional
+    public InteractionResponse toggle(Long memberId, Long artistId, Long targetId, Long commentId, PostType targetType) {
+        validateTarget(targetType, artistId, targetId);
+        Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, targetType, targetId);
+
+        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.COMMENT,
+                        comment.getId(),
+                        memberId,
+                        ReactionType.LIKE
+                )
+                .map(existingReaction -> cancelLike(existingReaction, comment.getId()))
+                .orElseGet(() -> addLike(memberId, comment.getId()));
+    }
+
+    private InteractionResponse addLike(Long memberId, Long commentId) {
+        interactionRepository.save(Reaction.create(
+                PostType.COMMENT,
+                commentId,
+                memberId,
+                ReactionType.LIKE
+        ));
+        commentRepository.changeLikeCountBy(commentId, 1L);
+        return InteractionResponse.of(commentId, true, loadLikeCount(commentId));
+    }
+
+    private InteractionResponse cancelLike(Reaction existingReaction, Long commentId) {
+        interactionRepository.delete(existingReaction);
+        commentRepository.changeLikeCountBy(commentId, -1L);
+        return InteractionResponse.of(commentId, false, loadLikeCount(commentId));
+    }
+
+    private long loadLikeCount(Long commentId) {
+        return commentRepository.findLikeCountById(commentId).orElse(0L);
+    }
+
+    private void validateTarget(PostType targetType, Long artistId, Long targetId) {
+        switch (targetType) {
+            case FAN_POST -> fanPostReader.findByIdAndArtistIdOrThrow(targetId, artistId);
+            case ARTIST_POST -> artistPostReader.findByIdAndArtistIdOrThrow(targetId, artistId);
+            default -> throw new IllegalArgumentException("지원하지 않는 댓글 대상 타입입니다: " + targetType);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonLockedService.java
@@ -1,0 +1,36 @@
+package com.example.infinite.domain.artistcontent.interaction.service.commentlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeRedissonLockedService {
+
+    private final CommentLikeCoreService commentLikeCoreService;
+
+    /**
+     * 댓글 좋아요는 같은 member + comment 조합만 직렬화한다.
+     * 댓글이 달린 게시글 전체를 잠그지 않으므로 서로 다른 유저/댓글 요청은 계속 병렬 처리된다.
+     */
+    @RedisLock(
+            key = "'comment:like:' + #commentId + ':member:' + #memberId",
+            waitTime = 700,
+            leaseTime = 3000,
+            timeUnit = TimeUnit.MILLISECONDS
+    )
+    public InteractionResponse toggleWithLock(
+            Long memberId,
+            Long artistId,
+            Long targetId,
+            Long commentId,
+            PostType targetType
+    ) {
+        return commentLikeCoreService.toggle(memberId, artistId, targetId, commentId, targetType);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
@@ -1,0 +1,30 @@
+package com.example.infinite.domain.artistcontent.interaction.service.commentlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeRedissonService {
+
+    private final CommentLikeRedissonLockedService commentLikeRedissonLockedService;
+
+    public InteractionResponse toggle(Long memberId, Long artistId, Long targetId, Long commentId, PostType targetType) {
+        try {
+            return commentLikeRedissonLockedService.toggleWithLock(
+                    memberId,
+                    artistId,
+                    targetId,
+                    commentId,
+                    targetType
+            );
+        } catch (LockException e) {
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
@@ -1,0 +1,61 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanletterlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FanLetterLikeCoreService {
+
+    private final InteractionRepository interactionRepository;
+    private final FanLetterReader fanLetterReader;
+    private final FanLetterRepository fanLetterRepository;
+
+    /**
+     * FanLetter 좋아요는 트래픽 규모상 즉시 처리로 충분하다.
+     * 다만 count 컬럼은 entity ++ 대신 DB atomic update로 일관성을 맞춘다.
+     */
+    @Transactional
+    public InteractionResponse toggle(Long memberId, Long artistId, Long fanLetterId) {
+        fanLetterReader.findByIdAndArtistIdOrThrow(fanLetterId, artistId);
+
+        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.FAN_LETTER,
+                        fanLetterId,
+                        memberId,
+                        ReactionType.LIKE
+                )
+                .map(existingReaction -> cancelLike(existingReaction, fanLetterId))
+                .orElseGet(() -> addLike(memberId, fanLetterId));
+    }
+
+    private InteractionResponse addLike(Long memberId, Long fanLetterId) {
+        interactionRepository.save(Reaction.create(
+                PostType.FAN_LETTER,
+                fanLetterId,
+                memberId,
+                ReactionType.LIKE
+        ));
+        fanLetterRepository.changeLikeCountBy(fanLetterId, 1L);
+        return InteractionResponse.of(fanLetterId, true, loadLikeCount(fanLetterId));
+    }
+
+    private InteractionResponse cancelLike(Reaction existingReaction, Long fanLetterId) {
+        interactionRepository.delete(existingReaction);
+        fanLetterRepository.changeLikeCountBy(fanLetterId, -1L);
+        return InteractionResponse.of(fanLetterId, false, loadLikeCount(fanLetterId));
+    }
+
+    private long loadLikeCount(Long fanLetterId) {
+        return fanLetterRepository.findLikeCountById(fanLetterId).orElse(0L);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonLockedService.java
@@ -1,0 +1,25 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanletterlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class FanLetterLikeRedissonLockedService {
+
+    private final FanLetterLikeCoreService fanLetterLikeCoreService;
+
+    @RedisLock(
+            key = "'fan-letter:like:' + #fanLetterId + ':member:' + #memberId",
+            waitTime = 700,
+            leaseTime = 3000,
+            timeUnit = TimeUnit.MILLISECONDS
+    )
+    public InteractionResponse toggleWithLock(Long memberId, Long artistId, Long fanLetterId) {
+        return fanLetterLikeCoreService.toggle(memberId, artistId, fanLetterId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonService.java
@@ -1,0 +1,27 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanletterlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FanLetterLikeRedissonService {
+
+    private final FanLetterLikeRedissonLockedService fanLetterLikeRedissonLockedService;
+
+    /**
+     * FanLetter도 즉시 처리 경로를 유지한다.
+     * 과한 비동기화보다 "같은 유저 중복 토글만 막고 count는 atomic update"가 더 적합한 영역이다.
+     */
+    public InteractionResponse toggle(Long memberId, Long artistId, Long fanLetterId) {
+        try {
+            return fanLetterLikeRedissonLockedService.toggleWithLock(memberId, artistId, fanLetterId);
+        } catch (LockException e) {
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeCoreService.java
@@ -1,0 +1,61 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
+import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FanPostLikeCoreService {
+
+    private final InteractionRepository interactionRepository;
+    private final FanPostReader fanPostReader;
+    private final FanPostRepository fanPostRepository;
+
+    /**
+     * FanPost 좋아요 핵심 비즈니스.
+     * 저트래픽 영역이라 stream까지는 쓰지 않고, Redisson 락 + atomic update로 단순하게 정리한다.
+     */
+    @Transactional
+    public InteractionResponse toggle(Long memberId, Long artistId, Long fanPostId) {
+        fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
+
+        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                        PostType.FAN_POST,
+                        fanPostId,
+                        memberId,
+                        ReactionType.LIKE
+                )
+                .map(existingReaction -> cancelLike(existingReaction, fanPostId))
+                .orElseGet(() -> addLike(memberId, fanPostId));
+    }
+
+    private InteractionResponse addLike(Long memberId, Long fanPostId) {
+        interactionRepository.save(Reaction.create(
+                PostType.FAN_POST,
+                fanPostId,
+                memberId,
+                ReactionType.LIKE
+        ));
+        fanPostRepository.changeLikeCountBy(fanPostId, 1L);
+        return InteractionResponse.of(fanPostId, true, loadLikeCount(fanPostId));
+    }
+
+    private InteractionResponse cancelLike(Reaction existingReaction, Long fanPostId) {
+        interactionRepository.delete(existingReaction);
+        fanPostRepository.changeLikeCountBy(fanPostId, -1L);
+        return InteractionResponse.of(fanPostId, false, loadLikeCount(fanPostId));
+    }
+
+    private long loadLikeCount(Long fanPostId) {
+        return fanPostRepository.findLikeCountById(fanPostId).orElse(0L);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeRedissonLockedService.java
@@ -1,0 +1,29 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.global.lock.RedisLock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class FanPostLikeRedissonLockedService {
+
+    private final FanPostLikeCoreService fanPostLikeCoreService;
+
+    /**
+     * FanPost 좋아요는 같은 member-target 조합만 직렬화한다.
+     * 같은 글에 대한 다른 유저 요청까지 잠그지 않아 병렬성은 유지한다.
+     */
+    @RedisLock(
+            key = "'fan-post:like:' + #fanPostId + ':member:' + #memberId",
+            waitTime = 700,
+            leaseTime = 3000,
+            timeUnit = TimeUnit.MILLISECONDS
+    )
+    public InteractionResponse toggleWithLock(Long memberId, Long artistId, Long fanPostId) {
+        return fanPostLikeCoreService.toggle(memberId, artistId, fanPostId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeRedissonService.java
@@ -1,0 +1,27 @@
+package com.example.infinite.domain.artistcontent.interaction.service.fanpostlike;
+
+import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
+import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
+import com.example.infinite.global.lock.LockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FanPostLikeRedissonService {
+
+    private final FanPostLikeRedissonLockedService fanPostLikeRedissonLockedService;
+
+    /**
+     * FanPost는 ArtistPost처럼 burst를 stream으로 흡수할 필요까진 없다고 보고,
+     * 운영 경로를 Redisson + 즉시 DB 반영으로 단순하게 유지한다.
+     */
+    public InteractionResponse toggle(Long memberId, Long artistId, Long fanPostId) {
+        try {
+            return fanPostLikeRedissonLockedService.toggleWithLock(memberId, artistId, fanPostId);
+        } catch (LockException e) {
+            throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
@@ -2,10 +2,87 @@ package com.example.infinite.domain.artistcontent.post.artistpost.repository;
 
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ArtistPostRepository extends JpaRepository<ArtistPost, Long>, ArtistPostRepositoryCustom {
 
     Optional<ArtistPost> findByIdAndArtistId(Long artistPostId, Long artistId);
+
+    /**
+     * flush 단계에서 사용되는 원자 update.
+     *
+     * 장점:
+     * - 현재 값을 읽어온 뒤 자바에서 +1/-1 하고 저장하는 read-modify-write 경쟁을 피한다
+     * - DB가 직접 likeCount = likeCount + delta 를 수행하므로 lost update 위험을 줄인다
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ArtistPost artistPost
+               set artistPost.likeCount =
+                   case
+                       when artistPost.likeCount + :delta < 0 then 0
+                       else artistPost.likeCount + :delta
+                   end
+             where artistPost.id = :artistPostId
+            """)
+    int changeLikeCountBy(@Param("artistPostId") Long artistPostId, @Param("delta") long delta);
+
+    /**
+     * full reconcile 단계에서 사용되는 전수 보정 쿼리.
+     *
+     * 방식:
+     * - reactions 에서 ARTIST_POST + LIKE 개수를 다시 센다
+     * - active artist_posts 와 left join 해서 0개 좋아요 글도 함께 맞춘다
+     *
+     * why native:
+     * - 전체 집계 + 조인 update 는 JPQL보다 native가 훨씬 간단하고 명확하다
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            update artist_posts artist_post
+            left join (
+                select reaction.target_id as artist_post_id, count(*) as like_count
+                  from reactions reaction
+                 where reaction.target_type = 'ARTIST_POST'
+                   and reaction.reaction_type = 'LIKE'
+                 group by reaction.target_id
+            ) reaction_counts
+              on reaction_counts.artist_post_id = artist_post.id
+               set artist_post.like_count = coalesce(reaction_counts.like_count, 0)
+             where artist_post.deleted_at is null
+            """, nativeQuery = true)
+    int reconcileAllLikeCounts();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ArtistPost artistPost
+               set artistPost.commentCount =
+                   case
+                       when artistPost.commentCount + :delta < 0 then 0
+                       else artistPost.commentCount + :delta
+                   end
+             where artistPost.id = :artistPostId
+            """)
+    int changeCommentCountBy(@Param("artistPostId") Long artistPostId, @Param("delta") long delta);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            update artist_posts artist_post
+            left join (
+                select comment.target_id as artist_post_id, count(*) as comment_count
+                  from comments comment
+                 where comment.target_type = 'ARTIST_POST'
+                   and comment.deleted_at is null
+                   and comment.deleted_placeholder = false
+                 group by comment.target_id
+            ) comment_counts
+              on comment_counts.artist_post_id = artist_post.id
+               set artist_post.comment_count = coalesce(comment_counts.comment_count, 0)
+             where artist_post.deleted_at is null
+            """, nativeQuery = true)
+    int reconcileAllCommentCounts();
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
@@ -193,7 +193,6 @@ public class ArtistPostService {
         if (artistPostIds.isEmpty()) {
             return Map.of();
         }
-
         // 목록 카드는 post당 앞쪽 6장만 미리보기로 내리고,
         // 전체 장수는 mediaCount 필드를 그대로 사용한다.
         return mediaRepository.findPreviewByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeCountFlushScheduler.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeCountFlushScheduler.java
@@ -1,0 +1,66 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service.likecount;
+
+import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikeCountFlushScheduler {
+
+    private final ArtistPostLikeDeltaBuffer artistPostLikeDeltaBuffer;
+    private final ArtistPostRepository artistPostRepository;
+
+    /**
+     * 1차 배치: flush
+     *
+     * 역할:
+     * - Redis에 누적된 "변경이 있었던 글"만 DB count에 반영
+     * - 전체 Reaction을 다시 세지 않으므로 자주 돌아도 부담이 상대적으로 작다
+     *
+     * 핵심 의도:
+     * - 요청 경로에서 DB count row hotspot을 제거
+     * - 대신 짧은 주기의 배치로 화면 count를 따라가게 만들기
+     */
+    @Scheduled(fixedDelayString = "${artist-post.like-count.flush-delay-ms:3000}")
+    @Transactional
+    public void flush() {
+        List<ArtistPostLikeDelta> deltas = artistPostLikeDeltaBuffer.drainAll();
+        if (deltas.isEmpty()) {
+            return;
+        }
+
+        for (ArtistPostLikeDelta delta : deltas) {
+            // 인기 글은 요청 쓰기를 빠르게 받고, DB count는 scheduler가 주기적으로 몰아서 반영한다.
+            int updatedRowCount = artistPostRepository.changeLikeCountBy(delta.artistPostId(), delta.delta());
+            if (updatedRowCount == 0) {
+                log.debug("ArtistPost likeCount flush skipped: artistPostId={}, delta={}", delta.artistPostId(), delta.delta());
+            }
+        }
+    }
+
+    /**
+     * 2차 배치: full reconcile
+     *
+     * 역할:
+     * - 하루 1회 Reaction 원본 기준으로 like_count를 전수 보정
+     * - flush 누락, 운영 중 장애, 예외 케이스로 생길 수 있는 드리프트를 최종 수정
+     *
+     * flush와 reconcile의 차이:
+     * - flush: 최근에 변한 글만
+     * - reconcile: 전체 활성 ArtistPost를 다시 계산
+     */
+    @Scheduled(cron = "${artist-post.like-count.reconcile-cron:0 0 4 * * *}")
+    @Transactional
+    public void reconcileAll() {
+        // 하루 1회 원본 Reaction 집계를 다시 세어 delta flush 누락이나 운영 중 드리프트를 최종 보정한다.
+        int updatedRowCount = artistPostRepository.reconcileAllLikeCounts();
+        log.info("ArtistPost likeCount full reconcile completed: updatedRows={}", updatedRowCount);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDelta.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDelta.java
@@ -1,0 +1,9 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service.likecount;
+
+public record ArtistPostLikeDelta(
+        Long artistPostId,
+        long delta
+) {
+    // flush 단계에서 "어느 글에 몇 개를 더하거나 뺄지"를 운반하는 값 객체다.
+    // 원본 Reaction 전체를 들고 다니지 않고 postId + delta만 유지해 배치 비용을 낮춘다.
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaBuffer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaBuffer.java
@@ -1,0 +1,91 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service.likecount;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikeDeltaBuffer {
+
+    private static final String ARTIST_POST_LIKE_DELTA_KEY = "artist-post:like:delta";
+
+    /**
+     * hash field를 읽고 지우는 작업을 한 번에 처리한다.
+     * flush 도중 새 delta가 들어와도 유실하지 않고 다음 주기에 넘기기 위한 atomic drain 용도다.
+     */
+    private static final DefaultRedisScript<Long> DRAIN_HASH_FIELD_SCRIPT;
+
+    static {
+        DRAIN_HASH_FIELD_SCRIPT = new DefaultRedisScript<>();
+        DRAIN_HASH_FIELD_SCRIPT.setScriptText("""
+                local current = redis.call('HGET', KEYS[1], ARGV[1])
+                if not current then
+                    return 0
+                end
+                redis.call('HDEL', KEYS[1], ARGV[1])
+                return tonumber(current)
+                """);
+        DRAIN_HASH_FIELD_SCRIPT.setResultType(Long.class);
+    }
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * Redis hash를 "변경량 버퍼"로 사용한다.
+     *
+     * 예:
+     * - artistPostId=10 글에 좋아요 3번, 취소 1번이 들어오면
+     * - hash field "10" 값은 최종적으로 +2만 남는다
+     *
+     * 이 방식의 장점:
+     * - DB에 요청마다 update 하지 않아도 된다
+     * - 같은 글에 대한 짧은 시간 내 다수 요청을 한 값으로 압축할 수 있다
+     */
+    public void accumulate(Long artistPostId, long delta) {
+        stringRedisTemplate.opsForHash().increment(
+                ARTIST_POST_LIKE_DELTA_KEY,
+                artistPostId.toString(),
+                delta
+        );
+    }
+
+    /**
+     * 현재 Redis에 쌓인 모든 post별 delta를 읽어 간다.
+     *
+     * 주의:
+     * - 단순 HGET 후 HDEL 두 번으로 처리하면 flush 도중 delta 유실 가능성이 있다
+     * - 그래서 field 단위 drain은 Lua로 원자 처리한다
+     */
+    public List<ArtistPostLikeDelta> drainAll() {
+        Set<Object> artistPostIds = stringRedisTemplate.opsForHash().keys(ARTIST_POST_LIKE_DELTA_KEY);
+        if (artistPostIds == null || artistPostIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ArtistPostLikeDelta> drainedDeltas = new ArrayList<>();
+        for (Object artistPostIdField : artistPostIds) {
+            Long artistPostId = Long.valueOf(artistPostIdField.toString());
+            long delta = drainOne(artistPostId);
+            if (delta != 0L) {
+                drainedDeltas.add(new ArtistPostLikeDelta(artistPostId, delta));
+            }
+        }
+        return drainedDeltas;
+    }
+
+    private long drainOne(Long artistPostId) {
+        // "읽고 삭제"를 한 번에 수행해야 flush와 동시 쓰기가 겹칠 때 값이 꼬이지 않는다.
+        Long delta = stringRedisTemplate.execute(
+                DRAIN_HASH_FIELD_SCRIPT,
+                List.of(ARTIST_POST_LIKE_DELTA_KEY),
+                artistPostId.toString()
+        );
+        return delta == null ? 0L : delta;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaEvent.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaEvent.java
@@ -1,0 +1,9 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service.likecount;
+
+public record ArtistPostLikeDeltaEvent(
+        Long artistPostId,
+        long delta
+) {
+    // 트랜잭션 커밋 이후 Redis delta 누적으로 넘기기 위한 경량 이벤트다.
+    // 핵심은 "원본 DB 저장은 지금, count 반영은 나중"을 분리하는 데 있다.
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaEventListener.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeDeltaEventListener.java
@@ -1,0 +1,26 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service.likecount;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostLikeDeltaEventListener {
+
+    private final ArtistPostLikeDeltaBuffer artistPostLikeDeltaBuffer;
+
+    /**
+     * AFTER_COMMIT 으로 둔 이유:
+     * - Reaction insert/delete 가 실제 커밋된 경우에만 delta를 Redis에 적재하려는 목적
+     * - 트랜잭션 롤백 시 count까지 잘못 증가/감소하는 것을 막는다
+     *
+     * 즉 "좋아요 원본"과 "좋아요 집계"의 경계를 가장 명확하게 나누는 지점이다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ArtistPostLikeDeltaEvent event) {
+        // DB 트랜잭션이 실제로 커밋된 경우에만 Redis 누적값을 올려 롤백 이벤트가 count에 섞이지 않게 한다.
+        artistPostLikeDeltaBuffer.accumulate(event.artistPostId(), event.delta());
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/eunms/PostType.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/eunms/PostType.java
@@ -3,6 +3,7 @@ package com.example.infinite.domain.artistcontent.post.eunms;
 public enum PostType {
     FAN_POST,
     ARTIST_POST,
+    COMMENT,
     FAN_LETTER,
     MEDIA,
     LIVE

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
@@ -2,6 +2,9 @@ package com.example.infinite.domain.artistcontent.post.fanletter.repository;
 
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +13,19 @@ public interface FanLetterRepository extends JpaRepository<FanLetter, Long>, Fan
     // 팬레터 상세/수정/삭제는 항상 artist 범위 안에서 조회해야
     // 다른 아티스트의 팬레터를 잘못 건드리지 않는다.
     Optional<FanLetter> findByIdAndArtistId(Long fanLetterId, Long artistId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update FanLetter fanLetter
+               set fanLetter.likeCount =
+                   case
+                       when fanLetter.likeCount + :delta < 0 then 0
+                       else fanLetter.likeCount + :delta
+                   end
+             where fanLetter.id = :fanLetterId
+            """)
+    int changeLikeCountBy(@Param("fanLetterId") Long fanLetterId, @Param("delta") long delta);
+
+    @Query("select fanLetter.likeCount from FanLetter fanLetter where fanLetter.id = :fanLetterId")
+    Optional<Long> findLikeCountById(@Param("fanLetterId") Long fanLetterId);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
@@ -2,9 +2,39 @@ package com.example.infinite.domain.artistcontent.post.fanpost.repository;
 
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface FanPostRepository extends JpaRepository<FanPost, Long>, FanPostRepositoryCustom {
     Optional<FanPost> findByIdAndArtistId(Long fanPostId, Long artistId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update FanPost fanPost
+               set fanPost.likeCount =
+                   case
+                       when fanPost.likeCount + :delta < 0 then 0
+                       else fanPost.likeCount + :delta
+                   end
+             where fanPost.id = :fanPostId
+            """)
+    int changeLikeCountBy(@Param("fanPostId") Long fanPostId, @Param("delta") long delta);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update FanPost fanPost
+               set fanPost.commentCount =
+                   case
+                       when fanPost.commentCount + :delta < 0 then 0
+                       else fanPost.commentCount + :delta
+                   end
+             where fanPost.id = :fanPostId
+            """)
+    int changeCommentCountBy(@Param("fanPostId") Long fanPostId, @Param("delta") long delta);
+
+    @Query("select fanPost.likeCount from FanPost fanPost where fanPost.id = :fanPostId")
+    Optional<Long> findLikeCountById(@Param("fanPostId") Long fanPostId);
 }

--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -112,10 +112,15 @@ public class SecurityConfig {
                         // 좋아요, 댓글
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts/*/likes/toggle").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/artist-posts/*/likes/toggle").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/post/v3/artists/*/artist-posts/*/likes/toggle").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts/*/comments/*/likes/toggle").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/artist-posts/*/comments/*/likes/toggle").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/fan-posts/*/comments").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/fan-posts/*/comments/*").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/post/v1/artists/*/artist-posts/*/comments").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/post/v1/artists/*/artist-posts/*/comments/*").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/post/v2/artists/*/artist-posts/*/comments").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/post/v2/artists/*/artist-posts/*/comments/*").authenticated()
                         .requestMatchers("/api/post/v1/comments/**", "/api/post/v1/*/likes/toggle").authenticated()
 
                         // DM (구독 검증은 서비스 레이어에서 수행)

--- a/src/main/java/com/example/infinite/global/common/redis/RedisStreamGroupHelper.java
+++ b/src/main/java/com/example/infinite/global/common/redis/RedisStreamGroupHelper.java
@@ -1,0 +1,69 @@
+package com.example.infinite.global.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisStreamGroupHelper {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final Set<String> initializedGroups = ConcurrentHashMap.newKeySet();
+
+    /**
+     * stream + consumer group 조합을 1회만 초기화한다.
+     * 첫 요청보다 consumer group 생성이 늦어지면 이벤트를 놓칠 수 있어 producer 진입 전에 보장한다.
+     */
+    public void ensureGroup(String streamKey, String groupName) {
+        String cacheKey = streamKey + "::" + groupName;
+        if (initializedGroups.contains(cacheKey)) {
+            return;
+        }
+
+        synchronized (this) {
+            if (initializedGroups.contains(cacheKey)) {
+                return;
+            }
+
+            try {
+                bootstrapStreamIfMissing(streamKey);
+                stringRedisTemplate.opsForStream().createGroup(streamKey, ReadOffset.latest(), groupName);
+                log.info("Redis Stream group created: streamKey={}, group={}", streamKey, groupName);
+            } catch (Exception e) {
+                String message = e.getMessage();
+                if (message != null && message.contains("BUSYGROUP")) {
+                    log.debug("Redis Stream group already exists: streamKey={}, group={}", streamKey, groupName);
+                } else {
+                    throw e;
+                }
+            }
+
+            initializedGroups.add(cacheKey);
+        }
+    }
+
+    private void bootstrapStreamIfMissing(String streamKey) {
+        // Redis Stream group는 stream이 존재하지 않으면 생성할 수 없다.
+        // 그래서 첫 요청 전에 bootstrap record를 하나 넣어 group 초기화 실패를 피한다.
+        if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(streamKey))) {
+            return;
+        }
+
+        stringRedisTemplate.opsForStream().add(StreamRecords.newRecord()
+                .in(streamKey)
+                .ofMap(Map.of(
+                        "__bootstrap__", "true",
+                        "timestamp", Instant.now().toString()
+                )));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,20 @@ jelly:
   fan-membership-cost: 9
   dm-subscription-cost: 15
 
+artist-post:
+  like-count:
+    # flush는 Redis delta가 쌓인 글만 반영한다.
+    flush-delay-ms: 3000
+    # full reconcile은 하루 1회 Reaction 원본을 다시 세어 DB count를 최종 보정한다.
+    reconcile-cron: 0 0 4 * * *
+  like-v3:
+    consumer-delay-ms: 300
+  comment-count:
+    flush-delay-ms: 3000
+    reconcile-cron: 0 10 4 * * *
+  comment-v2:
+    consumer-delay-ms: 300
+
 media:
   storage:
     # 기본은 비활성화로 두고, S3 설정이 준비된 환경에서만 활성화한다.


### PR DESCRIPTION
## 🧩 배경
ArtistPost 댓글 생성/삭제 경로에서 동시성 이슈를 줄이고, 실제 처리 흐름을 비동기 커맨드 기반으로 정리하기 위해 API/도메인/리포지토리 레벨을 함께 개편했습니다.

이번 변경은 단순 diff 수정이 아니라, 댓글 처리 방식(동기 응답 → 접수 응답 + 워커 처리)과 중복 요청 방지, 카운터 일관성까지 포함한 구조 변경입니다.

---

## ✅ 주요 변경사항

### 1) ArtistPost 댓글 API v2 추가 (실사용 경로)
- `POST /api/post/v2/artists/{artistId}/artist-posts/{artistPostId}/comments`
- `DELETE /api/post/v2/artists/{artistId}/artist-posts/{artistPostId}/comments/{commentId}`
- 응답을 `202 Accepted` + queued metadata 형태로 변경
- `v1`은 레거시 호환 경로로 유지(신규 연동은 v2 기준)

### 2) 큐 응답 DTO 신설
- `ArtistPostCommentQueuedResponse` 추가
- requestId, commandType, queuedAt 등 “접수 메타정보” 반환

### 3) Comment 엔티티/리포지토리 동시성 보강
- `commandRequestId` 저장 및 unique constraint로 중복 요청 방지
- `likeCount` 필드 추가 및 음수 방지 update 쿼리 도입
- `findByCommandRequestId`, likeCount 조회/증감 쿼리 추가

### 4) 서비스 레이어 처리 흐름 정리
- ArtistPost는 stream/v2 비동기 처리 경로 사용
- FanPost도 락 + 트랜잭션 경계 의도를 명확히 하도록 정리
- 동시 처리 중 충돌에 대한 에러코드 추가 (`COMMENT_REQUEST_IN_PROGRESS`)

### 5) 문서/핸드오프 반영
- 최신 버전 선택 규칙 명시
  - ArtistPost 좋아요: v3
  - ArtistPost 댓글 생성/삭제: v2
  - v1은 호환용

---

## 🏗️ 프로젝트 전체 맥락에서의 의미
- 이번 PR은 “ArtistPost 댓글 기능만 수정”이 아니라,
  - API 버전 전략(v1/v2/v3),
  - 비동기 커맨드 처리,
  - 중복 요청 방지(idempotency 성격),
  - 카운터 정합성 유지
  를 한 흐름으로 맞춘 변경입니다.
- 즉, 컨트롤러-서비스-엔티티-리포지토리-문서가 같은 방향(비동기/동시성 안전)으로 정렬되었습니다.

---

## 🔍 리뷰 포인트
1. **API 계약**
   - v2 응답이 `202 + queued metadata`로 정의된 점이 클라이언트 기대와 일치하는지
2. **중복 요청 방지**
   - `commandRequestId` unique constraint 전략이 운영 트래픽에서 충분한지
3. **락/트랜잭션 경계**
   - 실제 write가 락 범위 내 커밋되도록 구성된 의도가 코드와 일치하는지
4. **레거시 호환**
   - v1 유지 정책이 기존 클라이언트와 충돌 없는지
5. **카운터 정합성**
   - likeCount 증감 쿼리 및 하한(0) 처리 정책 타당성

---

## 🧪 테스트 체크리스트
- [ ] ArtistPost 댓글 생성 v2 호출 시 `202` 및 queued metadata 반환
- [ ] ArtistPost 댓글 삭제 v2 호출 시 `202` 및 queued metadata 반환
- [ ] 동일 requestId 중복 요청 시 기대한 충돌/중복방지 동작 확인
- [ ] 동시 요청 상황에서 댓글/카운트 정합성 유지 확인
- [ ] v1 경로 기존 동작(호환성) 회귀 테스트

---

## ⚠️ 영향 범위 / 리스크
- 댓글 API 소비 클라이언트가 즉시 `CommentResponse`를 기대하면 동작 차이가 발생할 수 있어, v2 계약(접수 응답) 기준 반영 필요
- 동시성 관련 로직은 부하 테스트/재시도 시나리오에서 추가 검증 권장