### PR TITLE
Feat/artistpost

### DIFF
--- a/FRONTEND_TEAM_VIBE_HANDOFF.md
+++ b/FRONTEND_TEAM_VIBE_HANDOFF.md
@@ -31,7 +31,8 @@
 
 - 실구현 완료: 아티스트 검색, 인기 검색어, 아티스트 상세, ArtistMember 관리, FanPost CRUD, FanPost 좋아요, FanPost 댓글/대댓글 조회, ArtistPost CRUD, ArtistPost 좋아요, ArtistPost 댓글/대댓글 조회, FanLetter CRUD, FanLetter 좋아요, Hashtag 추천, FanPost/ArtistPost/FanLetter 미디어 업로드 구조, 실시간 스트리밍 메타데이터/채팅 기본 구조
 - 부분 구현: Follow 엔티티
-- 필수 구현 예정: 아티스트페이지 코드 검토, 포스트페이지 동시성·캐싱, 메인 홈 대시보드/아티스트 홈 대시보드
+- 필수 구현 예정: 아티스트페이지 코드 검토, 메인 홈 대시보드/아티스트 홈 대시보드
+- 최근 반영 완료: FanPost / ArtistPost / FanLetter base/hot 캐시 분리, 댓글 조건부 짧은 TTL 캐시
 - 구현 예정이지만 미구현으로 끝날 수도 있음: YouTube 미디어 탭, 종료된 스트리밍 영상 보관 조회, Follow API, 알림
 
 ## 2. 가장 중요한 고정 정책
@@ -284,6 +285,10 @@ FanPost 댓글 현재 정책:
 - 작성자 옆 구독 배지 boolean은 현재 실제 subscription 조회 결과가 내려온다
 - FanPost는 별도 상위 버전 route가 없으므로 현재 route가 곧 최신 구현이다
 - 내부적으로는 백엔드가 Redisson 락/atomic update 구조로 바뀌었지만 응답 계약은 그대로다
+- 조회 캐시도 이미 1차 반영됐다
+- 포스트 본문/작성자/미디어/해시태그/배지 쪽은 base cache
+- `likeCount`, `commentCount`는 hot cache로 분리된다
+- 댓글 루트 슬라이스/대댓글 목록은 짧은 TTL 조건부 캐시를 쓴다
 
 프론트가 지금 바로 실연동 가능한 화면:
 
@@ -427,6 +432,11 @@ FanPost 댓글 현재 정책:
 - 새 `v2/v3`는 비동기 command enqueue 용도라 `202 Accepted` + queued metadata를 반환한다
 - ArtistPost 댓글 생성/삭제는 반드시 `v2`를 기준으로 붙여야 한다
 - ArtistPost 댓글 `v1`은 레거시 호환용으로만 남아 있다
+- 조회 캐시도 이미 반영됐다
+- 포스트 본문/작성자/미디어/해시태그/아티스트 배지 쪽은 base cache
+- `likeCount`, `commentCount`는 `3초` hot cache를 쓴다
+- 댓글 루트 슬라이스/대댓글 목록은 짧은 TTL 조건부 캐시를 쓴다
+- 따라서 프론트는 좋아요/댓글 수를 장시간 프론트 단독 truth로 잡기보다 서버 재조회 값으로 다시 맞춰지는 전제를 두는 편이 안전하다
 
 프론트가 지금 해두면 좋은 것:
 
@@ -460,6 +470,9 @@ FanPost 댓글 현재 정책:
 - FanLetter는 이제 mock 우선이 아니라 실연동 가능 영역이다
 - 다만 목록 응답과 상세 응답의 필드 구성이 다르다
 - special-like는 "아티스트 멤버 중 한 명이라도 좋아요했는가" 기준이다
+- 조회 캐시도 이미 반영됐다
+- 본문/수신자/이미지/special-like 표시용 안정 필드는 base cache
+- `likeCount`는 hot cache로 분리돼 있다
 
 프론트가 지금 해두면 좋은 것:
 
@@ -521,7 +534,8 @@ Dashboard B:
 
 아래는 현재 고정된 우선순위다.
 
-- `5-1 ~ 5-3`은 필수 구현 예정으로 보는 것이 맞다
+- `5-1`과 `5-3`은 필수 구현 예정으로 보는 것이 맞다
+- `5-2`의 포스트페이지 동시성/캐싱은 1차 구현이 끝났고, 이제는 검증/튜닝 단계로 보는 것이 맞다
 - `5-4 ~ 5-6`은 후순위라 이번 작업 범위에서 미구현으로 끝날 수 있다
 
 ## 5-1. 필수 1순위: 아티스트페이지 코드 검토
@@ -536,19 +550,25 @@ Dashboard B:
 - ArtistPost/artist-page 화면을 먼저 안정적으로 붙이는 게 우선이다
 - 이 단계에서는 큰 신규 API보다 세부 응답 shape 정리와 edge case 보정 가능성을 열어두는 편이 좋다
 
-## 5-2. 필수 2순위: 포스트페이지 동시성 / 캐싱
+## 5-2. 상태 반영: 포스트페이지 동시성 / 캐싱
 
-백엔드 예정 작업:
+백엔드 현재 반영 상태:
 
-- FanPost + FanLetter 동시성/캐싱
-- ArtistPost 대용량 동시성/캐싱
-- 캐싱/락/무효화 전략 정리
-- 관련 검증 테스트 추가
+- FanPost / ArtistPost / FanLetter는 post base cache + hot count cache로 분리되었다
+- `likeCount`, `commentCount` 같은 빠르게 바뀌는 숫자는 hot cache로 읽는다
+- ArtistPost hot count는 현재 `3초` TTL 기준으로 맞춰져 있다
+- 댓글은 base/hot 분리가 아니라 짧은 TTL 통캐시다
+- 부모댓글(root slice)은 보수적으로 조건부 캐시한다
+  - `post.commentCount >= 20 AND 10초 안에 5회 조회`
+- 자식댓글(replies)은 더 공격적으로 조건부 캐시한다
+  - `replyCount >= 20 OR 10초 안에 5회 조회`
+- 댓글 캐시 TTL은 현재 `3초`다
 
 프론트 준비 포인트:
 
-- count를 프론트 단독 truth로 두지 않는 구조가 좋다
-- optimistic UI는 가능하지만 서버 응답 덮어쓰기와 실패 롤백 경로가 필요하다
+- count를 프론트 단독 truth로 오래 들고 가지 않는 구조가 좋다
+- optimistic UI는 가능하지만 짧은 시간 뒤 서버 재조회 값으로 덮어쓸 수 있게 짜는 편이 안전하다
+- 댓글은 상세 진입 직후와 대댓글 펼침 시 재조회될 수 있으니, 로컬 상태와 서버 상태를 쉽게 동기화할 수 있게 두는 것이 좋다
 - HOT/최신 탭 전환이 생겨도 데이터 소스가 분리될 수 있게 컴포넌트를 짜두는 편이 좋다
 
 ## 5-3. 필수 3순위: 메인 홈 대시보드 / 아티스트 홈 대시보드
@@ -782,12 +802,17 @@ mock 우선:
 
 지금 프론트가 가장 안정적으로 붙일 수 있는 실구현 영역은 `검색 + 아티스트 상세 + FanPost 전체 + ArtistPost 전체 + FanLetter 전체 + Hashtag 추천`이다.
 
+추가로 알아둘 현재 백엔드 상태:
+
+- 포스트 조회는 base cache + hot count cache로 분리돼 있다
+- 댓글 조회는 짧은 TTL 조건부 캐시를 사용한다
+- 따라서 프론트는 숫자 count와 댓글 목록이 아주 짧은 간격으로 재동기화될 수 있음을 전제로 짜는 편이 안전하다
+
 앞으로 내가 구현할 핵심은 아래다.
 
 필수 구현 예정:
 
 - 아티스트페이지 코드 검토
-- 포스트페이지 동시성/캐싱
 - 메인 홈 대시보드 / 아티스트 홈 대시보드
 
 후순위 기능:

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/repository/CommentRepository.java
@@ -18,6 +18,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     List<Comment> findByParentIdOrderByIdAsc(Long parentId);
 
+    long countByParentId(Long parentId);
+
     boolean existsByParentId(Long parentId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/CommentService.java
@@ -10,6 +10,8 @@ import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
 import com.example.infinite.domain.artistcontent.comment.service.fanpost.FanPostCommentRedissonService;
 import com.example.infinite.domain.artistcontent.comment.service.artistpoststream.ArtistPostCommentStreamV2Service;
+import com.example.infinite.domain.artistcontent.comment.service.cache.CommentCacheInvalidationEvent;
+import com.example.infinite.domain.artistcontent.comment.service.cache.CommentQueryCacheService;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
@@ -25,6 +27,7 @@ import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMe
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +56,8 @@ public class CommentService {
     private final SubscriptionMembershipService subscriptionMembershipService;
     private final FanPostCommentRedissonService fanPostCommentRedissonService;
     private final ArtistPostCommentStreamV2Service artistPostCommentStreamV2Service;
+    private final CommentQueryCacheService commentQueryCacheService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public CommentResponse createFanPostComment(
@@ -171,6 +176,7 @@ public class CommentService {
         changeCommentCount(targetType, artistId, targetId, 1);
         CommentMentionResponse mentionedMember = commentMentionService.syncMention(comment, mentionNickname);
         WriterSubscriptionBadge writerBadge = loadSingleWriterBadge(artistId, member.getId());
+        publishCommentCacheInvalidation(targetType, targetId, parentComment == null ? null : parentComment.getId());
 
         return CommentResponse.from(
                 comment,
@@ -181,46 +187,14 @@ public class CommentService {
     }
 
     private CursorSliceResponse<CommentResponse> getComments(PostType targetType, Long artistId, Long targetId, Long cursor) {
-        // 댓글 기본 조회는 부모 댓글 slice만 내리고, 대댓글은 별도 endpoint에서 온디맨드로 조회한다.
-        List<Comment> rootComments = commentRepository.findRootSliceByTargetTypeAndTargetId(
+        // root comment는 "댓글 수도 충분히 많고 조회도 반복되는 post"에서만 admission을 통과한다.
+        return commentQueryCacheService.getRootSlice(
                 targetType,
+                artistId,
                 targetId,
                 cursor,
-                COMMENT_SLICE_SIZE + 1
+                () -> loadRootComments(targetType, artistId, targetId, cursor)
         );
-        boolean hasNext = rootComments.size() > COMMENT_SLICE_SIZE;
-        List<Comment> visibleRootComments = hasNext ? rootComments.subList(0, COMMENT_SLICE_SIZE) : rootComments;
-
-        List<Long> rootCommentIds = visibleRootComments.stream()
-                .map(Comment::getId)
-                .toList();
-        Map<Long, Integer> replyCountsByParentId = commentRepository.findReplyCountsByParentIds(rootCommentIds);
-        Map<Long, WriterSubscriptionBadge> badgeByWriterId = loadWriterBadges(
-                artistId,
-                visibleRootComments.stream().map(comment -> comment.getWriter().getId()).toList()
-        );
-
-        List<CommentResponse> content = visibleRootComments.stream()
-                .map(rootComment -> {
-                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
-                            rootComment.getWriter().getId(),
-                            WriterSubscriptionBadge.empty(rootComment.getWriter().getId())
-                    );
-                    return CommentResponse.from(
-                            rootComment,
-                            writerBadge.fanMembershipSubscribed(),
-                            writerBadge.dmSubscribed(),
-                            replyCountsByParentId.getOrDefault(rootComment.getId(), 0),
-                            null
-                    );
-                })
-                .toList();
-
-        Long nextCursor = hasNext && !visibleRootComments.isEmpty()
-                ? visibleRootComments.get(visibleRootComments.size() - 1).getId()
-                : null;
-
-        return new CursorSliceResponse<>(content, nextCursor, hasNext, COMMENT_SLICE_SIZE);
     }
 
     // 대댓글조회
@@ -230,26 +204,16 @@ public class CommentService {
             throw new CommentException(CommentErrorCode.INVALID_PARENT_COMMENT);
         }
 
-        List<Comment> replies = commentRepository.findRepliesByParentId(parentCommentId, COMMENT_REPLY_LIMIT);
-        Map<Long, CommentMentionResponse> mentionByCommentId = loadMentionByCommentId(replies);
-        Map<Long, WriterSubscriptionBadge> badgeByWriterId = loadWriterBadges(
+        long replyCount = commentRepository.countByParentId(parentCommentId);
+        // replies는 "개수가 많거나, 조회 heat가 높으면" 캐시 admission을 통과한다.
+        return commentQueryCacheService.getReplies(
+                targetType,
                 artistId,
-                replies.stream().map(reply -> reply.getWriter().getId()).toList()
+                targetId,
+                parentCommentId,
+                replyCount,
+                () -> loadReplies(artistId, parentCommentId)
         );
-        return replies.stream()
-                .map(reply -> {
-                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
-                            reply.getWriter().getId(),
-                            WriterSubscriptionBadge.empty(reply.getWriter().getId())
-                    );
-                    return CommentResponse.from(
-                            reply,
-                            writerBadge.fanMembershipSubscribed(),
-                            writerBadge.dmSubscribed(),
-                            mentionByCommentId.get(reply.getId())
-                    );
-                })
-                .toList();
     }
 
     private void deleteComment(
@@ -283,6 +247,7 @@ public class CommentService {
                 comment.markDeletedPlaceholder();
             }
             changeCommentCount(targetType, artistId, targetId, -1);
+            publishCommentCacheInvalidation(targetType, targetId, comment.getId());
             return;
         }
 
@@ -296,6 +261,7 @@ public class CommentService {
                 parentComment.delete();
             }
         }
+        publishCommentCacheInvalidation(targetType, targetId, parentComment == null ? null : parentComment.getId());
     }
 
     private Comment resolveParentComment(PostType targetType, Long parentId, Long targetId) {
@@ -370,6 +336,77 @@ public class CommentService {
         }
     }
 
+    private CursorSliceResponse<CommentResponse> loadRootComments(
+            PostType targetType,
+            Long artistId,
+            Long targetId,
+            Long cursor
+    ) {
+        // 댓글 기본 조회는 부모 댓글 slice만 내리고, 대댓글은 별도 endpoint에서 온디맨드로 조회한다.
+        List<Comment> rootComments = commentRepository.findRootSliceByTargetTypeAndTargetId(
+                targetType,
+                targetId,
+                cursor,
+                COMMENT_SLICE_SIZE + 1
+        );
+        boolean hasNext = rootComments.size() > COMMENT_SLICE_SIZE;
+        List<Comment> visibleRootComments = hasNext ? rootComments.subList(0, COMMENT_SLICE_SIZE) : rootComments;
+
+        List<Long> rootCommentIds = visibleRootComments.stream()
+                .map(Comment::getId)
+                .toList();
+        Map<Long, Integer> replyCountsByParentId = commentRepository.findReplyCountsByParentIds(rootCommentIds);
+        Map<Long, WriterSubscriptionBadge> badgeByWriterId = loadWriterBadges(
+                artistId,
+                visibleRootComments.stream().map(comment -> comment.getWriter().getId()).toList()
+        );
+
+        List<CommentResponse> content = visibleRootComments.stream()
+                .map(rootComment -> {
+                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
+                            rootComment.getWriter().getId(),
+                            WriterSubscriptionBadge.empty(rootComment.getWriter().getId())
+                    );
+                    return CommentResponse.from(
+                            rootComment,
+                            writerBadge.fanMembershipSubscribed(),
+                            writerBadge.dmSubscribed(),
+                            replyCountsByParentId.getOrDefault(rootComment.getId(), 0),
+                            null
+                    );
+                })
+                .toList();
+
+        Long nextCursor = hasNext && !visibleRootComments.isEmpty()
+                ? visibleRootComments.get(visibleRootComments.size() - 1).getId()
+                : null;
+
+        return new CursorSliceResponse<>(content, nextCursor, hasNext, COMMENT_SLICE_SIZE);
+    }
+
+    private List<CommentResponse> loadReplies(Long artistId, Long parentCommentId) {
+        List<Comment> replies = commentRepository.findRepliesByParentId(parentCommentId, COMMENT_REPLY_LIMIT);
+        Map<Long, CommentMentionResponse> mentionByCommentId = loadMentionByCommentId(replies);
+        Map<Long, WriterSubscriptionBadge> badgeByWriterId = loadWriterBadges(
+                artistId,
+                replies.stream().map(reply -> reply.getWriter().getId()).toList()
+        );
+        return replies.stream()
+                .map(reply -> {
+                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
+                            reply.getWriter().getId(),
+                            WriterSubscriptionBadge.empty(reply.getWriter().getId())
+                    );
+                    return CommentResponse.from(
+                            reply,
+                            writerBadge.fanMembershipSubscribed(),
+                            writerBadge.dmSubscribed(),
+                            mentionByCommentId.get(reply.getId())
+                    );
+                })
+                .toList();
+    }
+
     private Map<Long, CommentMentionResponse> loadMentionByCommentId(List<Comment> comments) {
         List<Long> commentIds = comments.stream()
                 .map(Comment::getId)
@@ -387,5 +424,9 @@ public class CommentService {
     private WriterSubscriptionBadge loadSingleWriterBadge(Long artistId, Long writerId) {
         return subscriptionMembershipService.getWriterBadges(artistId, List.of(writerId))
                 .getOrDefault(writerId, WriterSubscriptionBadge.empty(writerId));
+    }
+
+    private void publishCommentCacheInvalidation(PostType targetType, Long targetId, Long rootCommentId) {
+        applicationEventPublisher.publishEvent(new CommentCacheInvalidationEvent(targetType, targetId, rootCommentId));
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCommandType.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCommandType.java
@@ -1,7 +1,16 @@
 package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
 
+/**
+ * 댓글 stream consumer 가 어떤 작업을 수행해야 하는지 나타내는 명령 타입이다.
+ *
+ * 댓글은 "생성/삭제" 모두 같은 stream 으로 흘리므로
+ * consumer 는 이 enum 으로 분기해 실제 코어 로직을 호출한다.
+ */
 public enum ArtistPostCommentCommandType {
+    // parentCommentId 가 없는 원댓글 생성
     CREATE_ROOT,
+    // parentCommentId 가 있는 대댓글 생성
     CREATE_REPLY,
+    // commentId 기준 삭제 또는 placeholder 전환
     DELETE
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCoreService.java
@@ -3,6 +3,7 @@ package com.example.infinite.domain.artistcontent.comment.service.artistpoststre
 import com.example.infinite.domain.artistcontent.comment.entity.Comment;
 import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
 import com.example.infinite.domain.artistcontent.comment.service.CommentMentionService;
+import com.example.infinite.domain.artistcontent.comment.service.cache.CommentCacheInvalidationEvent;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
@@ -60,6 +61,7 @@ public class ArtistPostCommentCoreService {
         ));
         commentMentionService.syncMention(comment, null);
         publishDelta(command.artistPostId(), 1L);
+        publishCommentCacheInvalidation(command.artistPostId(), null);
     }
 
     @Transactional
@@ -91,6 +93,7 @@ public class ArtistPostCommentCoreService {
         ));
         commentMentionService.syncMention(comment, mentionNickname);
         publishDelta(command.artistPostId(), 1L);
+        publishCommentCacheInvalidation(command.artistPostId(), parentComment.getId());
     }
 
     @Transactional
@@ -125,6 +128,7 @@ public class ArtistPostCommentCoreService {
                 comment.markDeletedPlaceholder();
             }
             publishDelta(command.artistPostId(), -1L);
+            publishCommentCacheInvalidation(command.artistPostId(), comment.getId());
             return;
         }
 
@@ -135,6 +139,7 @@ public class ArtistPostCommentCoreService {
         if (parentComment != null && parentComment.isDeletedPlaceholder() && !commentRepository.existsByParentId(parentComment.getId())) {
             parentComment.delete();
         }
+        publishCommentCacheInvalidation(command.artistPostId(), parentComment == null ? null : parentComment.getId());
     }
 
     public Long resolveRootCommentIdForDelete(Long artistPostId, Long commentId) {
@@ -149,6 +154,12 @@ public class ArtistPostCommentCoreService {
 
     private void publishDelta(Long artistPostId, long delta) {
         applicationEventPublisher.publishEvent(new ArtistPostCommentDeltaEvent(artistPostId, delta));
+    }
+
+    private void publishCommentCacheInvalidation(Long artistPostId, Long rootCommentId) {
+        applicationEventPublisher.publishEvent(
+                new CommentCacheInvalidationEvent(PostType.ARTIST_POST, artistPostId, rootCommentId)
+        );
     }
 
     private String resolveMentionNickname(String content, Long targetId, Comment parentComment) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCountFlushScheduler.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentCountFlushScheduler.java
@@ -20,6 +20,9 @@ public class ArtistPostCommentCountFlushScheduler {
     /**
      * 댓글 수 1차 반영 배치.
      * 변경된 post만 반영하므로 자주 돌아도 전체 재집계보다 부담이 훨씬 낮다.
+     *
+     * 읽기 경로에서는 commentCount를 hot cache로 짧게 캐시하므로,
+     * flush 주기와 캐시 TTL을 같이 가져가면 숫자 체감이 부드럽게 맞춰진다.
      */
     @Scheduled(fixedDelayString = "${artist-post.comment-count.flush-delay-ms:3000}")
     @Transactional
@@ -38,6 +41,8 @@ public class ArtistPostCommentCountFlushScheduler {
     /**
      * 댓글 수 2차 보정 배치.
      * placeholder 규칙까지 포함한 실제 comments 원본 기준으로 comment_count를 다시 맞춘다.
+     *
+     * flush가 "최근 변화량 반영"이라면 reconcile은 "최종 원본 재정산" 역할이다.
      */
     @Scheduled(cron = "${artist-post.comment-count.reconcile-cron:0 10 4 * * *}")
     @Transactional

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDelta.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDelta.java
@@ -1,5 +1,11 @@
 package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
 
+/**
+ * flush scheduler 가 DB에 반영할 commentCount 증감치만 담는 값 객체다.
+ *
+ * 핵심은 "댓글 row 전체"가 아니라
+ * "어느 게시글에 몇 개를 더하고 뺄지"만 들고 다니는 것이다.
+ */
 public record ArtistPostCommentDelta(
         Long artistPostId,
         long delta

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaBuffer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaBuffer.java
@@ -9,6 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * ArtistPost commentCount 의 "임시 증감치"를 Redis Hash 로 모아두는 버퍼다.
+ *
+ * 왜 필요한가:
+ * - 댓글 생성/삭제마다 DB count 컬럼을 바로 갱신하면 hot post 에 쓰기 경쟁이 커진다
+ * - 먼저 Redis 에 delta 만 쌓아두고
+ * - scheduler 가 모아서 DB에 반영하면 write pressure 를 줄일 수 있다
+ */
 @Component
 @RequiredArgsConstructor
 public class ArtistPostCommentDeltaBuffer {
@@ -31,6 +39,10 @@ public class ArtistPostCommentDeltaBuffer {
 
     private final StringRedisTemplate stringRedisTemplate;
 
+    /**
+     * 댓글 1개 생성/삭제가 끝날 때마다 delta 를 누적한다.
+     * 같은 게시글로 burst 가 와도 Redis hash field 하나에 계속 합산된다.
+     */
     public void accumulate(Long artistPostId, long delta) {
         stringRedisTemplate.opsForHash().increment(
                 ARTIST_POST_COMMENT_DELTA_KEY,
@@ -39,6 +51,14 @@ public class ArtistPostCommentDeltaBuffer {
         );
     }
 
+    /**
+     * scheduler 가 호출하는 drain 메서드다.
+     *
+     * drain 의 의미:
+     * - 읽기만 하는 것이 아니라
+     * - Redis 에 쌓인 값을 가져오면서 비워
+     * - "이번 flush 배치가 책임질 delta"로 확정하는 과정
+     */
     public List<ArtistPostCommentDelta> drainAll() {
         Set<Object> artistPostIds = stringRedisTemplate.opsForHash().keys(ARTIST_POST_COMMENT_DELTA_KEY);
         if (artistPostIds == null || artistPostIds.isEmpty()) {
@@ -57,6 +77,8 @@ public class ArtistPostCommentDeltaBuffer {
     }
 
     private long drainOne(Long artistPostId) {
+        // HGET 후 HDEL 을 따로 하면 중간 경쟁에서 중복 반영 위험이 생길 수 있으므로
+        // Lua script 로 "읽고 바로 삭제"를 원자적으로 처리한다.
         Long delta = stringRedisTemplate.execute(
                 DRAIN_HASH_FIELD_SCRIPT,
                 List.of(ARTIST_POST_COMMENT_DELTA_KEY),

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEvent.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEvent.java
@@ -1,5 +1,11 @@
 package com.example.infinite.domain.artistcontent.comment.service.artistpoststream;
 
+/**
+ * 댓글 트랜잭션이 끝난 뒤 Redis delta 누적으로 넘기기 위한 경량 이벤트다.
+ *
+ * DB write 와 count 집계를 분리하되,
+ * 이벤트 자체는 "게시글 id + delta" 만큼만 남겨 비용을 줄인다.
+ */
 public record ArtistPostCommentDeltaEvent(
         Long artistPostId,
         long delta

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEventListener.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentDeltaEventListener.java
@@ -11,6 +11,12 @@ public class ArtistPostCommentDeltaEventListener {
 
     private final ArtistPostCommentDeltaBuffer artistPostCommentDeltaBuffer;
 
+    /**
+     * 댓글 원본 트랜잭션과 count 집계를 분리하는 연결 지점이다.
+     *
+     * 댓글 DB write 가 커밋된 뒤에만 Redis delta 누적을 허용해
+     * 롤백된 댓글이 count 에 섞이지 않게 한다.
+     */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ArtistPostCommentDeltaEvent event) {
         // 댓글 row 트랜잭션이 실제로 커밋된 뒤에만 commentCount delta를 누적한다.

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamCommand.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamCommand.java
@@ -7,6 +7,13 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * ArtistPost 댓글 비동기 처리용 Stream payload 객체다.
+ *
+ * 좋아요 stream command 와 비슷하지만 댓글은 명령 종류에 따라
+ * parentCommentId / commentId / content 의 필요 여부가 달라서
+ * null 가능 필드를 함께 가진다.
+ */
 public record ArtistPostCommentStreamCommand(
         String requestId,
         ArtistPostCommentCommandType commandType,
@@ -18,6 +25,10 @@ public record ArtistPostCommentStreamCommand(
         String content,
         String queuedAt
 ) {
+    /**
+     * queuedAt 은 "DB 반영 완료 시각"이 아니라 "큐에 들어간 시각"이다.
+     * 지연 추적이나 dead-letter 분석 때 도움이 된다.
+     */
     public static ArtistPostCommentStreamCommand create(
             String requestId,
             ArtistPostCommentCommandType commandType,
@@ -41,6 +52,10 @@ public record ArtistPostCommentStreamCommand(
         );
     }
 
+    /**
+     * commandType 에 따라 nullable 필드가 있으므로
+     * 값이 있는 필드만 Map 에 담아 Stream payload 를 가볍게 유지한다.
+     */
     public MapRecord<String, String, String> toRecord(String streamKey) {
         Map<String, String> fields = new LinkedHashMap<>();
         fields.put("requestId", requestId);
@@ -61,6 +76,10 @@ public record ArtistPostCommentStreamCommand(
         return StreamRecords.newRecord().in(streamKey).ofMap(fields);
     }
 
+    /**
+     * consumer 가 Redis 메시지를 읽은 뒤
+     * 다시 도메인 친화적인 command 객체로 복원하는 진입점이다.
+     */
     public static ArtistPostCommentStreamCommand from(MapRecord<String, Object, Object> record) {
         Map<Object, Object> fields = record.getValue();
         return new ArtistPostCommentStreamCommand(

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamConsumer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamConsumer.java
@@ -8,10 +8,13 @@ import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +25,9 @@ public class ArtistPostCommentStreamConsumer {
 
     private static final String CONSUMER_NAME = "artist-post-comment-v2-consumer";
     private static final int BATCH_SIZE = 100;
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final Duration RETRY_STATE_TTL = Duration.ofHours(1);
+    private static final String DLQ_STREAM_KEY = "artist-post:comment:v2:dlq";
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ArtistPostCommentStreamProcessor processor;
@@ -38,10 +44,9 @@ public class ArtistPostCommentStreamConsumer {
      */
     @Scheduled(fixedDelayString = "${artist-post.comment-v2.consumer-delay-ms:300}")
     public void consume() {
-        if (consumeRecords(readPendingRecords())) {
-            return;
-        }
-
+        // pending 을 먼저 재처리하되, 독성 메시지 하나 때문에 새 댓글 명령이 굶지 않게
+        // 이번 poll 에서 new message도 계속 읽는다.
+        consumeRecords(readPendingRecords());
         consumeRecords(readNewRecords());
     }
 
@@ -71,34 +76,87 @@ public class ArtistPostCommentStreamConsumer {
         }
     }
 
-    private boolean consumeRecords(List<MapRecord<String, Object, Object>> records) {
+    private void consumeRecords(List<MapRecord<String, Object, Object>> records) {
         if (records == null || records.isEmpty()) {
-            return false;
+            return;
         }
 
         for (MapRecord<String, Object, Object> record : records) {
             Map<Object, Object> fields = record.getValue();
             if (fields.containsKey("__bootstrap__")) {
-                acknowledge(record);
+                acknowledgeAndDelete(record);
                 continue;
             }
 
             try {
                 processor.process(ArtistPostCommentStreamCommand.from(record));
-                acknowledge(record);
+                clearRetryState(record);
+                acknowledgeAndDelete(record);
             } catch (Exception e) {
-                log.error("ArtistPost comment stream process failed: recordId={}, error={}", record.getId(), e.getMessage(), e);
+                long retryCount = increaseRetryCount(record);
+                log.error(
+                        "ArtistPost comment stream process failed: recordId={}, retryCount={}, error={}",
+                        record.getId(),
+                        retryCount,
+                        e.getMessage(),
+                        e
+                );
+
+                if (retryCount > MAX_RETRY_COUNT) {
+                    moveToDeadLetter(record, e, retryCount);
+                    clearRetryState(record);
+                    acknowledgeAndDelete(record);
+                }
             }
         }
-
-        return true;
     }
 
-    private void acknowledge(MapRecord<String, Object, Object> record) {
+    /**
+     * 현재 댓글 stream 도 단일 consumer group 전제이므로
+     * 성공 처리 후 ACK 만 하지 말고 원본 엔트리도 삭제해 메모리 누적을 막는다.
+     */
+    private void acknowledgeAndDelete(MapRecord<String, Object, Object> record) {
         stringRedisTemplate.opsForStream().acknowledge(
                 ArtistPostCommentStreamProducer.STREAM_KEY,
                 ArtistPostCommentStreamProducer.CONSUMER_GROUP,
                 record.getId()
         );
+        stringRedisTemplate.opsForStream().delete(
+                ArtistPostCommentStreamProducer.STREAM_KEY,
+                record.getId()
+        );
+    }
+
+    private long increaseRetryCount(MapRecord<String, Object, Object> record) {
+        String retryKey = buildRetryKey(record);
+        Long retryCount = stringRedisTemplate.opsForValue().increment(retryKey);
+        stringRedisTemplate.expire(retryKey, RETRY_STATE_TTL);
+        return retryCount == null ? 1L : retryCount;
+    }
+
+    private void clearRetryState(MapRecord<String, Object, Object> record) {
+        stringRedisTemplate.delete(buildRetryKey(record));
+    }
+
+    private void moveToDeadLetter(MapRecord<String, Object, Object> record, Exception exception, long retryCount) {
+        Map<String, String> deadLetterFields = new LinkedHashMap<>();
+        for (Map.Entry<Object, Object> entry : record.getValue().entrySet()) {
+            deadLetterFields.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+        deadLetterFields.put("originalRecordId", record.getId().getValue());
+        deadLetterFields.put("retryCount", Long.toString(retryCount));
+        deadLetterFields.put("failedAt", Instant.now().toString());
+        deadLetterFields.put("error", exception.getClass().getSimpleName());
+        deadLetterFields.put("errorMessage", exception.getMessage() == null ? "" : exception.getMessage());
+
+        stringRedisTemplate.opsForStream().add(
+                StreamRecords.newRecord()
+                        .in(DLQ_STREAM_KEY)
+                        .ofMap(deadLetterFields)
+        );
+    }
+
+    private String buildRetryKey(MapRecord<String, Object, Object> record) {
+        return "artist-post:comment:v2:retry:" + record.getId().getValue();
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProducer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/artistpoststream/ArtistPostCommentStreamProducer.java
@@ -5,6 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+/**
+ * 댓글 비동기 명령을 Redis Stream 에 적재하는 producer 다.
+ *
+ * producer 는 "큐에 넣는 책임"만 갖고,
+ * 실제 DB 반영은 consumer/processor 로 넘긴다.
+ */
 @Component
 @RequiredArgsConstructor
 public class ArtistPostCommentStreamProducer {
@@ -17,6 +23,7 @@ public class ArtistPostCommentStreamProducer {
 
     public void enqueue(ArtistPostCommentStreamCommand command) {
         // 댓글 v2도 좋아요 v3와 같은 패턴으로 "HTTP 요청 수신"과 "DB 댓글 쓰기"를 분리한다.
+        // group 이 먼저 있어야 consumer 가 처음 붙는 순간부터 pending 메시지를 정상 인계받는다.
         redisStreamGroupHelper.ensureGroup(STREAM_KEY, CONSUMER_GROUP);
         stringRedisTemplate.opsForStream().add(command.toRecord(STREAM_KEY));
     }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentCacheInvalidationEvent.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentCacheInvalidationEvent.java
@@ -1,0 +1,24 @@
+package com.example.infinite.domain.artistcontent.comment.service.cache;
+
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+
+/**
+ * 댓글 생성/삭제 후 어떤 댓글 캐시 범위를 비워야 하는지 전달하는 이벤트다.
+ *
+ * root comment slice는 post 단위로,
+ * replies는 root thread 단위로 관리하므로
+ * invalidation도 그 두 축으로 분리해 들고 간다.
+ */
+public record CommentCacheInvalidationEvent(
+        PostType targetType,
+        Long targetId,
+        Long rootCommentId
+) {
+    public static CommentCacheInvalidationEvent forRootSlice(PostType targetType, Long targetId) {
+        return new CommentCacheInvalidationEvent(targetType, targetId, null);
+    }
+
+    public static CommentCacheInvalidationEvent forThread(PostType targetType, Long targetId, Long rootCommentId) {
+        return new CommentCacheInvalidationEvent(targetType, targetId, rootCommentId);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentCacheInvalidationListener.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentCacheInvalidationListener.java
@@ -1,0 +1,25 @@
+package com.example.infinite.domain.artistcontent.comment.service.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCacheInvalidationListener {
+
+    private final CommentQueryCacheService commentQueryCacheService;
+
+    /**
+     * 댓글 캐시는 실제 DB write가 커밋된 뒤에만 비운다.
+     * 그래야 롤백된 댓글 생성/삭제 때문에 정상 캐시를 불필요하게 날리지 않는다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(CommentCacheInvalidationEvent event) {
+        commentQueryCacheService.evictRootSliceScope(event.targetType(), event.targetId());
+        if (event.rootCommentId() != null) {
+            commentQueryCacheService.evictReplyScope(event.targetType(), event.targetId(), event.rootCommentId());
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentQueryCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentQueryCacheService.java
@@ -1,0 +1,158 @@
+package com.example.infinite.domain.artistcontent.comment.service.cache;
+
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotDataCacheService;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.global.common.constant.CacheNames;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryCacheService {
+
+    private static final long ROOT_COMMENT_COUNT_THRESHOLD = 20L;
+    private static final long REPLY_COUNT_THRESHOLD = 20L;
+    private static final long HEAT_THRESHOLD = 5L;
+    private static final Duration HEAT_WINDOW = Duration.ofSeconds(10);
+    private static final Duration INDEX_TTL = Duration.ofMinutes(10);
+
+    private final CacheManager cacheManager;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final PostHotDataCacheService postHotDataCacheService;
+
+    /**
+     * root comment는 조건을 보수적으로 잡는다.
+     * post 전체의 commentCount도 충분히 크고, 실제 조회도 반복돼야 캐시 admission을 통과한다.
+     */
+    public CursorSliceResponse<CommentResponse> getRootSlice(
+            PostType targetType,
+            Long artistId,
+            Long targetId,
+            Long cursor,
+            Supplier<CursorSliceResponse<CommentResponse>> loader
+    ) {
+        long heat = increaseHeat(buildRootHeatKey(targetType, targetId));
+        PostHotData hotData = postHotDataCacheService.getPostHotData(targetType, targetId);
+        boolean shouldCache = hotData.commentCount() >= ROOT_COMMENT_COUNT_THRESHOLD && heat >= HEAT_THRESHOLD;
+        if (!shouldCache) {
+            return loader.get();
+        }
+
+        Cache cache = cacheManager.getCache(CacheNames.COMMENT_ROOT_SLICE);
+        String cacheKey = buildRootCacheKey(targetType, artistId, targetId, cursor);
+        CommentRootSliceCacheEntry cached = cache == null ? null : cache.get(cacheKey, CommentRootSliceCacheEntry.class);
+        if (cached != null) {
+            return cached.value();
+        }
+
+        CursorSliceResponse<CommentResponse> loaded = loader.get();
+        if (cache != null) {
+            cache.put(cacheKey, new CommentRootSliceCacheEntry(loaded));
+            registerScopeKey(buildRootScopeKey(targetType, targetId), cacheKey);
+        }
+        return loaded;
+    }
+
+    /**
+     * replies는 특정 thread만 갑자기 뜨거워질 수 있으므로 admission을 더 공격적으로 잡는다.
+     * reply 수가 많거나, 조회 heat가 높으면 캐시한다.
+     */
+    public List<CommentResponse> getReplies(
+            PostType targetType,
+            Long artistId,
+            Long targetId,
+            Long parentCommentId,
+            long replyCount,
+            Supplier<List<CommentResponse>> loader
+    ) {
+        long heat = increaseHeat(buildReplyHeatKey(targetType, targetId, parentCommentId));
+        boolean shouldCache = replyCount >= REPLY_COUNT_THRESHOLD || heat >= HEAT_THRESHOLD;
+        if (!shouldCache) {
+            return loader.get();
+        }
+
+        Cache cache = cacheManager.getCache(CacheNames.COMMENT_REPLY_LIST);
+        String cacheKey = buildReplyCacheKey(targetType, artistId, targetId, parentCommentId);
+        CommentReplyListCacheEntry cached = cache == null ? null : cache.get(cacheKey, CommentReplyListCacheEntry.class);
+        if (cached != null) {
+            return cached.value();
+        }
+
+        List<CommentResponse> loaded = loader.get();
+        if (cache != null) {
+            cache.put(cacheKey, new CommentReplyListCacheEntry(loaded));
+            registerScopeKey(buildReplyScopeKey(targetType, targetId, parentCommentId), cacheKey);
+        }
+        return loaded;
+    }
+
+    public void evictRootSliceScope(PostType targetType, Long targetId) {
+        evictScope(CacheNames.COMMENT_ROOT_SLICE, buildRootScopeKey(targetType, targetId));
+    }
+
+    public void evictReplyScope(PostType targetType, Long targetId, Long rootCommentId) {
+        evictScope(CacheNames.COMMENT_REPLY_LIST, buildReplyScopeKey(targetType, targetId, rootCommentId));
+    }
+
+    private void evictScope(String cacheName, String scopeKey) {
+        Cache cache = cacheManager.getCache(cacheName);
+        // 댓글 캐시는 cursor/parentCommentId마다 키가 갈라지므로,
+        // scopeKey에 "이번 post/thread에서 생성된 실제 cache key 목록"을 모아두고 한 번에 비운다.
+        Set<String> cacheKeys = stringRedisTemplate.opsForSet().members(scopeKey);
+        if (cacheKeys != null && cache != null) {
+            for (String cacheKey : cacheKeys) {
+                cache.evict(cacheKey);
+            }
+        }
+        stringRedisTemplate.delete(scopeKey);
+    }
+
+    private void registerScopeKey(String scopeKey, String cacheKey) {
+        // scope set이 없으면 댓글 생성/삭제 시 어떤 세부 키를 지워야 할지 몰라 evict 범위를 좁히기 어렵다.
+        stringRedisTemplate.opsForSet().add(scopeKey, cacheKey);
+        stringRedisTemplate.expire(scopeKey, INDEX_TTL);
+    }
+
+    private long increaseHeat(String heatKey) {
+        // admission 전용 조회 heat 카운터.
+        // 10초 창에서 "실제로 반복 조회되는가"만 보고, 기간이 지나면 자동으로 식는다.
+        Long heat = stringRedisTemplate.opsForValue().increment(heatKey);
+        stringRedisTemplate.expire(heatKey, HEAT_WINDOW);
+        return heat == null ? 1L : heat;
+    }
+
+    private String buildRootCacheKey(PostType targetType, Long artistId, Long targetId, Long cursor) {
+        return targetType.name() + ":" + artistId + ":" + targetId + ":" + (cursor == null ? "first" : cursor);
+    }
+
+    private String buildReplyCacheKey(PostType targetType, Long artistId, Long targetId, Long parentCommentId) {
+        return targetType.name() + ":" + artistId + ":" + targetId + ":" + parentCommentId;
+    }
+
+    private String buildRootScopeKey(PostType targetType, Long targetId) {
+        return "comment:cache:index:root:" + targetType.name() + ":" + targetId;
+    }
+
+    private String buildReplyScopeKey(PostType targetType, Long targetId, Long parentCommentId) {
+        return "comment:cache:index:reply:" + targetType.name() + ":" + targetId + ":" + parentCommentId;
+    }
+
+    private String buildRootHeatKey(PostType targetType, Long targetId) {
+        return "comment:cache:heat:root:" + targetType.name() + ":" + targetId;
+    }
+
+    private String buildReplyHeatKey(PostType targetType, Long targetId, Long parentCommentId) {
+        return "comment:cache:heat:reply:" + targetType.name() + ":" + targetId + ":" + parentCommentId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentReplyListCacheEntry.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentReplyListCacheEntry.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.artistcontent.comment.service.cache;
+
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+
+import java.util.List;
+
+/**
+ * 대댓글 목록 캐시 래퍼다.
+ * reply list도 제네릭 List<CommentResponse>를 직접 Cache.get(..., Class)로 읽기 어렵기 때문에 감싼다.
+ */
+public record CommentReplyListCacheEntry(
+        List<CommentResponse> value
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentRootSliceCacheEntry.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/cache/CommentRootSliceCacheEntry.java
@@ -1,0 +1,15 @@
+package com.example.infinite.domain.artistcontent.comment.service.cache;
+
+import com.example.infinite.domain.artistcontent.comment.dto.response.CommentResponse;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+
+/**
+ * 제네릭 댓글 슬라이스를 Spring Cache에 안전하게 넣고 꺼내기 위한 래퍼다.
+ *
+ * raw CursorSliceResponse.class 로 직접 캐스팅하면 내부 제네릭 정보가 흐려질 수 있어
+ * 전용 entry record로 한 번 감싼다.
+ */
+public record CommentRootSliceCacheEntry(
+        CursorSliceResponse<CommentResponse> value
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentCoreService.java
@@ -8,6 +8,7 @@ import com.example.infinite.domain.artistcontent.comment.error.CommentErrorCode;
 import com.example.infinite.domain.artistcontent.comment.error.CommentException;
 import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
 import com.example.infinite.domain.artistcontent.comment.service.CommentMentionService;
+import com.example.infinite.domain.artistcontent.comment.service.cache.CommentCacheInvalidationEvent;
 import com.example.infinite.domain.artistcontent.comment.support.CommentReader;
 import com.example.infinite.domain.artistcontent.comment.support.MentionParser;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
@@ -20,6 +21,7 @@ import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSub
 import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,7 @@ public class FanPostCommentCoreService {
     private final CommentMentionService commentMentionService;
     private final MemberReader memberReader;
     private final SubscriptionMembershipService subscriptionMembershipService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * FanPost 댓글은 기존 동기 계약을 유지하되, count 갱신은 atomic update로 바꾼다.
@@ -48,10 +51,14 @@ public class FanPostCommentCoreService {
      */
     @Transactional
     public CommentResponse create(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId, CommentCreateRequest request) {
+        // 작성자와 대상 글을 먼저 확정해야
+        // 이후의 parent 검증 / mention 해석 / count 반영이 모두 같은 기준 위에서 동작한다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
 
+        // parent 는 depth 2 정책을 지키는지 확인하는 핵심 지점이다.
         Comment parentComment = resolveParentComment(request.parentId(), fanPostId);
+        // mention 은 "대댓글에서만, 같은 thread 참여자만" 허용되는 규칙을 여기서 해석한다.
         String mentionNickname = resolveMentionNickname(request.content(), fanPostId, parentComment);
 
         Comment comment = commentRepository.save(Comment.create(
@@ -61,7 +68,10 @@ public class FanPostCommentCoreService {
                 request.content(),
                 parentComment
         ));
+        // count 는 엔티티를 다시 읽어 변경하지 않고 atomic update 로 바로 반영해
+        // 같은 게시글에 댓글이 몰릴 때 lost update 위험을 줄인다.
         fanPostRepository.changeCommentCountBy(fanPostId, 1L);
+        publishCommentCacheInvalidation(PostType.FAN_POST, fanPostId, parentComment == null ? null : parentComment.getId());
 
         CommentMentionResponse mentionedMember = commentMentionService.syncMention(comment, mentionNickname);
         WriterSubscriptionBadge writerBadge = loadSingleWriterBadge(artistId, member.getId());
@@ -83,6 +93,7 @@ public class FanPostCommentCoreService {
             throw new CommentException(CommentErrorCode.COMMENT_PERMISSION_DENIED);
         }
         if (comment.isDeletedPlaceholder()) {
+            // 이미 "삭제된 댓글" placeholder 인 경우 다시 count 를 건드리면 안 된다.
             return;
         }
 
@@ -90,24 +101,33 @@ public class FanPostCommentCoreService {
 
         if (comment.isRootComment()) {
             if (!commentRepository.existsByParentId(comment.getId())) {
+                // 자식이 하나도 없으면 부모 댓글 자체를 그냥 soft delete 한다.
                 comment.delete();
             } else {
+                // 자식이 남아 있으면 문맥 유지를 위해 placeholder 로만 바꾼다.
                 comment.markDeletedPlaceholder();
             }
             fanPostRepository.changeCommentCountBy(fanPostId, -1L);
+            publishCommentCacheInvalidation(PostType.FAN_POST, fanPostId, comment.getId());
             return;
         }
 
+        // reply 는 바로 soft delete 하고 count 를 감소시킨다.
         comment.delete();
         fanPostRepository.changeCommentCountBy(fanPostId, -1L);
 
         Comment parentComment = comment.getParent();
         if (parentComment != null && parentComment.isDeletedPlaceholder() && !commentRepository.existsByParentId(parentComment.getId())) {
+            // placeholder 부모에 달린 마지막 reply 도 사라졌다면
+            // 이제 부모를 실제 soft delete 로 마무리할 수 있다.
             parentComment.delete();
         }
+        publishCommentCacheInvalidation(PostType.FAN_POST, fanPostId, parentComment == null ? null : parentComment.getId());
     }
 
     public Long resolveRootCommentId(Long fanPostId, Long commentId) {
+        // 삭제 시 현재 댓글이 root 인지 reply 인지에 따라
+        // 어떤 thread lock 키를 써야 하는지 계산한다.
         Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, PostType.FAN_POST, fanPostId);
         return comment.isRootComment() ? comment.getId() : comment.getParent().getId();
     }
@@ -121,6 +141,8 @@ public class FanPostCommentCoreService {
             return null;
         }
 
+        // parent 는 반드시 같은 글의 root comment 여야 한다.
+        // reply 아래에 reply 를 다는 순간 3-depth 가 되므로 금지한다.
         Comment parentComment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(parentId, PostType.FAN_POST, fanPostId);
         if (!parentComment.isRootComment()) {
             throw new CommentException(CommentErrorCode.COMMENT_DEPTH_EXCEEDED);
@@ -131,6 +153,7 @@ public class FanPostCommentCoreService {
     private String resolveMentionNickname(String content, Long fanPostId, Comment parentComment) {
         List<String> mentionedNicknames = MentionParser.extractMentionedNicknames(content);
         if (mentionedNicknames.isEmpty() || parentComment == null) {
+            // 원댓글에서는 mention 을 해석하지 않고, 대댓글이 아닐 때도 그냥 일반 텍스트로 둔다.
             return null;
         }
 
@@ -144,6 +167,7 @@ public class FanPostCommentCoreService {
                 .map(nickname -> nickname.strip().toLowerCase(Locale.ROOT))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
+        // 여러 @문자가 있어도 "같은 thread 참여자에 해당하는 첫 번째 한 명"만 인정한다.
         return mentionedNicknames.stream()
                 .filter(allowedNicknames::contains)
                 .findFirst()
@@ -153,5 +177,9 @@ public class FanPostCommentCoreService {
     private WriterSubscriptionBadge loadSingleWriterBadge(Long artistId, Long writerId) {
         return subscriptionMembershipService.getWriterBadges(artistId, List.of(writerId))
                 .getOrDefault(writerId, WriterSubscriptionBadge.empty(writerId));
+    }
+
+    private void publishCommentCacheInvalidation(PostType targetType, Long targetId, Long rootCommentId) {
+        applicationEventPublisher.publishEvent(new CommentCacheInvalidationEvent(targetType, targetId, rootCommentId));
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/comment/service/fanpost/FanPostCommentRedissonLockedService.java
@@ -15,6 +15,14 @@ public class FanPostCommentRedissonLockedService {
 
     private final FanPostCommentCoreService fanPostCommentCoreService;
 
+    /**
+     * 대댓글 생성은 root thread 단위 락 안에서만 수행한다.
+     *
+     * 왜 rootCommentId 로 잠그는가:
+     * - 같은 스레드 안에서는 reply 생성/삭제/placeholder 처리 순서가 중요
+     * - 하지만 서로 다른 루트 댓글 스레드까지 함께 막을 필요는 없음
+     * - 그래서 "post 전체 락"보다 "thread 락"이 훨씬 덜 비싸다
+     */
     @RedisLock(
             key = "'fan-post:comment-thread:' + #rootCommentId",
             waitTime = 1,
@@ -28,9 +36,15 @@ public class FanPostCommentRedissonLockedService {
             CommentCreateRequest request,
             Long rootCommentId
     ) {
+        // 락을 잡은 상태에서 실제 생성은 core service에 위임해
+        // 비즈니스 로직과 락 기술 코드를 분리한다.
         return fanPostCommentCoreService.create(memberDetails, artistId, fanPostId, request);
     }
 
+    /**
+     * 삭제도 같은 root thread 기준으로 직렬화한다.
+     * 그래야 "마지막 reply 삭제 -> placeholder parent 정리" 같은 후처리가 꼬이지 않는다.
+     */
     @RedisLock(
             key = "'fan-post:comment-thread:' + #rootCommentId",
             waitTime = 1,

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamCommand.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamCommand.java
@@ -6,6 +6,14 @@ import org.springframework.data.redis.connection.stream.StreamRecords;
 import java.time.Instant;
 import java.util.Map;
 
+/**
+ * Redis Stream 에 넣는 ArtistPost 좋아요 명령 객체다.
+ *
+ * 왜 별도 record 로 분리했는가:
+ * - HTTP 요청 파라미터와 Stream payload 형식은 수명이 다르다
+ * - producer / consumer 가 같은 필드 이름 규약을 공유해야 한다
+ * - 직렬화/역직렬화 규칙을 한 파일에 모아야 추후 필드 추가 시 덜 위험하다
+ */
 public record ArtistPostLikeStreamCommand(
         String requestId,
         Long artistId,
@@ -15,6 +23,12 @@ public record ArtistPostLikeStreamCommand(
         long pendingVersion,
         String queuedAt
 ) {
+    /**
+     * command 생성 시점의 시간을 함께 넣어 두면
+     * - consumer 지연 관찰
+     * - 디버깅 시 "언제 큐에 들어왔는지" 추적
+     * 에 도움이 된다.
+     */
     public static ArtistPostLikeStreamCommand create(
             String requestId,
             Long artistId,
@@ -34,6 +48,10 @@ public record ArtistPostLikeStreamCommand(
         );
     }
 
+    /**
+     * Spring Redis Stream API 는 Map 형태 payload 를 다루므로
+     * record -> MapRecord 변환을 여기서 책임진다.
+     */
     public MapRecord<String, String, String> toRecord(String streamKey) {
         return StreamRecords.newRecord()
                 .in(streamKey)
@@ -48,6 +66,10 @@ public record ArtistPostLikeStreamCommand(
                 ));
     }
 
+    /**
+     * consumer 쪽에서는 Redis 레코드를 다시 command 로 복원해
+     * 일반 서비스 로직처럼 읽기 쉬운 형태로 처리한다.
+     */
     public static ArtistPostLikeStreamCommand from(MapRecord<String, Object, Object> record) {
         Map<Object, Object> fields = record.getValue();
         return new ArtistPostLikeStreamCommand(

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamConsumer.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamConsumer.java
@@ -8,10 +8,13 @@ import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +25,9 @@ public class ArtistPostLikeStreamConsumer {
 
     private static final String CONSUMER_NAME = "artist-post-like-v3-consumer";
     private static final int BATCH_SIZE = 200;
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final Duration RETRY_STATE_TTL = Duration.ofHours(1);
+    private static final String DLQ_STREAM_KEY = "artist-post:like:v3:dlq";
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ArtistPostLikeStreamProcessor processor;
@@ -40,10 +46,12 @@ public class ArtistPostLikeStreamConsumer {
     public void consume() {
         // 먼저 같은 consumer에 남아 있는 PEL(pending entries)을 재시도한다.
         // 그렇지 않으면 한 번 실패한 메시지는 lastConsumed() 경로에서 다시 안 읽혀 영구 미처리 상태가 된다.
-        if (consumeRecords(readPendingRecords())) {
-            return;
-        }
-
+        //
+        // 중요:
+        // 예전처럼 "pending 이 하나라도 있으면 여기서 종료"해 버리면
+        // 독성 메시지(poison message) 1개 때문에 뒤의 정상 새 메시지가 계속 굶을 수 있다.
+        // 그래서 pending 을 먼저 처리하되, 그 결과와 무관하게 new message도 계속 읽는다.
+        consumeRecords(readPendingRecords());
         consumeRecords(readNewRecords());
     }
 
@@ -73,34 +81,96 @@ public class ArtistPostLikeStreamConsumer {
         }
     }
 
-    private boolean consumeRecords(List<MapRecord<String, Object, Object>> records) {
+    private void consumeRecords(List<MapRecord<String, Object, Object>> records) {
         if (records == null || records.isEmpty()) {
-            return false;
+            return;
         }
 
         for (MapRecord<String, Object, Object> record : records) {
             Map<Object, Object> fields = record.getValue();
             if (fields.containsKey("__bootstrap__")) {
-                acknowledge(record);
+                acknowledgeAndDelete(record);
                 continue;
             }
 
             try {
                 processor.process(ArtistPostLikeStreamCommand.from(record));
-                acknowledge(record);
+                clearRetryState(record);
+                acknowledgeAndDelete(record);
             } catch (Exception e) {
-                log.error("ArtistPost like stream process failed: recordId={}, error={}", record.getId(), e.getMessage(), e);
+                long retryCount = increaseRetryCount(record);
+                log.error(
+                        "ArtistPost like stream process failed: recordId={}, retryCount={}, error={}",
+                        record.getId(),
+                        retryCount,
+                        e.getMessage(),
+                        e
+                );
+
+                // 재시도 횟수가 임계치를 넘으면 DLQ로 격리하고 본 스트림에서는 제거한다.
+                // 이렇게 해야 pending 하나가 전체 스트림을 무한히 막는 상황을 피할 수 있다.
+                if (retryCount > MAX_RETRY_COUNT) {
+                    moveToDeadLetter(record, e, retryCount);
+                    clearRetryState(record);
+                    acknowledgeAndDelete(record);
+                }
             }
         }
-
-        return true;
     }
 
-    private void acknowledge(MapRecord<String, Object, Object> record) {
+    /**
+     * 현재 구조는 consumer group 을 하나로만 쓰므로
+     * 성공 처리 후에는 ACK 뿐 아니라 원본 엔트리 삭제까지 같이 수행한다.
+     *
+     * ACK 만 하면 PEL 에서는 빠지지만 Stream 메모리에는 계속 남기 때문에
+     * 고트래픽 환경에서는 stream 길이가 무한히 커질 수 있다.
+     */
+    private void acknowledgeAndDelete(MapRecord<String, Object, Object> record) {
         stringRedisTemplate.opsForStream().acknowledge(
                 ArtistPostLikeStreamProducer.STREAM_KEY,
                 ArtistPostLikeStreamProducer.CONSUMER_GROUP,
                 record.getId()
         );
+        stringRedisTemplate.opsForStream().delete(
+                ArtistPostLikeStreamProducer.STREAM_KEY,
+                record.getId()
+        );
+    }
+
+    private long increaseRetryCount(MapRecord<String, Object, Object> record) {
+        String retryKey = buildRetryKey(record);
+        Long retryCount = stringRedisTemplate.opsForValue().increment(retryKey);
+        stringRedisTemplate.expire(retryKey, RETRY_STATE_TTL);
+        return retryCount == null ? 1L : retryCount;
+    }
+
+    private void clearRetryState(MapRecord<String, Object, Object> record) {
+        stringRedisTemplate.delete(buildRetryKey(record));
+    }
+
+    /**
+     * DLQ는 "나중에 사람이 보고 복구할 수 있게 남겨두는 격리 구역"이다.
+     * 원본 payload를 최대한 보존하고, 왜 떨어졌는지 최소한의 실패 메타데이터를 덧붙인다.
+     */
+    private void moveToDeadLetter(MapRecord<String, Object, Object> record, Exception exception, long retryCount) {
+        Map<String, String> deadLetterFields = new LinkedHashMap<>();
+        for (Map.Entry<Object, Object> entry : record.getValue().entrySet()) {
+            deadLetterFields.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+        deadLetterFields.put("originalRecordId", record.getId().getValue());
+        deadLetterFields.put("retryCount", Long.toString(retryCount));
+        deadLetterFields.put("failedAt", Instant.now().toString());
+        deadLetterFields.put("error", exception.getClass().getSimpleName());
+        deadLetterFields.put("errorMessage", exception.getMessage() == null ? "" : exception.getMessage());
+
+        stringRedisTemplate.opsForStream().add(
+                StreamRecords.newRecord()
+                        .in(DLQ_STREAM_KEY)
+                        .ofMap(deadLetterFields)
+        );
+    }
+
+    private String buildRetryKey(MapRecord<String, Object, Object> record) {
+        return "artist-post:like:v3:retry:" + record.getId().getValue();
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamV3Service.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/artistpostlike/stream/ArtistPostLikeStreamV3Service.java
@@ -13,10 +13,22 @@ public class ArtistPostLikeStreamV3Service {
 
     private final ArtistPostLikeRedissonV3LockedService artistPostLikeRedissonV3LockedService;
 
+    /**
+     * 컨트롤러가 호출하는 V3 좋아요 진입 서비스다.
+     *
+     * 역할을 얇게 둔 이유:
+     * - 실제 동시성 제어는 lock service가 담당
+     * - 여기서는 "락 충돌을 어떤 API 에러로 바꿀지"만 결정
+     *
+     * 즉 controller -> v3 service -> locked service 로 층을 나눠
+     * HTTP 계약과 락 처리 로직을 섞지 않게 만든다.
+     */
     public ArtistPostLikeQueuedResponse queue(Long memberId, Long artistId, Long artistPostId) {
         try {
             return artistPostLikeRedissonV3LockedService.queueWithLock(memberId, artistId, artistPostId);
         } catch (LockException e) {
+            // 같은 member + post 요청이 아직 처리 중이면 "이미 진행 중" 에러로 바꿔
+            // 클라이언트가 중복 클릭/재시도를 해석할 수 있게 한다.
             throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
         }
     }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeCoreService.java
@@ -34,9 +34,13 @@ public class CommentLikeCoreService {
      */
     @Transactional
     public InteractionResponse toggle(Long memberId, Long artistId, Long targetId, Long commentId, PostType targetType) {
+        // 댓글 좋아요는 "댓글이 속한 원글"이 유효한지와 "댓글 자체"가 유효한지를 둘 다 확인해야 한다.
+        // targetType/targetId 검증은 댓글이 올바른 게시글 문맥 안에 있는지 확인하는 단계다.
         validateTarget(targetType, artistId, targetId);
         Comment comment = commentReader.findByIdAndTargetTypeAndTargetIdOrThrow(commentId, targetType, targetId);
 
+        // Reaction의 실제 타깃은 FAN_POST / ARTIST_POST가 아니라 COMMENT다.
+        // 즉 "어느 글의 댓글인지"는 검증용 문맥이고, 좋아요 row는 commentId 기준으로 저장된다.
         return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
                         PostType.COMMENT,
                         comment.getId(),
@@ -69,6 +73,8 @@ public class CommentLikeCoreService {
     }
 
     private void validateTarget(PostType targetType, Long artistId, Long targetId) {
+        // 댓글 좋아요 API는 현재 FanPost, ArtistPost의 댓글만 지원한다.
+        // 원글을 먼저 검증해 두면 다른 글에 속한 commentId를 잘못 주는 요청도 초기에 걸러진다.
         switch (targetType) {
             case FAN_POST -> fanPostReader.findByIdAndArtistIdOrThrow(targetId, artistId);
             case ARTIST_POST -> artistPostReader.findByIdAndArtistIdOrThrow(targetId, artistId);

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/commentlike/CommentLikeRedissonService.java
@@ -14,6 +14,15 @@ public class CommentLikeRedissonService {
 
     private final CommentLikeRedissonLockedService commentLikeRedissonLockedService;
 
+    /**
+     * 컨트롤러/상위 서비스가 실제로 호출하는 댓글 좋아요 진입점이다.
+     *
+     * 이 계층을 따로 두는 이유:
+     * - locked service는 "락을 건 상태에서 실행"하는 데 집중
+     * - 여기서는 LockException을 API 의미가 있는 도메인 예외로 번역
+     *
+     * 즉 AOP 락 기술 세부사항이 바깥 계층으로 새지 않게 막는 얇은 facade다.
+     */
     public InteractionResponse toggle(Long memberId, Long artistId, Long targetId, Long commentId, PostType targetType) {
         try {
             return commentLikeRedissonLockedService.toggleWithLock(
@@ -24,6 +33,7 @@ public class CommentLikeRedissonService {
                     targetType
             );
         } catch (LockException e) {
+            // 사용자 입장에서는 "락 구현 실패"보다 "같은 좋아요 요청이 아직 처리 중"이라는 의미가 중요하다.
             throw new InteractionException(InteractionErrorCode.LIKE_REQUEST_IN_PROGRESS);
         }
     }

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeCoreService.java
@@ -6,8 +6,11 @@ import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
 import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.artistcontent.post.fanletter.service.FanLetterSpecialLikeCacheInvalidationEvent;
 import com.example.infinite.domain.artistcontent.post.fanletter.support.FanLetterReader;
+import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +22,8 @@ public class FanLetterLikeCoreService {
     private final InteractionRepository interactionRepository;
     private final FanLetterReader fanLetterReader;
     private final FanLetterRepository fanLetterRepository;
+    private final ArtistMemberRepository artistMemberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * FanLetter 좋아요는 트래픽 규모상 즉시 처리로 충분하다.
@@ -27,8 +32,9 @@ public class FanLetterLikeCoreService {
     @Transactional
     public InteractionResponse toggle(Long memberId, Long artistId, Long fanLetterId) {
         fanLetterReader.findByIdAndArtistIdOrThrow(fanLetterId, artistId);
+        boolean artistSpecialLikeActor = artistMemberRepository.existsByArtistIdAndMemberId(artistId, memberId);
 
-        return interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+        InteractionResponse response = interactionRepository.findByTargetTypeAndTargetIdAndMemberIdAndReactionType(
                         PostType.FAN_LETTER,
                         fanLetterId,
                         memberId,
@@ -36,6 +42,16 @@ public class FanLetterLikeCoreService {
                 )
                 .map(existingReaction -> cancelLike(existingReaction, fanLetterId))
                 .orElseGet(() -> addLike(memberId, fanLetterId));
+
+        if (artistSpecialLikeActor) {
+            // 팬 반응은 special-like overlay를 바꾸지 않지만,
+            // 아티스트 멤버 반응은 base cache에 들어 있는 artistLiked 값을 바꾼다.
+            applicationEventPublisher.publishEvent(
+                    new FanLetterSpecialLikeCacheInvalidationEvent(artistId, fanLetterId)
+            );
+        }
+
+        return response;
     }
 
     private InteractionResponse addLike(Long memberId, Long fanLetterId) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonLockedService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/interaction/service/fanletterlike/FanLetterLikeRedissonLockedService.java
@@ -13,6 +13,14 @@ public class FanLetterLikeRedissonLockedService {
 
     private final FanLetterLikeCoreService fanLetterLikeCoreService;
 
+    /**
+     * FanLetter 좋아요도 같은 member-target 조합만 직렬화한다.
+     *
+     * 학습 포인트:
+     * - 락 키를 fanLetterId + memberId로 잘게 쪼개면
+     * - "같은 유저의 중복 토글"만 막고
+     * - 다른 유저의 같은 글 좋아요는 계속 병렬 처리할 수 있다.
+     */
     @RedisLock(
             key = "'fan-letter:like:' + #fanLetterId + ':member:' + #memberId",
             waitTime = 700,

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostBaseResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostBaseResponse.java
@@ -1,0 +1,44 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * artist post 조회 응답에서 변동이 적은 base 필드만 담는 DTO다.
+ *
+ * count를 따로 떼어내면
+ * flush 주기와 무관한 본문/미디어는 더 길게 캐시할 수 있다.
+ */
+public record ArtistPostBaseResponse(
+        Long artistPostId,
+        Long artistId,
+        Long writerId,
+        String writerNickname,
+        String writerProfileImageUrl,
+        boolean artistBadge,
+        String content,
+        int mediaCount,
+        List<ArtistPostMediaResponse> media,
+        List<String> hashtags,
+        LocalDateTime createdAt
+) {
+    public static ArtistPostBaseResponse from(
+            ArtistPostReadRow row,
+            List<ArtistPostMediaResponse> media,
+            List<String> hashtags
+    ) {
+        return new ArtistPostBaseResponse(
+                row.artistPostId(),
+                row.artistId(),
+                row.writerId(),
+                row.writerNickname(),
+                row.writerProfileImageUrl(),
+                Boolean.TRUE.equals(row.artistBadge()),
+                row.content(),
+                row.mediaCount() == null ? 0 : row.mediaCount(),
+                media,
+                hashtags,
+                row.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostReadRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostReadRow.java
@@ -12,8 +12,6 @@ public record ArtistPostReadRow(
         String writerProfileImageUrl,
         Boolean artistBadge,
         String content,
-        Long likeCount,
-        Long commentCount,
         Integer mediaCount,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/dto/response/ArtistPostResponse.java
@@ -1,5 +1,7 @@
 package com.example.infinite.domain.artistcontent.post.artistpost.dto.response;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -20,26 +22,22 @@ public record ArtistPostResponse(
         List<String> hashtags,
         LocalDateTime createdAt
 ) {
-    public static ArtistPostResponse from(
-            ArtistPostReadRow row,
-            List<ArtistPostMediaResponse> media,
-            List<String> hashtags
-    ) {
-        // QueryDSL projection row + media + hashtag를 최종 API 응답 구조로 조립한다.
+    public static ArtistPostResponse from(ArtistPostBaseResponse baseResponse, PostHotData hotData) {
+        // base/hot 분리 캐시를 쓴 뒤, 응답 직전에만 하나로 합친다.
         return new ArtistPostResponse(
-                row.artistPostId(),
-                row.artistId(),
-                row.writerId(),
-                row.writerNickname(),
-                row.writerProfileImageUrl(),
-                Boolean.TRUE.equals(row.artistBadge()),
-                row.content(),
-                row.likeCount() == null ? 0L : row.likeCount(),
-                row.commentCount() == null ? 0L : row.commentCount(),
-                row.mediaCount() == null ? 0 : row.mediaCount(),
-                media,
-                hashtags,
-                row.createdAt()
+                baseResponse.artistPostId(),
+                baseResponse.artistId(),
+                baseResponse.writerId(),
+                baseResponse.writerNickname(),
+                baseResponse.writerProfileImageUrl(),
+                baseResponse.artistBadge(),
+                baseResponse.content(),
+                hotData.likeCount(),
+                hotData.commentCount(),
+                baseResponse.mediaCount(),
+                baseResponse.media(),
+                baseResponse.hashtags(),
+                baseResponse.createdAt()
         );
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
@@ -1,11 +1,14 @@
 package com.example.infinite.domain.artistcontent.post.artistpost.repository;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotRow;
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ArtistPostRepository extends JpaRepository<ArtistPost, Long>, ArtistPostRepositoryCustom {
@@ -85,4 +88,15 @@ public interface ArtistPostRepository extends JpaRepository<ArtistPost, Long>, A
              where artist_post.deleted_at is null
             """, nativeQuery = true)
     int reconcileAllCommentCounts();
+
+    @Query("""
+            select new com.example.infinite.domain.artistcontent.post.cache.PostHotRow(
+                artistPost.id,
+                artistPost.likeCount,
+                artistPost.commentCount
+            )
+              from ArtistPost artistPost
+             where artistPost.id in :artistPostIds
+            """)
+    List<PostHotRow> findHotRowsByIds(@Param("artistPostIds") Collection<Long> artistPostIds);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepositoryImpl.java
@@ -34,8 +34,6 @@ public class ArtistPostRepositoryImpl implements ArtistPostRepositoryCustom {
                         member.profileImageUrl,
                         Expressions.constant(Boolean.TRUE),
                         artistPost.content,
-                        artistPost.likeCount,
-                        artistPost.commentCount,
                         artistPost.mediaCount,
                         artistPost.createdAt
                 ))
@@ -67,8 +65,6 @@ public class ArtistPostRepositoryImpl implements ArtistPostRepositoryCustom {
                         member.profileImageUrl,
                         Expressions.constant(Boolean.TRUE),
                         artistPost.content,
-                        artistPost.likeCount,
-                        artistPost.commentCount,
                         artistPost.mediaCount,
                         artistPost.createdAt
                 ))

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostBaseCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostBaseCacheService.java
@@ -1,0 +1,139 @@
+package com.example.infinite.domain.artistcontent.post.artistpost.service;
+
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
+import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostBaseResponse;
+import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostMediaResponse;
+import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostReadRow;
+import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.global.common.constant.CacheNames;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistPostBaseCacheService {
+
+    private static final int ARTIST_POST_SLICE_SIZE = 10;
+    private static final int ARTIST_POST_LIST_MEDIA_PREVIEW_LIMIT = 6;
+
+    private final ArtistPostRepository artistPostRepository;
+    private final MediaRepository mediaRepository;
+    private final HashtagService hashtagService;
+
+    /**
+     * 목록 base 응답 캐시.
+     *
+     * ArtistPost는 좋아요/댓글 수가 3초 flush 구조를 타므로 count를 함께 캐시하면 전체 TTL이 짧아진다.
+     * 그래서 본문/미디어/해시태그/작성자 정보만 먼저 길게 캐시하고 count는 나중에 hot cache로 합친다.
+     */
+    @Cacheable(
+            value = CacheNames.ARTIST_POST_LIST_BASE,
+            key = "#artistId + ':' + (#cursor == null ? 'first' : #cursor)"
+    )
+    public CursorSliceResponse<ArtistPostBaseResponse> getArtistPostBaseSlice(Long artistId, Long cursor) {
+        return loadArtistPostBaseSlice(artistId, cursor);
+    }
+
+    /**
+     * 상세 base 응답 캐시.
+     * 댓글과 count는 변동성이 높아 별도 조회/별도 캐시 전략을 사용하므로 base 응답에는 섞지 않는다.
+     */
+    @Cacheable(
+            value = CacheNames.ARTIST_POST_DETAIL_BASE,
+            key = "#artistId + ':' + #artistPostId"
+    )
+    public ArtistPostBaseResponse getArtistPostBaseDetail(Long artistId, Long artistPostId) {
+        return loadArtistPostBaseDetail(artistId, artistPostId);
+    }
+
+    /**
+     * ArtistPost는 count 분리 후에도
+     * 본문/미디어/해시태그 쪽 조립 비용이 남기 때문에 base 캐시 효과가 크다.
+     */
+    public CursorSliceResponse<ArtistPostBaseResponse> loadArtistPostBaseSlice(Long artistId, Long cursor) {
+        List<ArtistPostReadRow> rows = artistPostRepository.findSliceRowsByArtistId(
+                artistId,
+                cursor,
+                ARTIST_POST_SLICE_SIZE + 1
+        );
+        boolean hasNext = rows.size() > ARTIST_POST_SLICE_SIZE;
+        List<ArtistPostReadRow> visibleRows = hasNext ? rows.subList(0, ARTIST_POST_SLICE_SIZE) : rows;
+        if (visibleRows.isEmpty()) {
+            return new CursorSliceResponse<>(List.of(), null, hasNext, ARTIST_POST_SLICE_SIZE);
+        }
+
+        List<Long> postIds = visibleRows.stream()
+                .map(ArtistPostReadRow::artistPostId)
+                .toList();
+        Map<Long, List<ArtistPostMediaResponse>> mediaMap = loadPreviewMediaMap(postIds);
+        Map<Long, List<String>> hashtagMap = hashtagService.findHashtagNamesByTargetIds(PostType.ARTIST_POST, postIds);
+
+        List<ArtistPostBaseResponse> content = visibleRows.stream()
+                .map(row -> ArtistPostBaseResponse.from(
+                        row,
+                        mediaMap.getOrDefault(row.artistPostId(), List.of()),
+                        hashtagMap.getOrDefault(row.artistPostId(), List.of())
+                ))
+                .toList();
+
+        Long nextCursor = hasNext
+                ? visibleRows.get(visibleRows.size() - 1).artistPostId()
+                : null;
+        return new CursorSliceResponse<>(content, nextCursor, hasNext, ARTIST_POST_SLICE_SIZE);
+    }
+
+    public ArtistPostBaseResponse loadArtistPostBaseDetail(Long artistId, Long artistPostId) {
+        ArtistPostReadRow row = artistPostRepository.findDetailRowByArtistIdAndArtistPostId(artistId, artistPostId)
+                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
+        // 상세는 preview가 아니라 전체 미디어를 붙인다.
+        List<ArtistPostMediaResponse> media = loadMediaMap(List.of(artistPostId)).getOrDefault(artistPostId, List.of());
+        List<String> hashtags = hashtagService.findHashtagNamesByTargetIds(PostType.ARTIST_POST, List.of(artistPostId))
+                .getOrDefault(artistPostId, List.of());
+        return ArtistPostBaseResponse.from(row, media, hashtags);
+    }
+
+    private Map<Long, List<ArtistPostMediaResponse>> loadMediaMap(Collection<Long> artistPostIds) {
+        if (artistPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.ARTIST_POST, artistPostIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        Media::getTargetId,
+                        Collectors.mapping(ArtistPostMediaResponse::from, Collectors.toList())
+                ));
+    }
+
+    private Map<Long, List<ArtistPostMediaResponse>> loadPreviewMediaMap(Collection<Long> artistPostIds) {
+        if (artistPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        // 목록은 UI 정책상 앞 6개 preview만 내리고, 전체 개수는 mediaCount로 표현한다.
+        return mediaRepository.findPreviewByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(
+                        PostType.ARTIST_POST,
+                        artistPostIds,
+                        ARTIST_POST_LIST_MEDIA_PREVIEW_LIMIT
+                )
+                .stream()
+                .collect(Collectors.groupingBy(
+                        Media::getTargetId,
+                        Collectors.mapping(ArtistPostMediaResponse::from, Collectors.toList())
+                ));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostService.java
@@ -1,23 +1,22 @@
 package com.example.infinite.domain.artistcontent.post.artistpost.service;
 
 import com.example.infinite.domain.artistcontent.comment.service.CommentService;
-import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.artistcontent.media.service.MediaService;
 import com.example.infinite.domain.artistcontent.post.artistpost.dto.request.ArtistPostCreateRequest;
 import com.example.infinite.domain.artistcontent.post.artistpost.dto.request.ArtistPostUpdateRequest;
+import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostBaseResponse;
 import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostCreateResponse;
 import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostDetailResponse;
-import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostMediaResponse;
-import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostReadRow;
 import com.example.infinite.domain.artistcontent.post.artistpost.dto.response.ArtistPostResponse;
 import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
 import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
 import com.example.infinite.domain.artistcontent.post.artistpost.support.ArtistPostReader;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotDataCacheService;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
-import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.member.artist.entity.Artist;
 import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
 import com.example.infinite.domain.member.artist.support.ArtistReader;
@@ -26,28 +25,25 @@ import com.example.infinite.domain.member.member.enums.MemberRole;
 import com.example.infinite.domain.member.member.support.MemberInputSupport;
 import com.example.infinite.domain.member.member.support.MemberReader;
 import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.constant.CacheNames;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-// ArtistPostService 는 FanPost 패턴을 재사용하되,
-// "공식 아티스트 멤버만 작성 가능"이라는 권한 규칙과 artist badge 응답을 추가로 책임진다.
+// ArtistPost는 동시성 설계가 가장 복잡한 영역이므로, 캐시도 base/hot 분리를 명시적으로 드러낸다.
+// 이렇게 해야 "본문은 길게, count는 flush 주기와 맞춘 짧은 TTL" 전략을 설명하기 쉽다.
 public class ArtistPostService {
 
-    private static final int ARTIST_POST_SLICE_SIZE = 10;
-    private static final int ARTIST_POST_LIST_MEDIA_PREVIEW_LIMIT = 6;
-
     private final ArtistPostRepository artistPostRepository;
-    private final MediaRepository mediaRepository;
     private final MemberReader memberReader;
     private final ArtistReader artistReader;
     private final ArtistPostReader artistPostReader;
@@ -55,8 +51,14 @@ public class ArtistPostService {
     private final HashtagService hashtagService;
     private final CommentService commentService;
     private final MediaService mediaService;
+    private final ArtistPostBaseCacheService artistPostBaseCacheService;
+    private final PostHotDataCacheService postHotDataCacheService;
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.ARTIST_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.ARTIST_POST_DETAIL_BASE, allEntries = true)
+    })
     public ArtistPostCreateResponse create(
             MemberDetailsImpl memberDetails,
             Long artistId,
@@ -71,7 +73,6 @@ public class ArtistPostService {
                 writer,
                 normalizeContent(request.getContent())
         ));
-        // 작성 후에는 hashtag/media 를 FanPost와 같은 순서로 동기화한다.
         hashtagService.syncHashtags(PostType.ARTIST_POST, artistPost.getId(), artistPost.getContent());
         mediaService.attachArtistPostMedia(artistId, artistPost, request.getFiles());
 
@@ -81,23 +82,27 @@ public class ArtistPostService {
     public CursorSliceResponse<ArtistPostResponse> getArtistPosts(Long artistId, Long cursor) {
         artistReader.findArtistByIdOrThrow(artistId);
 
-        List<ArtistPostReadRow> rows = artistPostRepository.findSliceRowsByArtistId(
-                artistId,
-                cursor,
-                ARTIST_POST_SLICE_SIZE + 1
+        CursorSliceResponse<ArtistPostBaseResponse> baseSlice = artistPostBaseCacheService.getArtistPostBaseSlice(artistId, cursor);
+        Map<Long, PostHotData> hotDataByPostId = postHotDataCacheService.getPostHotDataMap(
+                PostType.ARTIST_POST,
+                baseSlice.content().stream().map(ArtistPostBaseResponse::artistPostId).toList()
         );
-        boolean hasNext = rows.size() > ARTIST_POST_SLICE_SIZE;
-        List<ArtistPostReadRow> visibleRows = hasNext ? rows.subList(0, ARTIST_POST_SLICE_SIZE) : rows;
 
-        // 본문 row만 먼저 읽고 media/hashtag를 배치로 붙여 N+1을 피한다.
-        return toCursorSliceResponse(visibleRows, hasNext);
+        List<ArtistPostResponse> content = baseSlice.content().stream()
+                .map(baseResponse -> ArtistPostResponse.from(
+                        baseResponse,
+                        hotDataByPostId.getOrDefault(baseResponse.artistPostId(), PostHotData.empty())
+                ))
+                .toList();
+        return new CursorSliceResponse<>(content, baseSlice.nextCursor(), baseSlice.hasNext(), baseSlice.size());
     }
 
     public ArtistPostDetailResponse getArtistPost(Long artistId, Long artistPostId, Long commentCursor) {
         artistReader.findArtistByIdOrThrow(artistId);
 
-        // 상세는 게시글 1건 조립 결과 위에 댓글 슬라이스를 덧붙이는 구조다.
-        ArtistPostResponse artistPostResponse = buildArtistPostResponse(artistId, artistPostId);
+        ArtistPostBaseResponse baseResponse = artistPostBaseCacheService.getArtistPostBaseDetail(artistId, artistPostId);
+        PostHotData hotData = postHotDataCacheService.getPostHotData(PostType.ARTIST_POST, artistPostId);
+        ArtistPostResponse artistPostResponse = ArtistPostResponse.from(baseResponse, hotData);
         return ArtistPostDetailResponse.from(
                 artistPostResponse,
                 commentService.getArtistPostComments(artistId, artistPostId, commentCursor)
@@ -105,6 +110,10 @@ public class ArtistPostService {
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.ARTIST_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.ARTIST_POST_DETAIL_BASE, allEntries = true)
+    })
     public ArtistPostResponse update(
             MemberDetailsImpl memberDetails,
             Long artistId,
@@ -122,10 +131,18 @@ public class ArtistPostService {
             mediaService.replaceArtistPostMedia(artistId, artistPost, request.getFiles());
         }
 
-        return buildArtistPostResponse(artistId, artistPostId);
+        return buildCurrentArtistPostResponse(
+                artistId,
+                artistPostId,
+                PostHotData.of(artistPost.getLikeCount(), artistPost.getCommentCount())
+        );
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.ARTIST_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.ARTIST_POST_DETAIL_BASE, allEntries = true)
+    })
     public void delete(MemberDetailsImpl memberDetails, Long artistId, Long artistPostId) {
         Member writer = findAuthorizedArtistWriter(memberDetails, artistId);
         ArtistPost artistPost = findOwnedArtistPost(writer.getId(), artistId, artistPostId);
@@ -135,81 +152,13 @@ public class ArtistPostService {
         artistPost.delete();
     }
 
-    private CursorSliceResponse<ArtistPostResponse> toCursorSliceResponse(List<ArtistPostReadRow> visibleRows, boolean hasNext) {
-        if (visibleRows.isEmpty()) {
-            return new CursorSliceResponse<>(List.of(), null, hasNext, ARTIST_POST_SLICE_SIZE);
-        }
-
-        List<Long> postIds = extractPostIds(visibleRows);
-        Map<Long, List<ArtistPostMediaResponse>> mediaMap = loadPreviewMediaMap(postIds);
-        Map<Long, List<String>> hashtagMap = hashtagService.findHashtagNamesByTargetIds(PostType.ARTIST_POST, postIds);
-
-        List<ArtistPostResponse> responses = visibleRows.stream()
-                .map(row -> ArtistPostResponse.from(
-                        row,
-                        mediaMap.getOrDefault(row.artistPostId(), List.of()),
-                        hashtagMap.getOrDefault(row.artistPostId(), List.of())
-                ))
-                .toList();
-
-        Long nextCursor = hasNext && !visibleRows.isEmpty()
-                ? visibleRows.get(visibleRows.size() - 1).artistPostId()
-                : null;
-
-        return new CursorSliceResponse<>(responses, nextCursor, hasNext, ARTIST_POST_SLICE_SIZE);
-    }
-
-    private ArtistPostResponse buildArtistPostResponse(Long artistId, Long artistPostId) {
-        ArtistPostReadRow row = artistPostRepository.findDetailRowByArtistIdAndArtistPostId(artistId, artistPostId)
-                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
-        // 상세 1건도 목록과 같은 media/hashtag 조립 규칙을 재사용해 응답 일관성을 유지한다.
-        List<ArtistPostMediaResponse> media = loadMediaMap(List.of(artistPostId)).getOrDefault(artistPostId, List.of());
-        List<String> hashtags = hashtagService.findHashtagNamesByTargetIds(PostType.ARTIST_POST, List.of(artistPostId))
-                .getOrDefault(artistPostId, List.of());
-        return ArtistPostResponse.from(row, media, hashtags);
-    }
-
-    private List<Long> extractPostIds(List<ArtistPostReadRow> rows) {
-        return rows.stream()
-                .map(ArtistPostReadRow::artistPostId)
-                .toList();
-    }
-
-    private Map<Long, List<ArtistPostMediaResponse>> loadMediaMap(Collection<Long> artistPostIds) {
-        if (artistPostIds.isEmpty()) {
-            return Map.of();
-        }
-
-        // ArtistPost도 Media 공통 테이블을 targetType 기반으로 묶어 조회한다.
-        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.ARTIST_POST, artistPostIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        Media::getTargetId,
-                        Collectors.mapping(ArtistPostMediaResponse::from, Collectors.toList())
-                ));
-    }
-
-    private Map<Long, List<ArtistPostMediaResponse>> loadPreviewMediaMap(Collection<Long> artistPostIds) {
-        if (artistPostIds.isEmpty()) {
-            return Map.of();
-        }
-        // 목록 카드는 post당 앞쪽 6장만 미리보기로 내리고,
-        // 전체 장수는 mediaCount 필드를 그대로 사용한다.
-        return mediaRepository.findPreviewByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(
-                        PostType.ARTIST_POST,
-                        artistPostIds,
-                        ARTIST_POST_LIST_MEDIA_PREVIEW_LIMIT
-                )
-                .stream()
-                .collect(Collectors.groupingBy(
-                        Media::getTargetId,
-                        Collectors.mapping(ArtistPostMediaResponse::from, Collectors.toList())
-                ));
+    private ArtistPostResponse buildCurrentArtistPostResponse(Long artistId, Long artistPostId, PostHotData hotData) {
+        ArtistPostBaseResponse baseResponse = artistPostBaseCacheService.loadArtistPostBaseDetail(artistId, artistPostId);
+        return ArtistPostResponse.from(baseResponse, hotData);
     }
 
     private ArtistPost findOwnedArtistPost(Long memberId, Long artistId, Long artistPostId) {
         ArtistPost artistPost = artistPostReader.findByIdAndArtistIdOrThrow(artistPostId, artistId);
-        // 공식 계정 글이라도 수정/삭제는 실제 작성자 본인만 허용한다.
         if (!artistPost.getWriter().getId().equals(memberId)) {
             throw new ArtistContentException(ArtistContentErrorCode.POST_PERMISSION_DENIED);
         }
@@ -218,7 +167,6 @@ public class ArtistPostService {
 
     private Member findAuthorizedArtistWriter(MemberDetailsImpl memberDetails, Long artistId) {
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
-        // ArtistPost 작성/수정/삭제는 "ARTIST 역할"과 "해당 artist 소속 artist member"를 둘 다 만족해야 한다.
         if (member.getRole() != MemberRole.ARTIST || !artistMemberRepository.existsByArtistIdAndMemberId(artistId, member.getId())) {
             throw new ArtistContentException(ArtistContentErrorCode.POST_PERMISSION_DENIED);
         }
@@ -233,7 +181,6 @@ public class ArtistPostService {
     }
 
     private String normalizeContent(String content) {
-        // 사진/영상만 있는 공식 게시글도 허용하기 위해 본문은 optional 로 둔다.
         return content == null ? "" : content;
     }
 
@@ -252,8 +199,6 @@ public class ArtistPostService {
                 ? artistPost.getMediaCount() > 0
                 : !request.getFiles().isEmpty();
 
-        // 수정도 생성과 같은 불변조건을 지켜야 한다.
-        // 기존 media를 모두 비우는 요청이라면 최종 본문이 비어 있지 않아야 한다.
         if (!hasContent && !hasMediaAfterUpdate) {
             throw new ArtistContentException(ArtistContentErrorCode.POST_CONTENT_OR_MEDIA_REQUIRED);
         }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeCountFlushScheduler.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/likecount/ArtistPostLikeCountFlushScheduler.java
@@ -27,6 +27,10 @@ public class ArtistPostLikeCountFlushScheduler {
      * 핵심 의도:
      * - 요청 경로에서 DB count row hotspot을 제거
      * - 대신 짧은 주기의 배치로 화면 count를 따라가게 만들기
+     *
+     * 캐시와의 관계:
+     * - post hot cache TTL도 현재 3초라서
+     * - flush 주기와 읽기 캐시 수명이 거의 같은 eventual consistency 리듬을 만든다
      */
     @Scheduled(fixedDelayString = "${artist-post.like-count.flush-delay-ms:3000}")
     @Transactional
@@ -55,6 +59,8 @@ public class ArtistPostLikeCountFlushScheduler {
      * flush와 reconcile의 차이:
      * - flush: 최근에 변한 글만
      * - reconcile: 전체 활성 ArtistPost를 다시 계산
+     *
+     * 즉 flush는 "실시간에 가까운 추적", reconcile은 "하루 1회 원본 기준 정산"이다.
      */
     @Scheduled(cron = "${artist-post.like-count.reconcile-cron:0 0 4 * * *}")
     @Transactional

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotData.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotData.java
@@ -1,0 +1,29 @@
+package com.example.infinite.domain.artistcontent.post.cache;
+
+/**
+ * 좋아요/댓글처럼 자주 바뀌는 "hot 필드"만 따로 들고 다니는 값 객체다.
+ *
+ * base/hot 분리의 핵심 의도:
+ * - 본문/미디어/해시태그는 긴 TTL
+ * - count는 짧은 TTL
+ * 로 서로 다른 수명을 갖게 만드는 것이다.
+ */
+public record PostHotData(
+        long likeCount,
+        long commentCount
+) {
+    public static PostHotData of(Long likeCount, Long commentCount) {
+        return new PostHotData(
+                likeCount == null ? 0L : likeCount,
+                commentCount == null ? 0L : commentCount
+        );
+    }
+
+    public static PostHotData likeOnly(Long likeCount) {
+        return new PostHotData(likeCount == null ? 0L : likeCount, 0L);
+    }
+
+    public static PostHotData empty() {
+        return new PostHotData(0L, 0L);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotDataCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotDataCacheService.java
@@ -1,0 +1,79 @@
+package com.example.infinite.domain.artistcontent.post.cache;
+
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.global.common.constant.CacheNames;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PostHotDataCacheService {
+
+    private final CacheManager cacheManager;
+    private final PostHotDataLoaderService postHotDataLoaderService;
+
+    /**
+     * 단건 hot data 조회도 내부적으로는 공통 배치 로직을 재사용한다.
+     * 이렇게 하면 detail/list가 같은 캐시 키 규약을 공유하게 된다.
+     */
+    public PostHotData getPostHotData(PostType postType, Long postId) {
+        return getPostHotDataMap(postType, List.of(postId))
+                .getOrDefault(postId, PostHotData.empty());
+    }
+
+    /**
+     * hot data 캐시는 "post 하나당 key 하나"로 운영한다.
+     *
+     * 이유:
+     * - detail과 list가 같은 count 캐시를 재사용할 수 있고
+     * - 어떤 slice에서 조회됐는지와 무관하게 동일 post의 count는 한 키로 합쳐진다
+     */
+    public Map<Long, PostHotData> getPostHotDataMap(PostType postType, Collection<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Cache cache = cacheManager.getCache(CacheNames.POST_HOT_DATA);
+        List<Long> distinctPostIds = new ArrayList<>(new LinkedHashSet<>(postIds));
+        Map<Long, PostHotData> result = new LinkedHashMap<>();
+        List<Long> missedPostIds = new ArrayList<>();
+
+        for (Long postId : distinctPostIds) {
+            PostHotData cachedHotData = cache == null ? null : cache.get(buildCacheKey(postType, postId), PostHotData.class);
+            if (cachedHotData != null) {
+                result.put(postId, cachedHotData);
+                continue;
+            }
+            missedPostIds.add(postId);
+        }
+
+        if (missedPostIds.isEmpty()) {
+            return result;
+        }
+
+        // miss 난 id만 모아 한 번에 원본 테이블을 읽고, 다시 post별 캐시로 채운다.
+        Map<Long, PostHotData> loadedHotData = postHotDataLoaderService.load(postType, missedPostIds);
+        for (Long postId : missedPostIds) {
+            PostHotData hotData = loadedHotData.getOrDefault(postId, PostHotData.empty());
+            if (cache != null) {
+                cache.put(buildCacheKey(postType, postId), hotData);
+            }
+            result.put(postId, hotData);
+        }
+
+        return result;
+    }
+
+    private String buildCacheKey(PostType postType, Long postId) {
+        return postType.name() + ":" + postId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotDataLoaderService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotDataLoaderService.java
@@ -1,0 +1,50 @@
+package com.example.infinite.domain.artistcontent.post.cache;
+
+import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostHotDataLoaderService {
+
+    private final ArtistPostRepository artistPostRepository;
+    private final FanPostRepository fanPostRepository;
+    private final FanLetterRepository fanLetterRepository;
+
+    /**
+     * post type별 원본 테이블에서 hot 필드를 배치 조회한다.
+     *
+     * 왜 별도 loader가 필요한가:
+     * - cache miss 난 id만 한 번에 모아 DB를 친다
+     * - list 조회에서 post 10개를 각각 단건 조회하는 N+1을 피한다
+     */
+    public Map<Long, PostHotData> load(PostType postType, Collection<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostHotRow> hotRows = switch (postType) {
+            case ARTIST_POST -> artistPostRepository.findHotRowsByIds(postIds);
+            case FAN_POST -> fanPostRepository.findHotRowsByIds(postIds);
+            case FAN_LETTER -> fanLetterRepository.findHotRowsByIds(postIds);
+            default -> throw new IllegalArgumentException("지원하지 않는 hot data 대상 타입입니다: " + postType);
+        };
+
+        Map<Long, PostHotData> hotDataByPostId = new LinkedHashMap<>();
+        for (PostHotRow hotRow : hotRows) {
+            hotDataByPostId.put(hotRow.postId(), PostHotData.of(hotRow.likeCount(), hotRow.commentCount()));
+        }
+        return hotDataByPostId;
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/cache/PostHotRow.java
@@ -1,0 +1,22 @@
+package com.example.infinite.domain.artistcontent.post.cache;
+
+/**
+ * DB에서 hot 필드만 읽어올 때 사용하는 공통 projection row다.
+ *
+ * id + count만 가져오므로
+ * 본문/미디어 같은 무거운 read model을 다시 만들지 않고도
+ * 짧은 TTL 캐시를 채울 수 있다.
+ */
+public record PostHotRow(
+        Long postId,
+        Long likeCount,
+        Long commentCount
+) {
+    /**
+     * commentCount가 없는 도메인(FanLetter)용 보조 생성자.
+     * JPQL에서 상수 0L를 직접 넣는 대신 이 생성자를 쓰면 IDE 파서 경고를 줄일 수 있다.
+     */
+    public PostHotRow(Long postId, Long likeCount) {
+        this(postId, likeCount, 0L);
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterBaseResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterBaseResponse.java
@@ -1,0 +1,58 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
+
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
+
+import java.time.LocalDateTime;
+
+/**
+ * fan letter 상세 응답에서 변동이 적은 base 필드만 모아둔 DTO다.
+ *
+ * fan letter는 댓글이 없으므로 hot 필드는 likeCount만 분리한다.
+ */
+public record FanLetterBaseResponse(
+        Long fanLetterId,
+        Long artistId,
+        Long writerId,
+        String writerNickname,
+        String writerProfileImageUrl,
+        boolean fanMembershipSubscribed,
+        boolean dmSubscribed,
+        FanLetterRecipientType recipientType,
+        Long recipientArtistMemberId,
+        String recipientDisplayName,
+        String recipientProfileImageUrl,
+        FanLetterImageResponse image,
+        boolean artistLiked,
+        String artistLikeDisplayName,
+        String artistLikeProfileImageUrl,
+        LocalDateTime createdAt
+) {
+    public static FanLetterBaseResponse from(
+            FanLetterReadRow row,
+            FanLetterImageResponse image,
+            WriterSubscriptionBadge writerBadge,
+            boolean artistLiked,
+            String artistLikeDisplayName,
+            String artistLikeProfileImageUrl
+    ) {
+        return new FanLetterBaseResponse(
+                row.fanLetterId(),
+                row.artistId(),
+                row.writerId(),
+                row.writerNickname(),
+                row.writerProfileImageUrl(),
+                writerBadge.fanMembershipSubscribed(),
+                writerBadge.dmSubscribed(),
+                row.recipientType(),
+                row.recipientArtistMemberId(),
+                row.recipientDisplayName(),
+                row.recipientProfileImageUrl(),
+                image,
+                artistLiked,
+                artistLikeDisplayName,
+                artistLikeProfileImageUrl,
+                row.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterReadRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterReadRow.java
@@ -18,7 +18,6 @@ public record FanLetterReadRow(
         String recipientProfileImageUrl,
         String artistDisplayName,
         String artistProfileImageUrl,
-        Long likeCount,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/dto/response/FanLetterResponse.java
@@ -1,7 +1,7 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.dto.response;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
 import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
-import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
 
 import java.time.LocalDateTime;
 
@@ -27,32 +27,25 @@ public record FanLetterResponse(
         String artistLikeProfileImageUrl,
         LocalDateTime createdAt
 ) {
-    public static FanLetterResponse from(
-            FanLetterReadRow row,
-            FanLetterImageResponse image,
-            WriterSubscriptionBadge writerBadge,
-            boolean artistLiked,
-            String artistLikeDisplayName,
-            String artistLikeProfileImageUrl
-    ) {
+    public static FanLetterResponse from(FanLetterBaseResponse baseResponse, PostHotData hotData) {
         return new FanLetterResponse(
-                row.fanLetterId(),
-                row.artistId(),
-                row.writerId(),
-                row.writerNickname(),
-                row.writerProfileImageUrl(),
-                writerBadge.fanMembershipSubscribed(),
-                writerBadge.dmSubscribed(),
-                row.recipientType(),
-                row.recipientArtistMemberId(),
-                row.recipientDisplayName(),
-                row.recipientProfileImageUrl(),
-                image,
-                row.likeCount() == null ? 0L : row.likeCount(),
-                artistLiked,
-                artistLikeDisplayName,
-                artistLikeProfileImageUrl,
-                row.createdAt()
+                baseResponse.fanLetterId(),
+                baseResponse.artistId(),
+                baseResponse.writerId(),
+                baseResponse.writerNickname(),
+                baseResponse.writerProfileImageUrl(),
+                baseResponse.fanMembershipSubscribed(),
+                baseResponse.dmSubscribed(),
+                baseResponse.recipientType(),
+                baseResponse.recipientArtistMemberId(),
+                baseResponse.recipientDisplayName(),
+                baseResponse.recipientProfileImageUrl(),
+                baseResponse.image(),
+                hotData.likeCount(),
+                baseResponse.artistLiked(),
+                baseResponse.artistLikeDisplayName(),
+                baseResponse.artistLikeProfileImageUrl(),
+                baseResponse.createdAt()
         );
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
@@ -1,11 +1,14 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.repository;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotRow;
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface FanLetterRepository extends JpaRepository<FanLetter, Long>, FanLetterRepositoryCustom {
@@ -28,4 +31,14 @@ public interface FanLetterRepository extends JpaRepository<FanLetter, Long>, Fan
 
     @Query("select fanLetter.likeCount from FanLetter fanLetter where fanLetter.id = :fanLetterId")
     Optional<Long> findLikeCountById(@Param("fanLetterId") Long fanLetterId);
+
+    @Query("""
+            select new com.example.infinite.domain.artistcontent.post.cache.PostHotRow(
+                fanLetter.id,
+                fanLetter.likeCount
+            )
+              from FanLetter fanLetter
+             where fanLetter.id in :fanLetterIds
+            """)
+    List<PostHotRow> findHotRowsByIds(@Param("fanLetterIds") Collection<Long> fanLetterIds);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepositoryImpl.java
@@ -121,7 +121,6 @@ public class FanLetterRepositoryImpl implements FanLetterRepositoryCustom {
                         .otherwise(artist.profileImageUrl),
                 artist.name,
                 artist.profileImageUrl,
-                fanLetter.likeCount,
                 fanLetter.createdAt
         );
     }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterBaseCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterBaseCacheService.java
@@ -1,0 +1,209 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.service;
+
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.*;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
+import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
+import com.example.infinite.global.common.constant.CacheNames;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FanLetterBaseCacheService {
+
+    private static final int FAN_LETTER_SLICE_SIZE = 10;
+
+    private final FanLetterRepository fanLetterRepository;
+    private final MediaRepository mediaRepository;
+    private final InteractionRepository interactionRepository;
+    private final SubscriptionMembershipService subscriptionMembershipService;
+
+    /**
+     * FanLetter 목록 base 캐시.
+     *
+     * 목록은 이미지/수신자/special-like 표시용 정보처럼 비교적 안정적인 읽기 조립 결과가 중심이다.
+     * 그래서 목록 자체는 길게 캐시하고, hot 필드가 필요하면 상세에서만 따로 합친다.
+     */
+    @Cacheable(
+            value = CacheNames.FAN_LETTER_LIST_BASE,
+            key = "#artistId + ':' + (#cursor == null ? 'first' : #cursor)"
+    )
+    public CursorSliceResponse<FanLetterListResponse> getFanLetterListBaseSlice(Long artistId, Long cursor) {
+        return loadFanLetterListBaseSlice(artistId, cursor);
+    }
+
+    /**
+     * FanLetter 상세 base 캐시.
+     *
+     * writer badge, recipient, special-like 표시용 메타데이터는 자주 안 바뀌므로 base에 포함하고,
+     * likeCount만 hot cache에서 나중에 합친다.
+     */
+    @Cacheable(
+            value = CacheNames.FAN_LETTER_DETAIL_BASE,
+            key = "#artistId + ':' + #fanLetterId"
+    )
+    public FanLetterBaseResponse getFanLetterBaseDetail(Long artistId, Long fanLetterId) {
+        return loadFanLetterBaseDetail(artistId, fanLetterId);
+    }
+
+    public CursorSliceResponse<FanLetterListResponse> loadFanLetterListBaseSlice(Long artistId, Long cursor) {
+        List<FanLetterListRow> rows = fanLetterRepository.findSliceRowsByArtistId(
+                artistId,
+                cursor,
+                FAN_LETTER_SLICE_SIZE + 1
+        );
+        boolean hasNext = rows.size() > FAN_LETTER_SLICE_SIZE;
+        List<FanLetterListRow> visibleRows = hasNext ? rows.subList(0, FAN_LETTER_SLICE_SIZE) : rows;
+        if (visibleRows.isEmpty()) {
+            return new CursorSliceResponse<>(List.of(), null, false, FAN_LETTER_SLICE_SIZE);
+        }
+
+        List<Long> fanLetterIds = visibleRows.stream()
+                .map(FanLetterListRow::fanLetterId)
+                .toList();
+        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(fanLetterIds);
+        // special-like는 persisted field가 아니라 Reaction 원본을 바탕으로 읽기 시점에 조립한다.
+        Map<Long, SpecialLikeInfo> specialLikeInfoByLetterId = loadSpecialLikeInfo(
+                artistId,
+                visibleRows,
+                FanLetterListRow::fanLetterId,
+                FanLetterListRow::artistDisplayName,
+                FanLetterListRow::artistProfileImageUrl
+        );
+
+        List<FanLetterListResponse> content = visibleRows.stream()
+                .map(row -> FanLetterListResponse.from(
+                        row,
+                        imageByLetterId.get(row.fanLetterId()),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLiked(),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeDisplayName(),
+                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeProfileImageUrl()
+                ))
+                .toList();
+
+        Long nextCursor = hasNext
+                ? visibleRows.get(visibleRows.size() - 1).fanLetterId()
+                : null;
+        return new CursorSliceResponse<>(content, nextCursor, hasNext, FAN_LETTER_SLICE_SIZE);
+    }
+
+    public FanLetterBaseResponse loadFanLetterBaseDetail(Long artistId, Long fanLetterId) {
+        FanLetterReadRow row = fanLetterRepository.findDetailRowByArtistIdAndFanLetterId(artistId, fanLetterId)
+                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
+
+        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(List.of(fanLetterId));
+        WriterSubscriptionBadge writerBadge = loadWriterBadges(artistId, List.of(row.writerId()))
+                .getOrDefault(row.writerId(), WriterSubscriptionBadge.empty(row.writerId()));
+        // 상세도 special-like 진실값은 FanLetter 엔티티가 아니라 Reaction 조회 결과에서 만든다.
+        SpecialLikeInfo specialLikeInfo = loadSpecialLikeInfo(
+                artistId,
+                List.of(row),
+                FanLetterReadRow::fanLetterId,
+                FanLetterReadRow::artistDisplayName,
+                FanLetterReadRow::artistProfileImageUrl
+        )
+                .getOrDefault(fanLetterId, SpecialLikeInfo.empty());
+
+        return FanLetterBaseResponse.from(
+                row,
+                imageByLetterId.get(fanLetterId),
+                writerBadge,
+                specialLikeInfo.artistLiked(),
+                specialLikeInfo.artistLikeDisplayName(),
+                specialLikeInfo.artistLikeProfileImageUrl()
+        );
+    }
+
+    private Map<Long, FanLetterImageResponse> loadImageMap(Collection<Long> fanLetterIds) {
+        if (fanLetterIds.isEmpty()) {
+            return Map.of();
+        }
+
+        // FanLetter는 정책상 이미지 1장만 허용하므로 같은 targetId에서 첫 값만 유지하면 된다.
+        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.FAN_LETTER, fanLetterIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        Media::getTargetId,
+                        FanLetterImageResponse::from,
+                        (left, right) -> left
+                ));
+    }
+
+    private Map<Long, WriterSubscriptionBadge> loadWriterBadges(Long artistId, List<Long> writerIds) {
+        if (writerIds.isEmpty()) {
+            return Map.of();
+        }
+        return subscriptionMembershipService.getWriterBadges(artistId, writerIds);
+    }
+
+    private <T> Map<Long, SpecialLikeInfo> loadSpecialLikeInfo(
+            Long artistId,
+            List<T> rows,
+            Function<T, Long> fanLetterIdExtractor,
+            Function<T, String> artistDisplayNameExtractor,
+            Function<T, String> artistProfileImageUrlExtractor
+    ) {
+        if (rows.isEmpty()) {
+            return Map.of();
+        }
+
+        // "그 아티스트 소속 멤버 중 한 명이라도 좋아요했는가"를 한 번에 조회한다.
+        var likedFanLetterIds = interactionRepository.findTargetIdsReactedByArtistMembers(
+                artistId,
+                PostType.FAN_LETTER,
+                rows.stream().map(fanLetterIdExtractor).toList(),
+                ReactionType.LIKE
+        );
+
+        return rows.stream()
+                .collect(Collectors.toMap(
+                        fanLetterIdExtractor,
+                        row -> resolveSpecialLikeInfo(
+                                artistDisplayNameExtractor.apply(row),
+                                artistProfileImageUrlExtractor.apply(row),
+                                likedFanLetterIds.contains(fanLetterIdExtractor.apply(row))
+                        )
+                ));
+    }
+
+    private SpecialLikeInfo resolveSpecialLikeInfo(
+            String artistDisplayName,
+            String artistProfileImageUrl,
+            boolean artistReacted
+    ) {
+        if (!artistReacted) {
+            return SpecialLikeInfo.empty();
+        }
+
+        // 현재 정책상 "누가 눌렀는지" 세부 멤버를 노출하지 않고 아티스트 대표 표시 정보만 반환한다.
+        return new SpecialLikeInfo(true, artistDisplayName, artistProfileImageUrl);
+    }
+
+    private record SpecialLikeInfo(
+            boolean artistLiked,
+            String artistLikeDisplayName,
+            String artistLikeProfileImageUrl
+    ) {
+        private static SpecialLikeInfo empty() {
+            return new SpecialLikeInfo(false, null, null);
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterService.java
@@ -1,21 +1,16 @@
 package com.example.infinite.domain.artistcontent.post.fanletter.service;
 
-import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
-import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
-import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
-import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
 import com.example.infinite.domain.artistcontent.media.service.MediaService;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotDataCacheService;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterCreateRequest;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.request.FanLetterUpdateRequest;
+import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterBaseResponse;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterCreateResponse;
-import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterImageResponse;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListResponse;
-import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterListRow;
-import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterReadRow;
 import com.example.infinite.domain.artistcontent.post.fanletter.dto.response.FanLetterResponse;
 import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
 import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
@@ -27,51 +22,45 @@ import com.example.infinite.domain.member.artist.support.ArtistReader;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.domain.member.member.support.MemberInputSupport;
 import com.example.infinite.domain.member.member.support.MemberReader;
-import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
 import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.constant.CacheNames;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import com.example.infinite.global.error.ErrorCode;
 import com.example.infinite.global.error.SubscriptionMembershipException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FanLetterService {
 
-    private static final int FAN_LETTER_SLICE_SIZE = 10;
-
     private final FanLetterRepository fanLetterRepository;
     private final FanLetterReader fanLetterReader;
     private final ArtistReader artistReader;
     private final MemberReader memberReader;
-    private final MediaRepository mediaRepository;
     private final MediaService mediaService;
-    private final InteractionRepository interactionRepository;
     private final SubscriptionMembershipService subscriptionMembershipService;
+    private final FanLetterBaseCacheService fanLetterBaseCacheService;
+    private final PostHotDataCacheService postHotDataCacheService;
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_LETTER_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_LETTER_DETAIL_BASE, allEntries = true)
+    })
     public FanLetterCreateResponse create(
             MemberDetailsImpl memberDetails,
             Long artistId,
             FanLetterCreateRequest request
     ) {
-        // 팬레터는 팬 멤버십이 있는 사용자만 작성 가능하다.
-        // 생성 시점에 누구에게 보내는 편지인지(아티스트 전체 / 특정 멤버)를 먼저 확정한 뒤
-        // 본문 역할을 하는 이미지 한 장을 media 도메인에 위임해 저장한다.
         Member writer = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         Artist artist = artistReader.findArtistByIdOrThrow(artistId);
         validateWritePermission(artistId, writer.getId());
-        // 수신 대상은 "아티스트 전체" 또는 "특정 아티스트 멤버" 둘 중 하나로 정규화한다.
         ResolvedRecipient resolvedRecipient = resolveRecipient(
                 artistId,
                 request.getRecipientType(),
@@ -84,59 +73,29 @@ public class FanLetterService {
                 resolvedRecipient.recipientType(),
                 resolvedRecipient.recipientArtistMember()
         ));
-        // 팬레터 본문 역할을 하는 이미지 1장은 media 서비스가 storage 와 DB 메타데이터를 함께 처리한다.
         mediaService.attachFanLetterMedia(artistId, fanLetter, request.getImage());
         return FanLetterCreateResponse.from(fanLetter);
     }
 
     public CursorSliceResponse<FanLetterListResponse> getFanLetters(Long artistId, Long cursor) {
         artistReader.findArtistByIdOrThrow(artistId);
-
-        // 팬레터 목록은 사진 카드 렌더링에 필요한 최소 정보만 읽는다.
-        // 작성자 프로필/배지는 상세에서만 내려주고, 목록은 이미지/수신자/special-like만 조립한다.
-        List<FanLetterListRow> rows = fanLetterRepository.findSliceRowsByArtistId(
-                artistId,
-                cursor,
-                FAN_LETTER_SLICE_SIZE + 1
-        );
-        boolean hasNext = rows.size() > FAN_LETTER_SLICE_SIZE;
-        List<FanLetterListRow> visibleRows = hasNext ? rows.subList(0, FAN_LETTER_SLICE_SIZE) : rows;
-        if (visibleRows.isEmpty()) {
-            return new CursorSliceResponse<>(List.of(), null, false, FAN_LETTER_SLICE_SIZE);
-        }
-
-        return toCursorSliceResponse(artistId, visibleRows, hasNext);
+        // fan letter 목록은 count를 포함하지 않으므로 base 응답 자체를 길게 캐시해도 된다.
+        return fanLetterBaseCacheService.getFanLetterListBaseSlice(artistId, cursor);
     }
 
     public FanLetterResponse getFanLetter(Long artistId, Long fanLetterId) {
         artistReader.findArtistByIdOrThrow(artistId);
-        FanLetterReadRow row = fanLetterRepository.findDetailRowByArtistIdAndFanLetterId(artistId, fanLetterId)
-                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
 
-        // 상세는 작성자 프로필/배지까지 보여주므로 목록보다 더 많은 정보를 조립한다.
-        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(List.of(fanLetterId));
-        WriterSubscriptionBadge writerBadge = loadWriterBadges(artistId, List.of(row.writerId()))
-                .getOrDefault(row.writerId(), WriterSubscriptionBadge.empty(row.writerId()));
-        SpecialLikeInfo specialLikeInfo = loadSpecialLikeInfo(
-                artistId,
-                List.of(row),
-                FanLetterReadRow::fanLetterId,
-                FanLetterReadRow::artistDisplayName,
-                FanLetterReadRow::artistProfileImageUrl
-        )
-                .getOrDefault(fanLetterId, SpecialLikeInfo.empty());
-
-        return FanLetterResponse.from(
-                row,
-                imageByLetterId.get(fanLetterId),
-                writerBadge,
-                specialLikeInfo.artistLiked(),
-                specialLikeInfo.artistLikeDisplayName(),
-                specialLikeInfo.artistLikeProfileImageUrl()
-        );
+        FanLetterBaseResponse baseResponse = fanLetterBaseCacheService.getFanLetterBaseDetail(artistId, fanLetterId);
+        PostHotData hotData = postHotDataCacheService.getPostHotData(PostType.FAN_LETTER, fanLetterId);
+        return FanLetterResponse.from(baseResponse, hotData);
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_LETTER_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_LETTER_DETAIL_BASE, allEntries = true)
+    })
     public FanLetterResponse update(
             MemberDetailsImpl memberDetails,
             Long artistId,
@@ -146,8 +105,6 @@ public class FanLetterService {
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         FanLetter fanLetter = findOwnedFanLetter(member.getId(), artistId, fanLetterId);
 
-        // 수신 대상을 바꾸는 경우에는 "아티스트 전체" / "특정 멤버" 규칙을 다시 검증한다.
-        // recipientType=ARTIST 로 바꾸면 recipientArtistMember 는 null 이어야 하므로 resolveRecipient 에서 정규화한다.
         if (request.getRecipientType() != null || request.getRecipientArtistMemberId() != null) {
             FanLetterRecipientType resolvedRecipientType =
                     request.getRecipientType() != null ? request.getRecipientType() : fanLetter.getRecipientType();
@@ -170,19 +127,27 @@ public class FanLetterService {
         }
 
         if (request.getImage() != null && !request.getImage().isEmpty()) {
-            // 팬레터는 이미지 1장만 유지하므로 수정도 append 가 아니라 교체 정책으로 처리한다.
             mediaService.replaceFanLetterMedia(artistId, fanLetter, request.getImage());
         }
 
-        return getFanLetter(artistId, fanLetterId);
+        return buildCurrentFanLetterResponse(artistId, fanLetterId, PostHotData.likeOnly(fanLetter.getLikeCount()));
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_LETTER_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_LETTER_DETAIL_BASE, allEntries = true)
+    })
     public void delete(MemberDetailsImpl memberDetails, Long artistId, Long fanLetterId) {
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         FanLetter fanLetter = findOwnedFanLetter(member.getId(), artistId, fanLetterId);
         mediaService.deleteFanLetterMedia(fanLetter);
         fanLetter.delete();
+    }
+
+    private FanLetterResponse buildCurrentFanLetterResponse(Long artistId, Long fanLetterId, PostHotData hotData) {
+        FanLetterBaseResponse baseResponse = fanLetterBaseCacheService.loadFanLetterBaseDetail(artistId, fanLetterId);
+        return FanLetterResponse.from(baseResponse, hotData);
     }
 
     private FanLetter findOwnedFanLetter(Long memberId, Long artistId, Long fanLetterId) {
@@ -205,8 +170,6 @@ public class FanLetterService {
         }
 
         if (recipientType == FanLetterRecipientType.ARTIST) {
-            // To.세븐틴 같은 케이스다.
-            // 별도 recipientArtistMember 를 저장하지 않고 artist 자체를 수신자로 해석한다.
             return new ResolvedRecipient(recipientType, null);
         }
 
@@ -214,133 +177,13 @@ public class FanLetterService {
             throw new IllegalArgumentException("아티스트 멤버에게 보내는 팬레터는 수신 멤버 선택이 필요합니다.");
         }
 
-        // To.민규 같은 케이스다.
-        // fan letter 와 artistMember 를 직접 연결해 두면
-        // 상세 응답에서 stageName / profileImageUrl / special-like 판단을 안정적으로 재사용할 수 있다.
         ArtistMember recipientArtistMember = artistReader.findArtistMemberByIdAndArtistIdOrThrow(recipientArtistMemberId, artistId);
         return new ResolvedRecipient(recipientType, recipientArtistMember);
-    }
-
-    private CursorSliceResponse<FanLetterListResponse> toCursorSliceResponse(
-            Long artistId,
-            List<FanLetterListRow> visibleRows,
-            boolean hasNext
-    ) {
-        List<Long> fanLetterIds = visibleRows.stream()
-                .map(FanLetterListRow::fanLetterId)
-                .toList();
-        Map<Long, FanLetterImageResponse> imageByLetterId = loadImageMap(fanLetterIds);
-        Map<Long, SpecialLikeInfo> specialLikeInfoByLetterId = loadSpecialLikeInfo(
-                artistId,
-                visibleRows,
-                FanLetterListRow::fanLetterId,
-                FanLetterListRow::artistDisplayName,
-                FanLetterListRow::artistProfileImageUrl
-        );
-
-        List<FanLetterListResponse> responses = visibleRows.stream()
-                .map(row -> FanLetterListResponse.from(
-                        row,
-                        imageByLetterId.get(row.fanLetterId()),
-                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLiked(),
-                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeDisplayName(),
-                        specialLikeInfoByLetterId.getOrDefault(row.fanLetterId(), SpecialLikeInfo.empty()).artistLikeProfileImageUrl()
-                ))
-                .toList();
-
-        Long nextCursor = hasNext && !visibleRows.isEmpty()
-                ? visibleRows.get(visibleRows.size() - 1).fanLetterId()
-                : null;
-        return new CursorSliceResponse<>(responses, nextCursor, hasNext, FAN_LETTER_SLICE_SIZE);
-    }
-
-    private Map<Long, FanLetterImageResponse> loadImageMap(Collection<Long> fanLetterIds) {
-        if (fanLetterIds.isEmpty()) {
-            return Map.of();
-        }
-
-        // 팬레터는 이미지 한 장만 허용하므로 targetId 당 첫 번째 media row 만 응답에 매핑한다.
-        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.FAN_LETTER, fanLetterIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        Media::getTargetId,
-                        FanLetterImageResponse::from,
-                        (left, right) -> left
-                ));
-    }
-
-    private Map<Long, WriterSubscriptionBadge> loadWriterBadges(Long artistId, List<Long> writerIds) {
-        if (writerIds.isEmpty()) {
-            return Map.of();
-        }
-        // 팬포스트와 같은 배지 계약을 그대로 재사용해
-        // 팬레터 작성자 옆에도 멤버십/DM 배지를 동일한 방식으로 붙인다.
-        return subscriptionMembershipService.getWriterBadges(artistId, writerIds);
-    }
-
-    private <T> Map<Long, SpecialLikeInfo> loadSpecialLikeInfo(
-            Long artistId,
-            List<T> rows,
-            Function<T, Long> fanLetterIdExtractor,
-            Function<T, String> artistDisplayNameExtractor,
-            Function<T, String> artistProfileImageUrlExtractor
-    ) {
-        if (rows.isEmpty()) {
-            return Map.of();
-        }
-
-        // special-like 에 필요한 건 "아티스트 멤버가 좋아요한 fanLetterId 존재 여부"뿐이라
-        // reaction 전체를 가져오지 않고 targetId 집합만 바로 조회한다.
-        var likedFanLetterIds = interactionRepository.findTargetIdsReactedByArtistMembers(
-                artistId,
-                PostType.FAN_LETTER,
-                rows.stream().map(fanLetterIdExtractor).toList(),
-                ReactionType.LIKE
-        );
-
-        return rows.stream()
-                .collect(Collectors.toMap(
-                        fanLetterIdExtractor,
-                        row -> resolveSpecialLikeInfo(
-                                artistDisplayNameExtractor.apply(row),
-                                artistProfileImageUrlExtractor.apply(row),
-                                likedFanLetterIds.contains(fanLetterIdExtractor.apply(row))
-                        )
-                ));
-    }
-
-    private SpecialLikeInfo resolveSpecialLikeInfo(
-            String artistDisplayName,
-            String artistProfileImageUrl,
-            boolean artistReacted
-    ) {
-        if (!artistReacted) {
-            return SpecialLikeInfo.empty();
-        }
-
-        // 팬레터의 special-like 는 "아티스트 팀이 반응했는가"만 본다.
-        // 따라서 수신 대상이 그룹이든 특정 멤버든 상관없이,
-        // 아티스트 소속 멤버 중 한 명이라도 좋아요하면 artist 프로필 기준 오버레이를 켠다.
-        return new SpecialLikeInfo(true, artistDisplayName, artistProfileImageUrl);
     }
 
     private record ResolvedRecipient(
             FanLetterRecipientType recipientType,
             ArtistMember recipientArtistMember
     ) {
-        // recipientType 과 연결된 artistMember 를 한 덩어리로 다뤄
-        // create/update 모두 같은 정규화 로직을 재사용한다.
     }
-
-    private record SpecialLikeInfo(
-            boolean artistLiked,
-            String artistLikeDisplayName,
-            String artistLikeProfileImageUrl
-    ) {
-        private static SpecialLikeInfo empty() {
-            // 아티스트 측 반응이 아직 없으면 오버레이 관련 필드는 모두 비운다.
-            return new SpecialLikeInfo(false, null, null);
-        }
-    }
-
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterSpecialLikeCacheInvalidationEvent.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterSpecialLikeCacheInvalidationEvent.java
@@ -1,0 +1,14 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.service;
+
+/**
+ * FanLetter special-like 표시값을 다시 계산해야 할 때 발행하는 이벤트다.
+ *
+ * special-like는 FanLetter 엔티티 필드가 아니라
+ * "아티스트 멤버의 좋아요 존재 여부"를 읽기 시점에 조립하므로
+ * 좋아요 토글 후 base cache를 함께 비워야 한다.
+ */
+public record FanLetterSpecialLikeCacheInvalidationEvent(
+        Long artistId,
+        Long fanLetterId
+) {
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterSpecialLikeCacheInvalidationListener.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/service/FanLetterSpecialLikeCacheInvalidationListener.java
@@ -1,0 +1,34 @@
+package com.example.infinite.domain.artistcontent.post.fanletter.service;
+
+import com.example.infinite.global.common.constant.CacheNames;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class FanLetterSpecialLikeCacheInvalidationListener {
+
+    private final CacheManager cacheManager;
+
+    /**
+     * special-like는 Reaction 원본 기반 읽기 조립값이라
+     * 실제 좋아요 토글 트랜잭션이 커밋된 뒤에만 base cache를 비운다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(FanLetterSpecialLikeCacheInvalidationEvent event) {
+        Cache listCache = cacheManager.getCache(CacheNames.FAN_LETTER_LIST_BASE);
+        Cache detailCache = cacheManager.getCache(CacheNames.FAN_LETTER_DETAIL_BASE);
+
+        if (listCache != null) {
+            // 목록은 cursor 키가 갈라져 있어 special-like 변경 시 전체 목록 base cache를 비운다.
+            listCache.clear();
+        }
+        if (detailCache != null) {
+            detailCache.evict(event.artistId() + ":" + event.fanLetterId());
+        }
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostBaseResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostBaseResponse.java
@@ -1,0 +1,44 @@
+package com.example.infinite.domain.artistcontent.post.fanpost.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * fan post 조회 응답에서 덜 변하는 base 필드만 모아둔 DTO다.
+ *
+ * 의도:
+ * - 본문/작성자/미디어/해시태그는 긴 TTL 캐시
+ * - like/comment count는 hot 캐시
+ * 로 수명을 분리하기 위함이다.
+ */
+public record FanPostBaseResponse(
+        Long fanPostId,
+        Long artistId,
+        Long writerId,
+        String writerNickname,
+        String writerProfileImageUrl,
+        boolean fanMembershipSubscribed,
+        boolean dmSubscribed,
+        String content,
+        int mediaCount,
+        List<FanPostMediaResponse> media,
+        List<String> hashtags,
+        LocalDateTime createdAt
+) {
+    public static FanPostBaseResponse from(FanPostReadRow row, List<FanPostMediaResponse> media, List<String> hashtags) {
+        return new FanPostBaseResponse(
+                row.fanPostId(),
+                row.artistId(),
+                row.writerId(),
+                row.writerNickname(),
+                row.writerProfileImageUrl(),
+                Boolean.TRUE.equals(row.fanMembershipSubscribed()),
+                Boolean.TRUE.equals(row.dmSubscribed()),
+                row.content(),
+                row.mediaCount() == null ? 0 : row.mediaCount(),
+                media,
+                hashtags,
+                row.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostReadRow.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostReadRow.java
@@ -12,8 +12,6 @@ public record FanPostReadRow(
         Boolean fanMembershipSubscribed,
         Boolean dmSubscribed,
         String content,
-        Long likeCount,
-        Long commentCount,
         Integer mediaCount,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostResponse.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/dto/response/FanPostResponse.java
@@ -1,5 +1,7 @@
 package com.example.infinite.domain.artistcontent.post.fanpost.dto.response;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,23 +21,23 @@ public record FanPostResponse(
         List<String> hashtags,
         LocalDateTime createdAt
 ) {
-    public static FanPostResponse from(FanPostReadRow row, List<FanPostMediaResponse> media, List<String> hashtags) {
-        // projection row와 media 목록을 최종 API 응답 구조로 합친다.
+    public static FanPostResponse from(FanPostBaseResponse baseResponse, PostHotData hotData) {
+        // base 응답과 hot count를 마지막에 합쳐 최종 API 응답을 만든다.
         return new FanPostResponse(
-                row.fanPostId(),
-                row.artistId(),
-                row.writerId(),
-                row.writerNickname(),
-                row.writerProfileImageUrl(),
-                Boolean.TRUE.equals(row.fanMembershipSubscribed()),
-                Boolean.TRUE.equals(row.dmSubscribed()),
-                row.content(),
-                row.likeCount() == null ? 0L : row.likeCount(),
-                row.commentCount() == null ? 0L : row.commentCount(),
-                row.mediaCount() == null ? 0 : row.mediaCount(),
-                media,
-                hashtags,
-                row.createdAt()
+                baseResponse.fanPostId(),
+                baseResponse.artistId(),
+                baseResponse.writerId(),
+                baseResponse.writerNickname(),
+                baseResponse.writerProfileImageUrl(),
+                baseResponse.fanMembershipSubscribed(),
+                baseResponse.dmSubscribed(),
+                baseResponse.content(),
+                hotData.likeCount(),
+                hotData.commentCount(),
+                baseResponse.mediaCount(),
+                baseResponse.media(),
+                baseResponse.hashtags(),
+                baseResponse.createdAt()
         );
     }
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
@@ -1,11 +1,14 @@
 package com.example.infinite.domain.artistcontent.post.fanpost.repository;
 
+import com.example.infinite.domain.artistcontent.post.cache.PostHotRow;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface FanPostRepository extends JpaRepository<FanPost, Long>, FanPostRepositoryCustom {
@@ -37,4 +40,15 @@ public interface FanPostRepository extends JpaRepository<FanPost, Long>, FanPost
 
     @Query("select fanPost.likeCount from FanPost fanPost where fanPost.id = :fanPostId")
     Optional<Long> findLikeCountById(@Param("fanPostId") Long fanPostId);
+
+    @Query("""
+            select new com.example.infinite.domain.artistcontent.post.cache.PostHotRow(
+                fanPost.id,
+                fanPost.likeCount,
+                fanPost.commentCount
+            )
+              from FanPost fanPost
+             where fanPost.id in :fanPostIds
+            """)
+    List<PostHotRow> findHotRowsByIds(@Param("fanPostIds") Collection<Long> fanPostIds);
 }

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepositoryImpl.java
@@ -33,8 +33,6 @@ public class FanPostRepositoryImpl implements FanPostRepositoryCustom {
                         Expressions.constant(Boolean.FALSE),
                         Expressions.constant(Boolean.FALSE),
                         fanPost.content,
-                        fanPost.likeCount,
-                        fanPost.commentCount,
                         fanPost.mediaCount,
                         fanPost.createdAt
                 ))
@@ -69,8 +67,6 @@ public class FanPostRepositoryImpl implements FanPostRepositoryCustom {
                         Expressions.constant(Boolean.FALSE),
                         Expressions.constant(Boolean.FALSE),
                         fanPost.content,
-                        fanPost.likeCount,
-                        fanPost.commentCount,
                         fanPost.mediaCount,
                         fanPost.createdAt
                 ))

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostBaseCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostBaseCacheService.java
@@ -1,0 +1,173 @@
+package com.example.infinite.domain.artistcontent.post.fanpost.service;
+
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
+import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostBaseResponse;
+import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostMediaResponse;
+import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostReadRow;
+import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
+import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
+import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
+import com.example.infinite.global.common.constant.CacheNames;
+import com.example.infinite.global.common.dto.CursorSliceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FanPostBaseCacheService {
+
+    private static final int FAN_POST_SLICE_SIZE = 10;
+    private static final int FAN_POST_LIST_MEDIA_PREVIEW_LIMIT = 6;
+
+    private final FanPostRepository fanPostRepository;
+    private final MediaRepository mediaRepository;
+    private final HashtagService hashtagService;
+    private final SubscriptionMembershipService subscriptionMembershipService;
+
+    /**
+     * 목록 base 응답 캐시.
+     *
+     * 여기서는 count를 제외한 조립 결과만 캐시한다.
+     * count까지 함께 묶어 버리면 hot 필드 때문에 전체 TTL이 짧아져
+     * 미디어/해시태그까지 자주 다시 만들어야 하기 때문이다.
+     */
+    @Cacheable(
+            value = CacheNames.FAN_POST_LIST_BASE,
+            key = "#artistId + ':' + (#cursor == null ? 'first' : #cursor)"
+    )
+    public CursorSliceResponse<FanPostBaseResponse> getFanPostBaseSlice(Long artistId, Long cursor) {
+        return loadFanPostBaseSlice(artistId, cursor);
+    }
+
+    /**
+     * 상세 base 응답 캐시.
+     * 댓글과 count는 hot 영역이거나 별도 조회 대상이므로 여기서 섞지 않는다.
+     */
+    @Cacheable(
+            value = CacheNames.FAN_POST_DETAIL_BASE,
+            key = "#artistId + ':' + #fanPostId"
+    )
+    public FanPostBaseResponse getFanPostBaseDetail(Long artistId, Long fanPostId) {
+        return loadFanPostBaseDetail(artistId, fanPostId);
+    }
+
+    public CursorSliceResponse<FanPostBaseResponse> loadFanPostBaseSlice(Long artistId, Long cursor) {
+        List<FanPostReadRow> rows = fanPostRepository.findSliceRowsByArtistId(
+                artistId,
+                cursor,
+                FAN_POST_SLICE_SIZE + 1
+        );
+        boolean hasNext = rows.size() > FAN_POST_SLICE_SIZE;
+        List<FanPostReadRow> visibleRows = hasNext ? rows.subList(0, FAN_POST_SLICE_SIZE) : rows;
+        if (visibleRows.isEmpty()) {
+            return new CursorSliceResponse<>(List.of(), null, hasNext, FAN_POST_SLICE_SIZE);
+        }
+
+        List<Long> postIds = visibleRows.stream()
+                .map(FanPostReadRow::fanPostId)
+                .toList();
+        Map<Long, List<FanPostMediaResponse>> mediaMap = loadPreviewMediaMap(postIds);
+        Map<Long, List<String>> hashtagMap = hashtagService.findHashtagNamesByTargetIds(PostType.FAN_POST, postIds);
+        Map<Long, WriterSubscriptionBadge> badgeByWriterId = subscriptionMembershipService.getWriterBadges(
+                artistId,
+                visibleRows.stream().map(FanPostReadRow::writerId).toList()
+        );
+
+        List<FanPostBaseResponse> content = visibleRows.stream()
+                .map(row -> {
+                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
+                            row.writerId(),
+                            WriterSubscriptionBadge.empty(row.writerId())
+                    );
+                    FanPostReadRow rowWithBadge = new FanPostReadRow(
+                            row.fanPostId(),
+                            row.artistId(),
+                            row.writerId(),
+                            row.writerNickname(),
+                            row.writerProfileImageUrl(),
+                            writerBadge.fanMembershipSubscribed(),
+                            writerBadge.dmSubscribed(),
+                            row.content(),
+                            row.mediaCount(),
+                            row.createdAt()
+                    );
+                    return FanPostBaseResponse.from(
+                            rowWithBadge,
+                            mediaMap.getOrDefault(row.fanPostId(), List.of()),
+                            hashtagMap.getOrDefault(row.fanPostId(), List.of())
+                    );
+                })
+                .toList();
+
+        Long nextCursor = hasNext
+                ? visibleRows.get(visibleRows.size() - 1).fanPostId()
+                : null;
+        return new CursorSliceResponse<>(content, nextCursor, hasNext, FAN_POST_SLICE_SIZE);
+    }
+
+    public FanPostBaseResponse loadFanPostBaseDetail(Long artistId, Long fanPostId) {
+        FanPostReadRow row = fanPostRepository.findDetailRowByArtistIdAndFanPostId(artistId, fanPostId)
+                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
+        WriterSubscriptionBadge writerBadge = subscriptionMembershipService.getWriterBadges(artistId, List.of(row.writerId()))
+                .getOrDefault(row.writerId(), WriterSubscriptionBadge.empty(row.writerId()));
+        FanPostReadRow rowWithBadge = new FanPostReadRow(
+                row.fanPostId(),
+                row.artistId(),
+                row.writerId(),
+                row.writerNickname(),
+                row.writerProfileImageUrl(),
+                writerBadge.fanMembershipSubscribed(),
+                writerBadge.dmSubscribed(),
+                row.content(),
+                row.mediaCount(),
+                row.createdAt()
+        );
+        List<FanPostMediaResponse> media = loadMediaMap(List.of(fanPostId)).getOrDefault(fanPostId, List.of());
+        List<String> hashtags = hashtagService.findHashtagNamesByTargetIds(PostType.FAN_POST, List.of(fanPostId))
+                .getOrDefault(fanPostId, List.of());
+        return FanPostBaseResponse.from(rowWithBadge, media, hashtags);
+    }
+
+    private Map<Long, List<FanPostMediaResponse>> loadMediaMap(Collection<Long> fanPostIds) {
+        if (fanPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.FAN_POST, fanPostIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        Media::getTargetId,
+                        Collectors.mapping(FanPostMediaResponse::from, Collectors.toList())
+                ));
+    }
+
+    private Map<Long, List<FanPostMediaResponse>> loadPreviewMediaMap(Collection<Long> fanPostIds) {
+        if (fanPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return mediaRepository.findPreviewByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(
+                        PostType.FAN_POST,
+                        fanPostIds,
+                        FAN_POST_LIST_MEDIA_PREVIEW_LIMIT
+                )
+                .stream()
+                .collect(Collectors.groupingBy(
+                        Media::getTargetId,
+                        Collectors.mapping(FanPostMediaResponse::from, Collectors.toList())
+                ));
+    }
+}

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/service/FanPostService.java
@@ -1,19 +1,18 @@
 package com.example.infinite.domain.artistcontent.post.fanpost.service;
 
 import com.example.infinite.domain.artistcontent.comment.service.CommentService;
-import com.example.infinite.domain.artistcontent.media.entity.Media;
-import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.artistcontent.media.service.MediaService;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotData;
+import com.example.infinite.domain.artistcontent.post.cache.PostHotDataCacheService;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.artistcontent.post.enums.PostType;
-import com.example.infinite.domain.artistcontent.hashtag.service.HashtagService;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.request.FanPostCreateRequest;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.request.FanPostUpdateRequest;
+import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostBaseResponse;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostCreateResponse;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostDetailResponse;
-import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostMediaResponse;
-import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostReadRow;
 import com.example.infinite.domain.artistcontent.post.fanpost.dto.response.FanPostResponse;
 import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
 import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
@@ -23,43 +22,41 @@ import com.example.infinite.domain.member.artist.support.ArtistReader;
 import com.example.infinite.domain.member.member.entity.Member;
 import com.example.infinite.domain.member.member.support.MemberInputSupport;
 import com.example.infinite.domain.member.member.support.MemberReader;
-import com.example.infinite.domain.subscriptionmembership.dto.response.WriterSubscriptionBadge;
-import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
 import com.example.infinite.global.auth.MemberDetailsImpl;
+import com.example.infinite.global.common.constant.CacheNames;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-// FanPostService 는 팬포스트 본문/해시태그/댓글/미디어를 조립하는 중심 서비스다.
-// 특히 미디어는 별도 public controller 로 빼지 않고 fan-post write flow 내부에서 같이 처리한다.
+// FanPost는 읽기 경로에서 base/hot을 분리한다.
+// 본문/미디어/해시태그/작성자 정보는 base 캐시, like/comment count는 hot 캐시로 나눠 수명을 다르게 둔다.
 public class FanPostService {
 
-    // 팬 게시글 목록은 10개 고정 cursor slice 정책을 사용한다.
-    private static final int FAN_POST_SLICE_SIZE = 10;
-    private static final int FAN_POST_LIST_MEDIA_PREVIEW_LIMIT = 6;
-
     private final FanPostRepository fanPostRepository;
-    private final MediaRepository mediaRepository;
     private final MemberReader memberReader;
     private final ArtistReader artistReader;
     private final FanPostReader fanPostReader;
     private final HashtagService hashtagService;
     private final CommentService commentService;
     private final MediaService mediaService;
-    private final SubscriptionMembershipService subscriptionMembershipService;
+    private final FanPostBaseCacheService fanPostBaseCacheService;
+    private final PostHotDataCacheService postHotDataCacheService;
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_POST_DETAIL_BASE, allEntries = true)
+    })
     public FanPostCreateResponse create(MemberDetailsImpl memberDetails, Long artistId, FanPostCreateRequest request) {
-        // 로그인 작성자와 대상 artist를 먼저 확정한 뒤 게시글을 저장한다.
         Member writer = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         Artist artist = artistReader.findArtistByIdOrThrow(artistId);
         validateCreateRequest(request);
@@ -69,42 +66,37 @@ public class FanPostService {
                 writer,
                 normalizeContent(request.getContent())
         ));
-        // 순서:
-        // 1) fan_post row 저장
-        // 2) hashtag sync
-        // 3) media attach
-        // media 는 targetId 가 필요한 구조라 fanPost id 생성 이후에만 붙일 수 있다.
-        // 팬포스트 id가 생성된 뒤에야 content_hashtag.target_id를 채울 수 있으므로 저장 직후 sync를 호출한다.
         hashtagService.syncHashtags(PostType.FAN_POST, fanPost.getId(), fanPost.getContent());
-        // 팬포스트 첨부파일은 게시글 row 생성 후 targetId 기준으로 연결한다.
         mediaService.attachFanPostMedia(artistId, fanPost, request.getFiles());
 
         return FanPostCreateResponse.from(fanPost);
     }
 
     public CursorSliceResponse<FanPostResponse> getFanPosts(Long artistId, Long cursor) {
-        // 잘못된 artistId에 대한 조회를 초기에 차단한다.
         artistReader.findArtistByIdOrThrow(artistId);
 
-        // limit + 1 방식으로 다음 slice 존재 여부를 계산한다.
-        List<FanPostReadRow> rows = fanPostRepository.findSliceRowsByArtistId(
-                artistId,
-                cursor,
-                FAN_POST_SLICE_SIZE + 1
+        CursorSliceResponse<FanPostBaseResponse> baseSlice = fanPostBaseCacheService.getFanPostBaseSlice(artistId, cursor);
+        Map<Long, PostHotData> hotDataByPostId = postHotDataCacheService.getPostHotDataMap(
+                PostType.FAN_POST,
+                baseSlice.content().stream().map(FanPostBaseResponse::fanPostId).toList()
         );
-        // 11번째 row는 hasNext 판단용으로만 쓰고, 실제 media 조회와 DTO 조립은 노출할 10개에만 수행한다.
-        boolean hasNext = rows.size() > FAN_POST_SLICE_SIZE;
-        List<FanPostReadRow> visibleRows = hasNext ? rows.subList(0, FAN_POST_SLICE_SIZE) : rows;
 
-        // 본문 row와 media를 분리 조회한 뒤 서비스에서 합쳐 N+1 없이 응답을 조립한다.
-        return toCursorSliceResponse(visibleRows, hasNext);
+        // 읽기 응답은 마지막에만 base + hot을 합친다.
+        List<FanPostResponse> content = baseSlice.content().stream()
+                .map(baseResponse -> FanPostResponse.from(
+                        baseResponse,
+                        hotDataByPostId.getOrDefault(baseResponse.fanPostId(), PostHotData.empty())
+                ))
+                .toList();
+        return new CursorSliceResponse<>(content, baseSlice.nextCursor(), baseSlice.hasNext(), baseSlice.size());
     }
 
     public FanPostDetailResponse getFanPost(Long artistId, Long fanPostId, Long commentCursor) {
-        // 상세 조회도 artist 소속을 함께 확인해 다른 커뮤니티 글을 잘못 읽지 않게 한다.
         artistReader.findArtistByIdOrThrow(artistId);
 
-        FanPostResponse fanPostResponse = buildFanPostResponse(artistId, fanPostId);
+        FanPostBaseResponse baseResponse = fanPostBaseCacheService.getFanPostBaseDetail(artistId, fanPostId);
+        PostHotData hotData = postHotDataCacheService.getPostHotData(PostType.FAN_POST, fanPostId);
+        FanPostResponse fanPostResponse = FanPostResponse.from(baseResponse, hotData);
         return FanPostDetailResponse.from(
                 fanPostResponse,
                 commentService.getFanPostComments(artistId, fanPostId, commentCursor)
@@ -112,44 +104,53 @@ public class FanPostService {
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_POST_DETAIL_BASE, allEntries = true)
+    })
     public FanPostResponse update(
             MemberDetailsImpl memberDetails,
             Long artistId,
             Long fanPostId,
             FanPostUpdateRequest request
     ) {
-        // 수정은 작성자 본인 글인지 먼저 확인한 뒤 본문만 변경한다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         FanPost fanPost = findOwnedFanPost(member.getId(), artistId, fanPostId);
 
-        // 본문과 media 를 따로 수정하지 않고, 한 요청 안에서 "본문 수정 + 필요시 첨부 교체"까지 끝낸다.
         fanPost.update(resolveUpdatedContent(request.getContent(), fanPost.getContent()));
-        // 수정은 "기존 매핑 제거 -> 수정된 본문 기준 재생성" 규칙을 그대로 따른다.
         hashtagService.syncHashtags(PostType.FAN_POST, fanPost.getId(), fanPost.getContent());
-        // files 파라미터를 보낸 경우에만 기존 미디어를 전체 교체한다.
         if (request.getFiles() != null) {
             mediaService.replaceFanPostMedia(artistId, fanPost, request.getFiles());
         }
 
-        return buildFanPostResponse(artistId, fanPostId);
+        // write 응답은 캐시를 다시 채우지 않고, 현재 트랜잭션 상태를 기준으로 즉석 조립한다.
+        return buildCurrentFanPostResponse(
+                artistId,
+                fanPostId,
+                PostHotData.of(fanPost.getLikeCount(), fanPost.getCommentCount())
+        );
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = CacheNames.FAN_POST_LIST_BASE, allEntries = true),
+            @CacheEvict(value = CacheNames.FAN_POST_DETAIL_BASE, allEntries = true)
+    })
     public void delete(MemberDetailsImpl memberDetails, Long artistId, Long fanPostId) {
-        // 삭제도 동일한 소유자 검증 흐름을 재사용한다.
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
         FanPost fanPost = findOwnedFanPost(member.getId(), artistId, fanPostId);
-        // soft delete 전에 매핑을 먼저 비워야 usageCount와 hashtag 검색 결과가 즉시 일치한다.
         hashtagService.syncHashtags(PostType.FAN_POST, fanPost.getId(), null);
-        // 게시글 삭제 시 첨부 미디어 메타데이터와 스토리지 파일도 함께 정리한다.
         mediaService.deleteFanPostMedia(fanPost);
         fanPost.delete();
     }
 
+    private FanPostResponse buildCurrentFanPostResponse(Long artistId, Long fanPostId, PostHotData hotData) {
+        FanPostBaseResponse baseResponse = fanPostBaseCacheService.loadFanPostBaseDetail(artistId, fanPostId);
+        return FanPostResponse.from(baseResponse, hotData);
+    }
+
     private FanPost findOwnedFanPost(Long memberId, Long artistId, Long fanPostId) {
         FanPost fanPost = fanPostReader.findByIdAndArtistIdOrThrow(fanPostId, artistId);
-
-        // 팬 게시글 수정/삭제는 작성자 본인만 허용한다.
         if (!fanPost.getWriter().getId().equals(memberId)) {
             throw new ArtistContentException(ArtistContentErrorCode.POST_PERMISSION_DENIED);
         }
@@ -157,7 +158,6 @@ public class FanPostService {
     }
 
     private String resolveUpdatedContent(String requestedContent, String currentContent) {
-        // null이면 부분 수정 요청으로 보고 기존 본문을 유지한다.
         if (requestedContent == null) {
             return currentContent;
         }
@@ -165,7 +165,6 @@ public class FanPostService {
     }
 
     private String normalizeContent(String content) {
-        // 사진/영상만 있는 글을 허용하기 위해 본문은 선택값으로 두고, 없으면 빈 문자열로 저장한다.
         return content == null ? "" : content;
     }
 
@@ -173,113 +172,8 @@ public class FanPostService {
         boolean hasContent = request.getContent() != null && !request.getContent().isBlank();
         boolean hasFiles = request.getFiles() != null && !request.getFiles().isEmpty();
 
-        // 텍스트 없는 사진/영상 글은 허용하지만, 본문도 파일도 둘 다 없는 빈 게시글은 막는다.
         if (!hasContent && !hasFiles) {
             throw new IllegalArgumentException("팬포스트는 본문 또는 첨부파일 중 하나가 필요합니다.");
         }
-    }
-
-    private List<Long> extractPostIds(List<FanPostReadRow> rows) {
-        // media batch 조회를 위해 현재 slice에 포함된 게시글 id만 추출한다.
-        return rows.stream()
-                .map(FanPostReadRow::fanPostId)
-                .toList();
-    }
-
-    private FanPostResponse buildFanPostResponse(Long artistId, Long fanPostId) {
-        FanPostReadRow row = fanPostRepository.findDetailRowByArtistIdAndFanPostId(artistId, fanPostId)
-                .orElseThrow(() -> new ArtistContentException(ArtistContentErrorCode.POST_NOT_FOUND));
-        WriterSubscriptionBadge writerBadge = subscriptionMembershipService.getWriterBadges(artistId, List.of(row.writerId()))
-                .getOrDefault(row.writerId(), WriterSubscriptionBadge.empty(row.writerId()));
-        List<FanPostMediaResponse> media = loadMediaMap(List.of(fanPostId)).getOrDefault(fanPostId, List.of());
-        List<String> hashtags = hashtagService.findHashtagNamesByTargetIds(PostType.FAN_POST, List.of(fanPostId))
-                .getOrDefault(fanPostId, List.of());
-        return FanPostResponse.from(overrideBadge(row, writerBadge), media, hashtags);
-    }
-
-    private CursorSliceResponse<FanPostResponse> toCursorSliceResponse(List<FanPostReadRow> visibleRows, boolean hasNext) {
-        List<Long> postIds = extractPostIds(visibleRows);
-        if (visibleRows.isEmpty()) {
-            return new CursorSliceResponse<>(List.of(), null, hasNext, FAN_POST_SLICE_SIZE);
-        }
-
-        // 응답 조립은 "본문 row / media / hashtag / writer badge"를 각각 배치 조회한 뒤 메모리에서 합친다.
-        // 이렇게 해야 게시글별 media/hashtag/badge 개별 조회로 인한 N+1을 피할 수 있다.
-        Map<Long, List<FanPostMediaResponse>> mediaMap = loadPreviewMediaMap(postIds);
-        Map<Long, List<String>> hashtagMap = hashtagService.findHashtagNamesByTargetIds(PostType.FAN_POST, postIds);
-        Map<Long, WriterSubscriptionBadge> badgeByWriterId = subscriptionMembershipService.getWriterBadges(
-                visibleRows.get(0).artistId(),
-                visibleRows.stream().map(FanPostReadRow::writerId).toList()
-        );
-
-        List<FanPostResponse> responses = visibleRows.stream()
-                .map(row -> {
-                    WriterSubscriptionBadge writerBadge = badgeByWriterId.getOrDefault(
-                            row.writerId(),
-                            WriterSubscriptionBadge.empty(row.writerId())
-                    );
-                    return FanPostResponse.from(
-                            overrideBadge(row, writerBadge),
-                            mediaMap.getOrDefault(row.fanPostId(), List.of()),
-                            hashtagMap.getOrDefault(row.fanPostId(), List.of())
-                    );
-                })
-                .toList();
-        // nextCursor는 실제 응답에 포함된 마지막 fanPostId를 기준으로 만든다.
-        Long nextCursor = hasNext && !visibleRows.isEmpty()
-                ? visibleRows.get(visibleRows.size() - 1).fanPostId()
-                : null;
-
-        return new CursorSliceResponse<>(responses, nextCursor, hasNext, FAN_POST_SLICE_SIZE);
-    }
-
-    private Map<Long, List<FanPostMediaResponse>> loadMediaMap(Collection<Long> fanPostIds) {
-        if (fanPostIds.isEmpty()) {
-            return Map.of();
-        }
-
-        // 미디어는 targetId 묶음 조회 후 게시글별로 그룹핑해 목록 조회의 N+1을 방지한다.
-        return mediaRepository.findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(PostType.FAN_POST, fanPostIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        Media::getTargetId,
-                        Collectors.mapping(FanPostMediaResponse::from, Collectors.toList())
-                ));
-    }
-
-    private Map<Long, List<FanPostMediaResponse>> loadPreviewMediaMap(Collection<Long> fanPostIds) {
-        if (fanPostIds.isEmpty()) {
-            return Map.of();
-        }
-
-        // 목록 카드는 post당 앞쪽 6장만 내려주고,
-        // 전체 mediaCount는 별도 필드로 유지해 프론트가 "+N"을 계산할 수 있게 한다.
-        return mediaRepository.findPreviewByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(
-                        PostType.FAN_POST,
-                        fanPostIds,
-                        FAN_POST_LIST_MEDIA_PREVIEW_LIMIT
-                )
-                .stream()
-                .collect(Collectors.groupingBy(
-                        Media::getTargetId,
-                        Collectors.mapping(FanPostMediaResponse::from, Collectors.toList())
-                ));
-    }
-
-    private FanPostReadRow overrideBadge(FanPostReadRow row, WriterSubscriptionBadge writerBadge) {
-        return new FanPostReadRow(
-                row.fanPostId(),
-                row.artistId(),
-                row.writerId(),
-                row.writerNickname(),
-                row.writerProfileImageUrl(),
-                writerBadge.fanMembershipSubscribed(),
-                writerBadge.dmSubscribed(),
-                row.content(),
-                row.likeCount(),
-                row.commentCount(),
-                row.mediaCount(),
-                row.createdAt()
-        );
     }
 }

--- a/src/main/java/com/example/infinite/global/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/RedisCacheConfig.java
@@ -20,16 +20,21 @@ import java.util.Map;
 /**
  * Spring Cache + Redis 설정.
  *
- * <p>현재 프로젝트는 Redis를 인기 검색어 집계, 분산 락, 래플 상태 저장에도 사용하고 있다.
- * 여기에 Spring Cache 추상화를 추가로 얹어 "조회 결과 캐시"를 같은 Redis 안에서 분리 운영한다.</p>
+ * <p>현재 프로젝트는 Redis를 인기 검색어 집계, 분산 락, Redis Stream 보조 상태, 조회 캐시에 함께 사용한다.
+ * 같은 Redis를 쓰더라도 용도를 분리해서 봐야 하므로, Spring Cache는 "읽기 최적화용 namespace"로 따로 운영한다.</p>
  *
- * <p>이번 설정의 목적은 아티스트 상세 조회 v2를 Cache-aside 전략으로 캐싱하는 것이다.
- * 즉, 캐시 miss 때만 DB/Querydsl 원본 조회를 수행하고, hit면 Redis 값을 바로 반환한다.</p>
+ * <p>학습 포인트:
+ * <ul>
+ *   <li>base cache: 본문/미디어/해시태그처럼 상대적으로 덜 변하는 조립 결과</li>
+ *   <li>hot cache: like/comment count처럼 매우 자주 바뀌는 숫자</li>
+ *   <li>comment cache: 구조 전체가 같이 움직이므로 짧은 TTL 통캐시</li>
+ * </ul>
+ * </p>
  *
  * <p>핵심 설정 포인트:
  * <ul>
  *   <li>TTL을 명시해 캐시 데이터가 영구히 남지 않게 한다.</li>
- *   <li>key prefix를 분리해 기존 Redis 직접 사용 키(ZSet/Lock/Lua)와 충돌을 방지한다.</li>
+ *   <li>key prefix를 분리해 기존 Redis 직접 사용 키(ZSet/Lock/Lua/Stream 보조 키)와 충돌을 방지한다.</li>
  *   <li>값 직렬화는 JSON으로 맞춰 redis-cli에서 확인 가능한 형태를 유지한다.</li>
  * </ul>
  * </p>
@@ -53,9 +58,22 @@ public class RedisCacheConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
 
         // 캐시별 성격에 따라 TTL을 다르게 둘 수 있도록 분리한다.
-        Map<String, RedisCacheConfiguration> perCacheConfig = Map.of(
+        Map<String, RedisCacheConfiguration> perCacheConfig = Map.ofEntries(
                 // 아티스트 상세는 수정 빈도가 검색 결과보다 적지 않으므로 너무 길지 않은 5분 TTL을 둔다.
-                CacheNames.ARTIST_DETAIL_V2, defaultConfig.entryTtl(Duration.ofMinutes(5))
+                Map.entry(CacheNames.ARTIST_DETAIL_V2, defaultConfig.entryTtl(Duration.ofMinutes(5))),
+                // post base 캐시는 본문/작성자/미디어/해시태그처럼 상대적으로 덜 변하는 읽기 조립 결과다.
+                Map.entry(CacheNames.ARTIST_POST_LIST_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                Map.entry(CacheNames.ARTIST_POST_DETAIL_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                Map.entry(CacheNames.FAN_POST_LIST_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                Map.entry(CacheNames.FAN_POST_DETAIL_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                Map.entry(CacheNames.FAN_LETTER_LIST_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                Map.entry(CacheNames.FAN_LETTER_DETAIL_BASE, defaultConfig.entryTtl(Duration.ofMinutes(10))),
+                // hot data는 like/comment count처럼 flush 주기와 함께 움직이는 짧은 수명 캐시다.
+                // ArtistPost는 현재 3초 flush 배치에 맞춰 eventual consistency를 설명하는 구조다.
+                Map.entry(CacheNames.POST_HOT_DATA, defaultConfig.entryTtl(Duration.ofSeconds(3))),
+                // 댓글 목록은 구조 전체가 같이 움직이므로 base/hot 분리 대신 짧은 TTL 통캐시를 사용한다.
+                Map.entry(CacheNames.COMMENT_ROOT_SLICE, defaultConfig.entryTtl(Duration.ofSeconds(3))),
+                Map.entry(CacheNames.COMMENT_REPLY_LIST, defaultConfig.entryTtl(Duration.ofSeconds(3)))
         );
 
         return RedisCacheManager.builder(redisConnectionFactory)

--- a/src/main/java/com/example/infinite/global/common/constant/CacheNames.java
+++ b/src/main/java/com/example/infinite/global/common/constant/CacheNames.java
@@ -4,6 +4,15 @@ package com.example.infinite.global.common.constant;
 public final class CacheNames {
 
     public static final String ARTIST_DETAIL_V2 = "artistDetailV2";
+    public static final String ARTIST_POST_LIST_BASE = "artistPostListBase";
+    public static final String ARTIST_POST_DETAIL_BASE = "artistPostDetailBase";
+    public static final String FAN_POST_LIST_BASE = "fanPostListBase";
+    public static final String FAN_POST_DETAIL_BASE = "fanPostDetailBase";
+    public static final String FAN_LETTER_LIST_BASE = "fanLetterListBase";
+    public static final String FAN_LETTER_DETAIL_BASE = "fanLetterDetailBase";
+    public static final String POST_HOT_DATA = "postHotData";
+    public static final String COMMENT_ROOT_SLICE = "commentRootSlice";
+    public static final String COMMENT_REPLY_LIST = "commentReplyList";
 
     private CacheNames() {
     }

--- a/src/main/java/com/example/infinite/global/common/redis/ArtistPostStreamGroupInitializer.java
+++ b/src/main/java/com/example/infinite/global/common/redis/ArtistPostStreamGroupInitializer.java
@@ -1,0 +1,29 @@
+package com.example.infinite.global.common.redis;
+
+import com.example.infinite.domain.artistcontent.comment.service.artistpoststream.ArtistPostCommentStreamProducer;
+import com.example.infinite.domain.artistcontent.interaction.service.artistpostlike.stream.ArtistPostLikeStreamProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArtistPostStreamGroupInitializer {
+
+    private final RedisStreamGroupHelper redisStreamGroupHelper;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeGroups() {
+        // producer가 처음 호출되기 전에도 consumer가 안전하게 읽을 수 있도록
+        // ArtistPost stream group을 앱 기동 시점에 미리 보장한다.
+        redisStreamGroupHelper.ensureGroup(
+                ArtistPostLikeStreamProducer.STREAM_KEY,
+                ArtistPostLikeStreamProducer.CONSUMER_GROUP
+        );
+        redisStreamGroupHelper.ensureGroup(
+                ArtistPostCommentStreamProducer.STREAM_KEY,
+                ArtistPostCommentStreamProducer.CONSUMER_GROUP
+        );
+    }
+}

--- a/src/main/java/com/example/infinite/global/common/redis/RedisStreamGroupHelper.java
+++ b/src/main/java/com/example/infinite/global/common/redis/RedisStreamGroupHelper.java
@@ -17,6 +17,14 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 public class RedisStreamGroupHelper {
 
+    /**
+     * Redis Stream과 consumer group 초기화를 안전하게 보장하는 헬퍼다.
+     *
+     * 학습 포인트:
+     * - Stream consumer는 group이 없으면 XREADGROUP에서 NOGROUP 에러가 난다.
+     * - 그래서 producer/initializer가 "stream 존재 + group 존재"를 먼저 맞춰 줘야 한다.
+     */
+
     private final StringRedisTemplate stringRedisTemplate;
     private final Set<String> initializedGroups = ConcurrentHashMap.newKeySet();
 
@@ -31,6 +39,7 @@ public class RedisStreamGroupHelper {
         }
 
         synchronized (this) {
+            // 여러 스레드가 동시에 첫 초기화를 시도할 수 있어 JVM 내부에서는 한 번만 통과시킨다.
             if (initializedGroups.contains(cacheKey)) {
                 return;
             }

--- a/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
+++ b/src/main/java/com/example/infinite/global/lock/RedisLockAspect.java
@@ -19,6 +19,16 @@ import org.springframework.stereotype.Component;
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)
 public class RedisLockAspect {
 
+    /**
+     * @RedisLock 메서드 주위를 감싸 분산 락을 자동 적용하는 AOP 계층이다.
+     *
+     * 학습 포인트:
+     * - 서비스 메서드는 비즈니스 로직만 유지하고
+     * - 락 획득/해제는 aspect가 공통으로 처리한다.
+     *
+     * 즉 "락 기술 코드"와 "도메인 코드"를 분리하는 장치다.
+     */
+
     private final LockService lockService;
     private final ExpressionParser parser = new SpelExpressionParser();
 
@@ -30,12 +40,15 @@ public class RedisLockAspect {
 
     @Around("@annotation(redisLock)")
     public Object around(ProceedingJoinPoint joinPoint, RedisLock redisLock) throws Throwable {
+        // SpEL로 메서드 인자에서 실제 락 키를 계산한다.
+        // 예: "'artist-post:like:' + #artistPostId + ':member:' + #memberId"
         String key = resolveKey(joinPoint, redisLock.key());
 
         lockService.lock(key, redisLock.waitTime(), redisLock.leaseTime(), redisLock.timeUnit());
         try {
             return joinPoint.proceed();
         } finally {
+            // 비즈니스 예외가 나도 finally에서 해제해 락 누수를 막는다.
             lockService.unlock(key);
         }
     }
@@ -50,6 +63,7 @@ public class RedisLockAspect {
             context.setVariable(paramNames[i], args[i]);
         }
 
+        // 메서드 파라미터 이름을 SpEL 변수로 바인딩해 annotation 문자열을 실제 키로 바꾼다.
         return parser.parseExpression(keyExpression).getValue(context, String.class);
     }
 }

--- a/src/main/java/com/example/infinite/global/lock/lettuce/LettuceLockService.java
+++ b/src/main/java/com/example/infinite/global/lock/lettuce/LettuceLockService.java
@@ -20,6 +20,17 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class LettuceLockService implements LockService {
 
+    /**
+     * Redis의 SET NX EX를 직접 사용해 분산 락을 구현한 버전이다.
+     *
+     * 학습 포인트:
+     * - Redisson처럼 추상화된 락 객체를 쓰지 않고
+     * - "키가 없을 때만 저장" + TTL + 소유자 UUID 검증을 직접 조합한다.
+     *
+     * 그래서 V1은 동작 원리를 이해하기 좋지만,
+     * 재시도/해제/소유권 관리까지 모두 직접 책임져야 해 코드가 더 거칠다.
+     */
+
     private final StringRedisTemplate stringRedisTemplate;
 
     /**
@@ -55,12 +66,15 @@ public class LettuceLockService implements LockService {
 
     @Override
     public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
+        // 같은 키를 잡으려는 요청끼리만 경쟁시키고,
+        // value에는 소유자 UUID를 저장해 "누가 락을 잡았는지"를 식별한다.
         String uuid = UUID.randomUUID().toString();
         long waitTimeMs = timeUnit.toMillis(waitTime);
         long leaseTimeSec = timeUnit.toSeconds(leaseTime);
         long deadline = System.currentTimeMillis() + waitTimeMs;
 
         while (System.currentTimeMillis() < deadline) {
+            // SET NX EX 한 번으로 "없으면 저장 + TTL 부여"를 원자적으로 수행한다.
             Boolean acquired = stringRedisTemplate.opsForValue()
                     .setIfAbsent(key, uuid, Duration.ofSeconds(leaseTimeSec));
 
@@ -71,6 +85,7 @@ public class LettuceLockService implements LockService {
             }
 
             try {
+                // V1은 별도 큐 없이 짧게 잠들었다가 다시 시도하는 스핀락 패턴이다.
                 Thread.sleep(SPIN_LOCK_RETRY_INTERVAL_MS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -104,6 +119,8 @@ public class LettuceLockService implements LockService {
         if (result != null && result == 1L) {
             log.debug("락 해제 완료 [Lettuce]: key={}, uuid={}", key, uuid);
         } else {
+            // TTL 만료 뒤 다른 요청이 같은 키를 재사용했을 수 있으므로,
+            // 값 비교 없이 DEL 하면 남의 락을 지우는 심각한 버그가 된다.
             log.warn("락 해제 실패 (이미 만료 또는 소유자 불일치) [Lettuce]: key={}", key);
         }
     }

--- a/src/main/java/com/example/infinite/global/lock/redisson/RedissonLockService.java
+++ b/src/main/java/com/example/infinite/global/lock/redisson/RedissonLockService.java
@@ -15,10 +15,22 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedissonLockService implements LockService {
 
+    /**
+     * Redisson이 제공하는 RLock 추상화를 감싼 분산 락 서비스다.
+     *
+     * 학습 포인트:
+     * - V1처럼 SET NX를 직접 다루지 않아도 되고
+     * - tryLock / unlock / 스레드 소유권 확인 같은 공통 기능을 라이브러리가 맡아준다.
+     *
+     * 그래서 V2 이후는 "락을 어디에 걸 것인가"에 더 집중할 수 있다.
+     */
+
     private final RedissonClient redissonClient;
 
     @Override
     public void lock(String key, long waitTime, long leaseTime, TimeUnit timeUnit) {
+        // Redisson은 키마다 RLock 프록시를 제공하고,
+        // tryLock이 waitTime 동안 대기 후 성공 여부를 boolean으로 돌려준다.
         RLock rLock = redissonClient.getLock(key);
         try {
             boolean acquired = rLock.tryLock(waitTime, leaseTime, timeUnit);
@@ -35,6 +47,8 @@ public class RedissonLockService implements LockService {
     @Override
     public void unlock(String key) {
         RLock rLock = redissonClient.getLock(key);
+        // 현재 스레드가 실제 소유자인 경우에만 unlock 해야
+        // lease 만료 후 다른 요청이 잡은 락을 잘못 푸는 일을 막을 수 있다.
         if (rLock.isHeldByCurrentThread()) {
             rLock.unlock();
             log.debug("락 해제 완료 [Redisson]: key={}", key);


### PR DESCRIPTION
#92 
## 작업 배경
포스트 조회에서 본문/미디어/해시태그처럼 비교적 덜 변하는 데이터와
likeCount/commentCount처럼 자주 바뀌는 hot 데이터를 같은 응답 조립 흐름으로 다루고 있어서,
TTL을 길게 가져가기 어렵고 조회 비용도 커지는 문제가 있었습니다.

또한 댓글 목록과 FanLetter special-like는
읽기 시점 조립값이라 write 이후 캐시 정합성을 따로 맞춰줄 필요가 있었습니다.

이번 PR에서는
- 포스트 조회 응답을 base/hot cache로 분리하고
- 댓글 조회를 짧은 TTL의 조건부 캐시로 붙이고
- FanLetter special-like 캐시 무효화까지 연결해
조회 안정성과 응답 비용을 함께 정리했습니다.

## 주요 변경 사항

### 1. FanPost / ArtistPost / FanLetter 조회 응답 base/hot cache 분리
- `FanPost`, `ArtistPost`, `FanLetter` 조회 응답에서 hot 필드(`likeCount`, `commentCount`)를 분리
- 각 도메인별 `*BaseResponse`, `*BaseCacheService` 추가
- 목록/상세 조회는
  - base cache: 본문, 작성자, 미디어, 해시태그, 배지, special-like 등 상대적으로 덜 변하는 필드
  - hot cache: like/comment count
  구조로 조립
- write(create/update/delete) 시 list/detail base cache evict 적용

### 2. 공통 hot count 캐시 도입
- `PostHotData`, `PostHotRow` 추가
- `PostHotDataCacheService`, `PostHotDataLoaderService` 추가
- post type별 원본 테이블에서 hot 필드만 배치 조회
- list/detail 모두 같은 post 단위 hot cache key를 재사용하도록 정리

### 3. FanPost 조회 경로 캐시 적용
- `FanPostReadRow`에서 like/comment count 제거
- `FanPostBaseCacheService` 추가
- 작성자 구독 배지 + media + hashtag 조립 결과를 base cache로 분리
- `FanPostService`는 목록/상세 응답에서 base + hot 조합 방식으로 변경

### 4. ArtistPost 조회 경로 캐시 적용
- `ArtistPostReadRow`에서 like/comment count 제거
- `ArtistPostBaseCacheService` 추가
- media/hashtag 조립 결과를 base cache로 분리
- `ArtistPostService`는 목록/상세 응답에서 base + hot 조합 방식으로 변경

### 5. FanLetter 조회 경로 캐시 적용
- `FanLetterReadRow`에서 likeCount 제거
- `FanLetterBaseResponse`, `FanLetterBaseCacheService` 추가
- 목록은 base 응답 자체를 길게 캐시
- 상세는 writer badge / recipient / image / special-like를 포함한 base 응답 + hot likeCount 조합으로 변경

### 6. FanLetter special-like 캐시 무효화 추가
- FanLetter 좋아요 토글 시
  아티스트 멤버가 반응한 경우에만 `FanLetterSpecialLikeCacheInvalidationEvent` 발행
- AFTER_COMMIT listener에서
  - `FAN_LETTER_LIST_BASE` 전체 clear
  - `FAN_LETTER_DETAIL_BASE` 단건 evict
  처리
- reaction 원본 기반 조립값인 special-like의 정합성을 캐시와 함께 맞춤

### 7. 댓글 조회 캐시 추가
- `CommentQueryCacheService` 추가
- root comment slice / reply list를 짧은 TTL 캐시로 운영
- admission 정책:
  - root slice: 댓글 수가 충분히 많고 조회 heat가 반복되는 post만 캐시
  - replies: replyCount가 많거나 heat가 높은 thread만 캐시
- 현재 기준
  - heat window: 10초
  - heat threshold: 5회
  - root/reply count threshold: 20
  - comment cache TTL: 3초

### 8. 댓글 캐시 무효화 이벤트 연결
- 댓글 생성/삭제 후 `CommentCacheInvalidationEvent` 발행
- AFTER_COMMIT listener에서
  - root slice scope evict
  - 필요 시 reply scope evict
  처리
- DB write 커밋 이후에만 댓글 캐시를 비워 정합성 보장

### 9. 댓글 조회 지원용 repository 보강
- `CommentRepository`
  - `countByParentId`
  - `existsByParentId`
  추가
- reply count / thread 존재 여부 판단을 캐시 admission 및 삭제 후처리에 활용

### 10. Redis cache 설정 확장
- `CacheNames` 확장
  - `ARTIST_POST_LIST_BASE`
  - `ARTIST_POST_DETAIL_BASE`
  - `FAN_POST_LIST_BASE`
  - `FAN_POST_DETAIL_BASE`
  - `FAN_LETTER_LIST_BASE`
  - `FAN_LETTER_DETAIL_BASE`
  - `POST_HOT_DATA`
  - `COMMENT_ROOT_SLICE`
  - `COMMENT_REPLY_LIST`
- `RedisCacheConfig`에 cache별 TTL 분리
  - artist detail: 5분
  - post base caches: 10분
  - hot data: 3초
  - comment caches: 3초

### 11. ArtistPost stream group 초기화 추가
- `ArtistPostStreamGroupInitializer` 추가
- 앱 기동 시점에
  - ArtistPost like stream
  - ArtistPost comment stream
  consumer group을 미리 보장
- producer 호출 이전에도 consumer가 `NOGROUP` 없이 안전하게 읽을 수 있도록 보강

### 12. 동시성/에러 응답 보강
- comment like 토글에서 lock 예외를 infra 예외 그대로 노출하지 않고
  `LIKE_REQUEST_IN_PROGRESS` 의미로 변환
- FanLetter like도 member-target 단위 락으로 직렬화

### 13. 프론트 핸드오프 문서 최신화
- FanPost / ArtistPost / FanLetter의 base/hot cache 분리 반영
- 댓글의 짧은 TTL 조건부 캐시 반영
- 현재 구현 범위와 우선순위 문구 업데이트

## 리뷰 포인트
- FanPost / ArtistPost / FanLetter 목록/상세가 base + hot 조합으로 의도대로 동작하는지
- write 이후 list/detail base cache evict가 빠짐없이 연결됐는지
- FanLetter에서 아티스트 멤버 좋아요 시 special-like 캐시가 정상 무효화되는지
- 댓글 캐시 admission 조건과 AFTER_COMMIT 무효화 범위가 적절한지
- hot cache 3초 TTL과 현재 count 반영 방식이 eventual consistency 관점에서 허용 가능한지
- ArtistPost stream group initializer가 배포 환경에서 중복/선행 초기화 이슈 없이 동작하는지

