### PR TITLE
Chore: ExceptionHandler 누락 패치 + eunms→enums 패키지명 오타 수정

### DIFF
--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/entity/Comment.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/entity/Comment.java
@@ -1,6 +1,6 @@
 package com.example.infinite.domain.artistcontent.comment.entity;
 
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.comment.repository;
 
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.comment.repository;
 
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.example.infinite.domain.artistcontent.comment.repository;
 
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
 import com.example.infinite.domain.artistcontent.comment.entity.QComment;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.member.member.entity.QMember;
 import com.example.infinite.global.common.util.querydsl.CursorSliceUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
@@ -12,7 +12,7 @@ import com.example.infinite.domain.artistcontent.comment.service.fanpost.FanPost
 import com.example.infinite.domain.artistcontent.comment.service.artistpoststream.ArtistPostCommentStreamV2Service;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
@@ -6,7 +6,7 @@ import com.example.infinite.domain.artistcontent.comment.service.CommentMentionS
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.domain.member.member.support.MemberReader;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamV2Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamV2Service.java
@@ -7,7 +7,7 @@ import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
 import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.domain.member.member.support.MemberInputSupport;
 import com.example.infinite.domain.member.member.support.MemberReader;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
@@ -10,7 +10,7 @@ import com.example.infinite.domain.artistcontent.comment.repository.CommentRepos
 import com.example.infinite.domain.artistcontent.comment.service.CommentMentionService;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
 import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
 import com.example.infinite.domain.member.member.entity.Member;

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/support/CommentReader.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/support/CommentReader.java
@@ -4,7 +4,7 @@ import com.example.infinite.domain.artistcontent.comment.entity.Comment;
 import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
 import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/infinite/domain/artistcontent/hashtag/entity/ContentHashtag.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/hashtag/entity/ContentHashtag.java
@@ -1,6 +1,6 @@
 package com.example.infinite.domain.artistcontent.hashtag.entity;
 
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/infinite/domain/artistcontent/hashtag/repository/ContentHashtagRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/hashtag/repository/ContentHashtagRepository.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.hashtag.repository;
 
 import com.example.infinite.domain.artistcontent.hashtag.entity.ContentHashtag;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/infinite/domain/artistcontent/hashtag/service/HashtagService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/hashtag/service/HashtagService.java
@@ -8,7 +8,7 @@ import com.example.infinite.domain.artistcontent.hashtag.error.HashtagException;
 import com.example.infinite.domain.artistcontent.hashtag.repository.ContentHashtagRepository;
 import com.example.infinite.domain.artistcontent.hashtag.repository.HashtagRepository;
 import com.example.infinite.domain.artistcontent.hashtag.support.HashtagParser;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/entity/Reaction.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/entity/Reaction.java
@@ -1,6 +1,6 @@
 package com.example.infinite.domain.artistcontent.interaction.entity;
 
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepository.java
@@ -2,7 +2,7 @@ package com.example.infinite.domain.artistcontent.interaction.repository;
 
 import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryCustom.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.interaction.repository;
 
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 
 import java.util.Collection;
 import java.util.Set;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/repository/InteractionRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.example.infinite.domain.artistcontent.interaction.repository;
 
 import com.example.infinite.domain.artistcontent.interaction.entity.QReaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.member.artist.entity.QArtistMember;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/InteractionService.java
@@ -8,7 +8,7 @@ import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
 import com.example.infinite.domain.artistcontent.interaction.service.commentlike.CommentLikeRedissonService;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.interaction.service.fanletterlike.FanLetterLikeRedissonService;
 import com.example.infinite.domain.artistcontent.interaction.service.fanpostlike.FanPostLikeRedissonService;
 import com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.ArtistPostLikeRedissonV2Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/ArtistPostLikeCoreService.java
@@ -7,7 +7,7 @@ import com.example.infinite.domain.artistcontent.interaction.repository.Interact
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import com.example.infinite.domain.artistcontent.post.artistpost.service.likecount.ArtistPostLikeDeltaEvent;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeRedissonV3LockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeRedissonV3LockedService.java
@@ -4,7 +4,7 @@ import com.example.infinite.domain.artistcontent.interaction.dto.response.Artist
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.global.lock.RedisLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProcessor.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamProcessor.java
@@ -6,7 +6,7 @@ import com.example.infinite.domain.artistcontent.interaction.repository.Interact
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.artistcontent.post.artistpost.service.likecount.ArtistPostLikeDeltaEvent;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
@@ -8,7 +8,7 @@ import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonLockedService.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.interaction.service.commentlike;
 
 import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.global.lock.RedisLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
@@ -3,7 +3,7 @@ package com.example.infinite.domain.artistcontent.interaction.service.commentlik
 import com.example.infinite.domain.artistcontent.interaction.dto.response.InteractionResponse;
 import com.example.infinite.domain.artistcontent.interaction.error.InteractionErrorCode;
 import com.example.infinite.domain.artistcontent.interaction.error.InteractionException;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.global.lock.LockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
@@ -4,7 +4,7 @@ import com.example.infinite.domain.artistcontent.interaction.dto.response.Intera
 import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
 import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanpostlike/FanPostLikeCoreService.java
@@ -4,7 +4,7 @@ import com.example.infinite.domain.artistcontent.interaction.dto.response.Intera
 import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
 import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
 import com.example.infinite.domain.artistcontent.post.fanpost.support.FanPostReader;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/entity/Media.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/entity/Media.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.media.entity;
 
 import com.example.infinite.domain.artistcontent.media.enums.MediaType;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepository.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.media.repository;
 
 import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepositoryCustom.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepositoryCustom.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.media.repository;
 
 import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/repository/MediaRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.media.repository;
 
 import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.query.NativeQuery;

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/service/MediaService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/service/MediaService.java
@@ -9,7 +9,7 @@ import com.example.infinite.domain.artistcontent.media.storage.UploadedObject;
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/entity/ArtistPost.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/entity/ArtistPost.java
@@ -1,6 +1,6 @@
 package com.example.infinite.domain.artistcontent.post.artistpost.entity;
 
-import com.example.infinite.domain.artistcontent.post.eunms.PostVisibility;
+import com.example.infinite.domain.artistcontent.post.enums.PostVisibility;
 import com.example.infinite.domain.member.artist.entity.Artist;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.global.common.entity.BaseEntity;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
@@ -16,7 +16,7 @@ import com.example.infinite.domain.artistcontent.post.artistpost.repository.Arti
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.member.artist.entity.Artist;
 import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/enums/PostType.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/enums/PostType.java
@@ -1,4 +1,4 @@
-package com.example.infinite.domain.artistcontent.post.eunms;
+package com.example.infinite.domain.artistcontent.post.enums;
 
 public enum PostType {
     FAN_POST,

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/enums/PostVisibility.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/enums/PostVisibility.java
@@ -1,4 +1,4 @@
-package com.example.infinite.domain.artistcontent.post.eunms;
+package com.example.infinite.domain.artistcontent.post.enums;
 
 public enum PostVisibility {
     PUBLIC,

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
@@ -8,7 +8,7 @@ import com.example.infinite.domain.artistcontent.media.repository.MediaRepositor
 import com.example.infinite.domain.artistcontent.media.service.MediaService;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterCreateRequest;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterUpdateRequest;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterCreateResponse;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/entity/FanPost.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/entity/FanPost.java
@@ -2,7 +2,7 @@ package com.example.infinite.domain.artistcontent.post.fanpost.entity;
 
 import com.example.infinite.domain.member.artist.entity.Artist;
 import com.example.infinite.domain.member.member.entity.Member;
-import com.example.infinite.domain.artistcontent.post.eunms.PostVisibility;
+import com.example.infinite.domain.artistcontent.post.enums.PostVisibility;
 import com.example.infinite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostService.java
@@ -6,7 +6,7 @@ import com.example.infinite.domain.artistcontent.media.repository.MediaRepositor
 import com.example.infinite.domain.artistcontent.media.service.MediaService;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
-import com.example.infinite.domain.artistcontent.post.eunms.PostType;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.request.FanPostCreateRequest;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.request.FanPostUpdateRequest;

--- a/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import com.example.infinite.domain.raffle.error.RaffleException;
 import com.example.infinite.domain.realtimelive.error.LiveException;
 import com.example.infinite.global.common.dto.ApiResponse;
 import com.example.infinite.global.common.dto.ErrorResponse;
+import com.example.infinite.global.exception.BusinessException;
+import com.example.infinite.global.s3.s3error.S3Exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -217,6 +219,22 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(SubscriptionMembershipException.class)
     public ResponseEntity<ApiResponse<Void>> handleSubscriptionMembershipException(SubscriptionMembershipException e, HttpServletRequest request) {
         return handleCustomException("SubscriptionMembershipException", e.getErrorCode(), e, request);
+    }
+
+    /**
+     * 4xx/5xx: 공통 비즈니스 예외 처리 (인증 실패, 로그인, 회원가입)
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e, HttpServletRequest request) {
+        return handleCustomException("BusinessException", e.getErrorCode(), e, request);
+    }
+
+    /**
+     * 4xx/5xx: S3 파일 업로드 예외 처리
+     */
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleS3Exception(S3Exception e, HttpServletRequest request) {
+        return handleCustomException("S3Exception", e.getErrorCode(), e, request);
     }
 
     /**


### PR DESCRIPTION
## Summary

- GlobalExceptionHandler에 `BusinessException`, `S3Exception` 핸들러 2개 추가 (인증/로그인/회원가입 500 응답 이슈 해결)
- `domain/artistcontent/post/eunms` → `enums` 패키지 rename (git rename으로 처리) 및 37개 참조 파일 import 일괄 치환

## Commits

- `Fix: GlobalExceptionHandler에 BusinessException, S3Exception 핸들러 추가` — #101
- `Chore: artistcontent/post/eunms 패키지명 오타 수정 (eunms → enums)` — #102

## Test plan

- [x] `./gradlew compileJava` 성공
- [x] `grep -r "eunms" src/main/java/` 결과 0건
- [x] GlobalExceptionHandler에 `@ExceptionHandler(BusinessException.class)`, `@ExceptionHandler(S3Exception.class)` 존재 확인
- [ ] 리뷰어: 기존 핸들러 패턴과 동일한지 확인

Closes #101
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)