### PR TITLE
Feat: 프론트엔드 인프라 세팅 (api-client, 로그인 모달, Security 정적 리소스 허용)

### DIFF
--- a/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/infinite/global/common/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                                 "/api/auth/v1/**",
                                 "/h2-console/**",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/", "/index.html", "/components/**"
                         ).permitAll()
 
                         // 공개 GET: 팬포스트, 해시태그, 아티스트 포스트, 미디어, 아티스트 상세

--- a/src/main/resources/static/components/api-client.jsx
+++ b/src/main/resources/static/components/api-client.jsx
@@ -1,0 +1,168 @@
+// ═══════════════════════════════════════════════════════════
+// Connectfin API Client
+// Spring Boot 내장 서빙 (같은 origin) 전용. CORS 불필요.
+// ═══════════════════════════════════════════════════════════
+
+const ConnectfinAPI = (() => {
+  const TOKEN_KEY = 'connectfin_token';
+
+  // ── 토큰 관리 ──
+  function getToken() {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  function setToken(token) {
+    localStorage.setItem(TOKEN_KEY, token);
+  }
+
+  function clearToken() {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+
+  // ── 공통 헤더 생성 ──
+  function authHeaders() {
+    const token = getToken();
+    const headers = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    return headers;
+  }
+
+  // ── JSON API 호출 ──
+  // 응답 분기:
+  //   - ApiResponse 래퍼 (success 필드 있음) → data 반환
+  //   - PageResponse 등 직접 반환 (success 필드 없음) → 응답 전체 반환
+  //   - 202 Accepted → 정상 (비동기 API: ArtistPost v3 좋아요, v2 댓글)
+  async function api(path, options = {}) {
+    const { method = 'GET', body, headers: extraHeaders = {} } = options;
+
+    const headers = {
+      ...authHeaders(),
+      ...extraHeaders,
+    };
+
+    // GET이 아니고 body가 string이면 JSON
+    if (body && typeof body === 'string') {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(path, {
+      method,
+      headers,
+      body: body || undefined,
+    });
+
+    // 204 No Content
+    if (response.status === 204) return null;
+
+    const json = await response.json();
+
+    // 에러 응답 (4xx, 5xx)
+    if (!response.ok && response.status !== 202) {
+      const errMsg = json.error?.message || json.message || `HTTP ${response.status}`;
+      const err = new Error(errMsg);
+      err.status = response.status;
+      err.code = json.error?.code;
+      err.response = json;
+      throw err;
+    }
+
+    // ApiResponse 래퍼 판별
+    if (json.success !== undefined) {
+      if (!json.success) {
+        const errMsg = json.error?.message || 'Unknown error';
+        const err = new Error(errMsg);
+        err.code = json.error?.code;
+        err.response = json;
+        throw err;
+      }
+      return json.data;
+    }
+
+    // PageResponse 등 래퍼 없는 직접 반환
+    return json;
+  }
+
+  // ── Multipart API 호출 ──
+  // Content-Type을 설정하지 않는다 — 브라우저가 boundary를 자동 생성해야 한다.
+  // FormData 객체를 그대로 body로 전달한다.
+  async function apiMultipart(path, formData, method = 'POST') {
+    const response = await fetch(path, {
+      method,
+      headers: authHeaders(),  // Content-Type 의도적 미설정
+      body: formData,
+    });
+
+    if (response.status === 204) return null;
+
+    const json = await response.json();
+
+    if (!response.ok) {
+      const errMsg = json.error?.message || json.message || `HTTP ${response.status}`;
+      const err = new Error(errMsg);
+      err.status = response.status;
+      err.code = json.error?.code;
+      err.response = json;
+      throw err;
+    }
+
+    if (json.success !== undefined) {
+      if (!json.success) {
+        const errMsg = json.error?.message || 'Unknown error';
+        const err = new Error(errMsg);
+        err.code = json.error?.code;
+        err.response = json;
+        throw err;
+      }
+      return json.data;
+    }
+
+    return json;
+  }
+
+  // ── 포맷 유틸 ──
+
+  // ISO 날짜 → 상대 시간 또는 "MM.DD. HH:mm"
+  function formatTime(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMin = Math.floor(diffMs / 60000);
+    const diffHour = Math.floor(diffMs / 3600000);
+    const diffDay = Math.floor(diffMs / 86400000);
+
+    if (diffMin < 1) return '방금';
+    if (diffMin < 60) return `${diffMin}분 전`;
+    if (diffHour < 24) return `${diffHour}h`;
+    if (diffDay < 7) return `${diffDay}일 전`;
+
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mi = String(date.getMinutes()).padStart(2, '0');
+    return `${mm}.${dd}. ${hh}:${mi}`;
+  }
+
+  // 숫자 → "1.3K", "42K"
+  function formatCount(n) {
+    if (n == null) return '0';
+    if (n < 1000) return String(n);
+    if (n < 10000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+    if (n < 1000000) return Math.floor(n / 1000) + 'K';
+    return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
+  }
+
+  // ── Public API ──
+  return {
+    getToken,
+    setToken,
+    clearToken,
+    api,
+    apiMultipart,
+    formatTime,
+    formatCount,
+  };
+})();
+
+// 전역 노출 — 다른 JSX 컴포넌트에서 window.ConnectfinAPI.api(...) 로 접근
+Object.assign(window, { ConnectfinAPI });

--- a/src/main/resources/static/components/desktop-data.jsx
+++ b/src/main/resources/static/components/desktop-data.jsx
@@ -1,0 +1,324 @@
+// Connectfin — extended fixture data for desktop web screens
+
+// Notices (공지사항)
+const NOTICES = [
+  { id: 1, artistId: 1, pinned: true, emoji: '🎉', title: '[LUMEN8 1st Anniversary Pop-up : 다시 설레는 시작] 루멘 팝업스토어 운영 안내', date: '2026.04.17' },
+  { id: 2, artistId: 1, pinned: true, emoji: '🛍', title: '[LUMEN8 1st Anniversary Pop-up : 다시 설레는 시작] 루멘 팝업스토어 MD 상품 안내', date: '2026.04.16' },
+  { id: 3, artistId: 1, pinned: false, emoji: '📅', title: '[LUMEN8 1st Anniversary Pop-up] 루멘 팝업스토어 사전 예약 안내', date: '2026.04.13' },
+  { id: 4, artistId: 1, pinned: false, emoji: '🎧', title: '[Prism 스트리밍 인증 이벤트] 안내', date: '2026.04.10' },
+  { id: 5, artistId: 1, pinned: false, emoji: '🏬', title: '[LUMEN8 1st Anniversary Pop-up : 다시 설레는 시작] 루멘 팝업스토어 오픈 안내', date: '2026.04.10' },
+  { id: 6, artistId: 1, pinned: false, emoji: '📢', title: '[공지사항] 2026년 "LUMEN8" 2차 창작 가이드라인 안내 (04.09 업데이트)', date: '2026.04.09' },
+  { id: 7, artistId: 1, pinned: false, emoji: '✨', title: '[안내] 얼터너티브 유니버스 프로젝트 Error 01_Allergy 공개', date: '2026.04.06' },
+  { id: 8, artistId: 1, pinned: false, emoji: '🎬', title: '[안내] 얼터너티브 유니버스 프로젝트 : Error 01_Allergy 공개 안내', date: '2026.04.05' },
+  { id: 9, artistId: 1, pinned: false, emoji: '💌', title: '[멤버십 이벤트] 월간 DM 추첨 결과 공지', date: '2026.03.28' },
+  { id: 10, artistId: 1, pinned: false, emoji: '⚠️', title: '[점검 안내] 4/2 02:00 ~ 04:00 서비스 점검 예정', date: '2026.03.25' },
+];
+
+// Fan letters — rendered as texture cards (notepad/blackboard/hearts/etc)
+const FAN_LETTERS = [
+  { id: 1, artistId: 1, texture: 'notepad', author: '바다뱅배무', body: '루멘빙 월요일 고생했어요~\n드뎌 내일이면 4월 22일! 1주년!!\n루멘빙이 온지 벌써 1년이나 되었다니 시간 정말 빠르다\n그래도 차곡차곡 쌓인 추억이 하나둘씩 기억나기 시작하네요 1주년이라 생각하니까 그런가?\n아무튼 오늘도 안녕히 주무세요 루멘공주~\n사랑해요 ❤️❤️' },
+  { id: 2, artistId: 1, texture: 'blackboard', author: 'LUMINARY_07', body: '2026년 4월 21일\n루멘빙 1주년 잡업 스토리[2026.4.22~29.] D-1\n\nERROR 01_Allergy 공개[2026.4.6.] D+15\nFROM HERE 콘서트[2026.3.27~29.] D+23\n씨미 풀시 등록[2026.3.16.] D+36\nBECOME 발매[2026.1.22.] D+89\n루멘빙 DM 오픈[2025.12.23.] D+118\nHuman Eclipse 공개[2025.10.20.] D+184' },
+  { id: 3, artistId: 1, texture: 'hearts', author: '별빛모아', body: '새로운 한 주가 다가왔던 하루였\n어느새 끝나가고 있는 밤이네 YUNA~\n점점 루멘8의 1주년이 다가오니까\n매우 기대되고 뭐랄까 설레는 기분이\n들었는데 내일 루멘 노래방이 온다니\n매우 행복해서 싱글벙글해 하이🥰\n뭔가 3번 방송 이후로 계속 조용한것\n같아 방송 준비로 인해서 많이\n바쁘다고 생각이 드는데 부디\n무사히 준비 잘하길 바라고 1주년 \n그리고 팝업 기간 내내 잘 진행하길\n응원하고 있을께 파이팅😭\n그럼 남은 하루 잘 마무리 짓길\n바라고 내일의 루멘 방송보러 꼭 갈게\n같이 1주년 축하하는 시간을 가지자!\n오늘도 별빛들에게 행복만안\n소식을 전해주러 온 루멘만을\n세상에서 제일 많이 사랑해💙' },
+  { id: 4, artistId: 1, texture: 'balloon', author: 'rainpeach', body: '루멘사랑해루멘사랑해루멘사랑해루멘사랑해' },
+  { id: 5, artistId: 1, texture: 'notepad', author: 'drift_ko', body: '진짜 못할 말 쑥스럽게\n그래도 꼭 전하고 싶어서 써봐요\n YUNA 덕분에 나의 2026이\n훨씬 반짝여\n고마워요, 늘 건강하길' },
+  { id: 6, artistId: 1, texture: 'grid', author: 'neonpop', body: '1주년 축하해요!!!\n앞으로의 모든 순간도\n응원할게요 🩷' },
+];
+
+// Highlights (상단 큰 가로 스크롤 카드)
+const HIGHLIGHTS = [
+  { id: 1, artistId: 1, title: 'FROM HERE 콘서트 현장', tag: 'CONCERT', emoji: '🎤' },
+  { id: 2, artistId: 1, title: 'Prism M/V Teaser', tag: 'TEASER', emoji: '▶' },
+  { id: 3, artistId: 1, title: '멤버 Vlog · YUNA편', tag: 'VLOG', emoji: '📹' },
+  { id: 4, artistId: 1, title: '1주년 기념 팝업 현장', tag: 'EVENT', emoji: '🎉' },
+  { id: 5, artistId: 1, title: '팬사인회 비하인드', tag: 'BEHIND', emoji: '✨' },
+];
+
+// LIVE Replays
+const LIVE_REPLAYS = [
+  { id: 1, artistId: 1, title: '루멘의 기습 노래방 (멤버십 전용)', duration: '40:53', date: '04.16. 22:47', plays: '8.9K', likes: '14.9K', comments: 60, voiceOnly: true, membership: false },
+  { id: 2, artistId: 1, title: '루멘8 기습 노래방 (멤버십 전용)', duration: '18:02', date: '04.12. 18:02', plays: '12.1K', likes: '132K', comments: 114, voiceOnly: false, membership: true },
+  { id: 3, artistId: 1, title: '1', duration: '15:30', date: '04.10. 15:30', plays: '3.9K', likes: '14.6K', comments: 38, voiceOnly: false, membership: true },
+  { id: 4, artistId: 1, title: '콘서트가 끝이 났네유 🥰🫶', duration: '10:46', date: '03.29. 20:40', plays: '9.7K', likes: '26.6K', comments: 179, voiceOnly: true, membership: false },
+  { id: 5, artistId: 1, title: '퇴근길 랜덤 스트림', duration: '1:03:09', date: '03.22. 19:12', plays: '18.2K', likes: '42K', comments: 321, voiceOnly: true, membership: false },
+  { id: 6, artistId: 1, title: '연습실 몰래 방송', duration: '51:06', date: '03.18. 23:04', plays: '22.8K', likes: '58K', comments: 491, voiceOnly: true, membership: true },
+  { id: 7, artistId: 1, title: 'Q&A 털어보기', duration: '28:40', date: '03.11. 20:00', plays: '14.2K', likes: '31K', comments: 208, voiceOnly: false, membership: false },
+  { id: 8, artistId: 1, title: '비하인드 첫공개', duration: '12:11', date: '03.05. 21:15', plays: '6.5K', likes: '22K', comments: 142, voiceOnly: false, membership: true },
+];
+
+// Media items with category splits
+const MEDIA_EXTENDED = [
+  { id: 1, artistId: 1, title: '📸 FROM HERE 1st Fan Concert – Opening, 지금부터(Onward)...', date: '2026.04.05', duration: '05:15', isNew: true, membership: false, kind: 'video' },
+  { id: 2, artistId: 1, title: '콘서트 안무 연습 비하인드 🤫', date: '2026.02.21', duration: '02:41', isNew: true, membership: false, kind: 'video' },
+  { id: 3, artistId: 1, title: '[Error :warning:] ACCESS TEMPORARILY GRANTED', date: '2026.04.03', duration: '00:57', isNew: false, membership: false, kind: 'video' },
+  { id: 4, artistId: 1, title: '루멘의 꿈 속 들여다보기', date: '2026.02.02', duration: '00:46', isNew: false, membership: true, kind: 'video' },
+  { id: 5, artistId: 1, title: '멤버십 가입을 해주신 루멘이 여러분들께', date: '2026.01.27', duration: '00:35', isNew: false, membership: true, kind: 'video' },
+  { id: 6, artistId: 1, title: 'LUMEN8 - Become Official MV', date: '2026.01.23', duration: '03:12', isNew: false, membership: false, kind: 'video' },
+  { id: 7, artistId: 1, title: 'Prism - Behind Scene', date: '2025.12.30', duration: '08:22', isNew: false, membership: true, kind: 'video' },
+  { id: 8, artistId: 1, title: '연말 인사 영상 💌', date: '2025.12.25', duration: '01:15', isNew: false, membership: false, kind: 'video' },
+];
+
+// Jelly packages (일반충전)
+const JELLY_PACKS = [
+  { jelly: 4, price: '₩1,200', bonus: 0, benefit: null },
+  { jelly: 8, price: '₩2,400', bonus: 0, benefit: null },
+  { jelly: 20, price: '₩6,000', bonus: 1, benefit: '5% 혜택' },
+  { jelly: 40, price: '₩12,000', bonus: 3, benefit: '7% 혜택' },
+  { jelly: 60, price: '₩18,000', bonus: 5, benefit: '8% 혜택' },
+  { jelly: 80, price: '₩24,000', bonus: 7, benefit: '8% 혜택' },
+  { jelly: 120, price: '₩36,000', bonus: 11, benefit: '9% 혜택' },
+  { jelly: 160, price: '₩48,000', bonus: 15, benefit: '9% 혜택' },
+  { jelly: 240, price: '₩72,000', bonus: 24, benefit: '10% 혜택', best: true },
+];
+
+// Home hero slides (캐러셀)
+const HERO_SLIDES = [
+  { id: 1, artist: 'LUMEN8', kind: 'MERCH', title: '개화(FLOWERING)\nOFFICIAL MERCH', body: '커넥트핀샵에서 만나보세요!', color1: '#FDE68A', color2: '#FBBF24', textDark: true },
+  { id: 2, artist: 'NOIR7', kind: 'CONCERT', title: 'NOIR7\n1st CONCERT TOUR', body: "'INTO THE LIGHT : Our WISH' ENCORE IN SEOUL 공식 상품", color1: '#0F172A', color2: '#334155', textDark: false },
+  { id: 3, artist: 'hanabi*', kind: 'ALBUM', title: 'hanabi*\n2nd MINI ALBUM', body: "'FIREWORKS' pre-order now", color1: '#FCA5A5', color2: '#A78BFA', textDark: false },
+];
+
+// On LIVE (홈 하단)
+const ON_LIVE_NOW = [
+  { id: 1, artistId: 1, title: 'HBD 2 me', host: 'YUNA', group: 'LUMEN8', status: 'LIVE', kind: 'video' },
+  { id: 2, artistId: 4, title: 'We on Fire Official Listening Party', host: 'hanabi*', group: 'hanabi*', status: 'Party', kind: 'voice' },
+];
+
+// Fan posts (Fan 탭)
+const FAN_POSTS = [
+  { id: 1, artistId: 1, author: '헤이즐넛초코', tag: '#Prism_Streaming', body: '20260421 유튜브뮤직', likes: '4.2K', comments: 238, timeAgo: '04. 21. 00:36', hasGrid: true, gridCount: 4 },
+  { id: 2, artistId: 1, author: '헤이즐넛초코', tag: '#Prism_Streaming', body: '20260421 스포티파이', likes: '5.1K', comments: 288, timeAgo: '04. 21. 00:35', hasGrid: true, gridCount: 4 },
+  { id: 3, artistId: 1, author: 'AspCY', body: '루멘시 ❤️ | 이 | | 식 사랑해!!! 악\n(+6)\n항상 너무 고마워!! 나의 우상!!!', likes: 20, comments: null, timeAgo: '5h' },
+  { id: 4, artistId: 1, author: '누군가가웃는다면만족하는뱀뱀', body: '오늘이 중간고사 시험날이구나... 화이팅\n해야겠다.\n행복 부적 들고가야지...', likes: 35, comments: 16, timeAgo: '6h' },
+  { id: 5, artistId: 1, author: '이선지', body: '오늘 국어 수행평가로 좋아하는 노래 또는 시 갈래로 나타내어 표현법 쓰기 시험 봤는데 다른 애들은 다 어려워 하던데 저는 왠지모르게 쉬워서 이틀만 준비...', likes: 24, comments: 6, timeAgo: '8h' },
+  { id: 6, artistId: 1, author: '날이날', body: '22일날에 팝업예약 안하고 가면 굿즈 못사죠? 그죠?', likes: 17, comments: 5, timeAgo: '9h' },
+  { id: 7, artistId: 1, author: 'Wilt', body: '[ 루멘 콘서트와 팝업을 못 갔으므로, 지금부터 굿즈 자체제작 시작하려합니다 ]', likes: 26, comments: 12, timeAgo: '11h' },
+  { id: 8, artistId: 1, author: 'Legend', body: '루멘시', likes: 18, comments: null, timeAgo: '12h' },
+];
+
+// Artist posts (Artist 탭)
+const ARTIST_POSTS = [
+  { id: 1, artistId: 1, author: 'YUNA', body: '방송 킬까나😊', likes: '1.3K', comments: 641, time: '04. 08. 19:58', moment: true },
+  { id: 2, artistId: 1, author: 'YUNA', body: '오늘.. 첫 프로젝트의 시작을 알리는 에피소드 1화 알레르기가 오후 6시에 공개 될 예정이에요!\n진짜 애니메이션도 너무너무 멋지고... 노래도 넘 좋으니까 다들 많이 관심 가져주셨으면 좋겠네요 하핫\n오늘은 방송 7시에 킬 예정입니다\n녹음 비하인드 썰이나 노래 관련 이야기 많이 해용\n이따 봐요😙', likes: '1.6K', comments: 443, time: '04. 06. 10:30' },
+  { id: 3, artistId: 1, author: 'YUNA', body: '방송 온!!!! ⭐⭐⭐', likes: '1.3K', comments: 339, time: '04. 03. 17:47' },
+  { id: 4, artistId: 1, author: 'YUNA', body: '보구치!!', likes: '980', comments: 218, time: '04. 02. 18:25' },
+];
+
+// ═══════════════════════════════════════════════════════════
+// 나머지 5명 아티스트 데이터 (id 2~6)
+// Kagerō(2), NOIR7(3), hanabi*(4), Velvet Static(5), ORBITAL(6)
+// ═══════════════════════════════════════════════════════════
+
+NOTICES.push(
+  // Kagerō (J-ROCK)
+  { id: 101, artistId: 2, pinned: true, emoji: '🎸', title: '[Kagerō] 4th Single "Mirage" 발매 안내', date: '2026.04.18' },
+  { id: 102, artistId: 2, pinned: true, emoji: '🎤', title: '[TOUR] Kagerō LIVE "SHINKAI 2026" 티켓 예매 공지', date: '2026.04.12' },
+  { id: 103, artistId: 2, pinned: false, emoji: '📻', title: '[RADIO] J-WAVE 심야방송 게스트 출연 안내', date: '2026.04.08' },
+  { id: 104, artistId: 2, pinned: false, emoji: '💿', title: '[한정반] 블루레이 선착순 예약 판매', date: '2026.04.02' },
+  { id: 105, artistId: 2, pinned: false, emoji: '📢', title: '[공지] 2차 창작 가이드라인 업데이트 (04.01)', date: '2026.04.01' },
+
+  // NOIR7 (K-POP 보이그룹)
+  { id: 201, artistId: 3, pinned: true, emoji: '🌟', title: "[NOIR7] 1st CONCERT TOUR 'INTO THE LIGHT' ENCORE IN SEOUL 공지", date: '2026.04.19' },
+  { id: 202, artistId: 3, pinned: true, emoji: '🛍', title: '[NOIR7] ENCORE 공식 MD 상품 안내 (4/25 오픈)', date: '2026.04.17' },
+  { id: 203, artistId: 3, pinned: false, emoji: '📸', title: '[NOIR7] 4th Mini Album "OUR WISH" 콘셉트 포토 공개', date: '2026.04.14' },
+  { id: 204, artistId: 3, pinned: false, emoji: '🎬', title: '[NOIR7] 자체 콘텐츠 "SEVEN-TAKE" S2 런칭 안내', date: '2026.04.10' },
+  { id: 205, artistId: 3, pinned: false, emoji: '💎', title: '[FANCLUB] SEVENTS 3기 모집 안내', date: '2026.04.05' },
+
+  // hanabi* (우타이테)
+  { id: 301, artistId: 4, pinned: true, emoji: '🎆', title: '[hanabi*] 2nd Mini Album "FIREWORKS" 선주문 오픈', date: '2026.04.20' },
+  { id: 302, artistId: 4, pinned: false, emoji: '🎙', title: '[hanabi*] 첫 단독 콘서트 "BLOOM" 공지', date: '2026.04.15' },
+  { id: 303, artistId: 4, pinned: false, emoji: '🎨', title: '[콜라보] 유명 일러스트레이터와의 아트북 크라우드펀딩', date: '2026.04.08' },
+  { id: 304, artistId: 4, pinned: false, emoji: '📅', title: '[스케줄] 4월 방송 일정 안내', date: '2026.04.01' },
+
+  // Velvet Static (인디록)
+  { id: 401, artistId: 5, pinned: true, emoji: '🎸', title: '[Velvet Static] EP "Ashlight" 발매 공지', date: '2026.04.16' },
+  { id: 402, artistId: 5, pinned: false, emoji: '🎤', title: '[공연] 홍대 롤링홀 단독 공연 오픈 안내', date: '2026.04.10' },
+  { id: 403, artistId: 5, pinned: false, emoji: '📢', title: '[공지] 머치 스토어 정기 점검 안내', date: '2026.04.05' },
+
+  // ORBITAL (힙합)
+  { id: 501, artistId: 6, pinned: true, emoji: '🔥', title: '[ORBITAL] 크루 정규 1집 "GRAVITY" 트랙리스트 공개', date: '2026.04.19' },
+  { id: 502, artistId: 6, pinned: true, emoji: '🎤', title: '[CYPHER] ORBITAL x OVERDRIVE 콜라보 사이퍼 공지', date: '2026.04.13' },
+  { id: 503, artistId: 6, pinned: false, emoji: '🎬', title: '[MV] "Blacklight" 뮤직비디오 티저 공개', date: '2026.04.07' },
+  { id: 504, artistId: 6, pinned: false, emoji: '📅', title: '[투어] 전국 클럽 투어 "NO CEILING" 라인업 공지', date: '2026.04.01' },
+);
+
+FAN_LETTERS.push(
+  // Kagerō
+  { id: 201, artistId: 2, texture: 'blackboard', author: 'hotaru_jp', body: '東京の夜更け、\nまだ音が残っている。\n\nKagerōのライブで感じた\nあの熱を胸に、\n今日も生きていく。\n\nありがとう。' },
+  { id: 202, artistId: 2, texture: 'notepad', author: '深海星', body: '카게로 진짜 고마워요\n힘들 때마다 MIRAGE 반복 재생\n이번 투어도 건강히 돌아와줘요' },
+  { id: 203, artistId: 2, texture: 'grid', author: 'riku.k', body: '새 싱글 미리 듣기만 했는데\n벌써 울어버렸어요\n이 감정을 음악으로 만들어줘서 고마워요' },
+  { id: 204, artistId: 2, texture: 'hearts', author: 'fade_blue', body: '카게로의 소리는\n항상 나를 살렸어요\n계속 들려주세요 🌊' },
+
+  // NOIR7
+  { id: 301, artistId: 3, texture: 'balloon', author: 'SEVENTIE', body: 'NOIR7 ENCORE 진짜 기다렸어\n세븐스들 준비됐어!' },
+  { id: 302, artistId: 3, texture: 'notepad', author: '세븐♡모아', body: '카이야 요즘 잠 잘 자?\n너무 바쁜 것 같아서 걱정돼\n팬미팅에서 봤을 때 많이 피곤해보였어\n건강 꼭 챙겨줘' },
+  { id: 303, artistId: 3, texture: 'hearts', author: 'light_07', body: 'INTO THE LIGHT\n우리가 너희의 빛이 되어줄게\n사랑해 🤍' },
+  { id: 304, artistId: 3, texture: 'grid', author: '세븐다이어리', body: '데뷔 1500일 축하해\n앞으로의 1500일도 함께' },
+  { id: 305, artistId: 3, texture: 'blackboard', author: 'N7archive', body: '[ENCORE D-5]\n2026.04.26 SAT\n좌석 E7\n모든 순간을 기억할게.' },
+
+  // hanabi*
+  { id: 401, artistId: 4, texture: 'balloon', author: '小さな火', body: '하나비 짱 오늘도\n너무 예뻐요 🎆' },
+  { id: 402, artistId: 4, texture: 'hearts', author: '꽃불', body: 'FIREWORKS 프리오더 성공!\n첫 콘서트도 너무 기대돼\n준비 많이 하고 있는거 다 알아\n우리도 열심히 응원할게요' },
+  { id: 403, artistId: 4, texture: 'notepad', author: 'sparkle_9', body: '하나비의 목소리를 들으면\n마음이 따뜻해져요\n계속 노래해주세요' },
+
+  // Velvet Static
+  { id: 501, artistId: 5, texture: 'blackboard', author: 'ashlight.', body: '롤링홀 공연 일주일 앞으로\n이번엔 꼭 갈게요\n드럼 스틱 던져주세요 농담 🥁' },
+  { id: 502, artistId: 5, texture: 'grid', author: '벨벳팬', body: '인디씬에 이런 밴드가 있다는 게\n우리 세대의 행운이에요\n오래 해주세요' },
+  { id: 503, artistId: 5, texture: 'hearts', author: 'staticwave', body: '가사 하나하나가 시예요\n앨범 나오면 꼭 피지컬 살거예요' },
+
+  // ORBITAL
+  { id: 601, artistId: 6, texture: 'blackboard', author: 'lowgrav', body: 'GRAVITY 트랙리스트 보고\n기절함. 3, 7, 11번 제목만 봐도\n각이다. 발매일만 기다림.' },
+  { id: 602, artistId: 6, texture: 'grid', author: 'orbit_crew', body: '사이퍼 영상 100번 돌려봄\n한국힙합 다시 살아났음' },
+  { id: 603, artistId: 6, texture: 'notepad', author: 'rap_diary', body: '오늘도 출근길에 ORBITAL\n이 바이브 없으면 못 버텨요\n정규 1집 기다릴게요' },
+);
+
+HIGHLIGHTS.push(
+  // Kagerō
+  { id: 201, artistId: 2, title: 'SHINKAI TOUR 리허설', tag: 'REHEARSAL', emoji: '🎸' },
+  { id: 202, artistId: 2, title: 'Mirage MV Behind', tag: 'BEHIND', emoji: '🎬' },
+  { id: 203, artistId: 2, title: '새 싱글 스튜디오 세션', tag: 'STUDIO', emoji: '🎙' },
+  { id: 204, artistId: 2, title: '라이브 셋리스트 공개', tag: 'SETLIST', emoji: '📝' },
+
+  // NOIR7
+  { id: 301, artistId: 3, title: 'INTO THE LIGHT 서울 앙코르', tag: 'CONCERT', emoji: '🌟' },
+  { id: 302, artistId: 3, title: 'OUR WISH 컨셉포토', tag: 'PHOTO', emoji: '📸' },
+  { id: 303, artistId: 3, title: 'SEVEN-TAKE EP.01', tag: 'CONTENT', emoji: '🎬' },
+  { id: 304, artistId: 3, title: '멤버 VLOG · KAI', tag: 'VLOG', emoji: '📹' },
+  { id: 305, artistId: 3, title: '팬사인회 현장', tag: 'EVENT', emoji: '✨' },
+
+  // hanabi*
+  { id: 401, artistId: 4, title: 'FIREWORKS 티저', tag: 'TEASER', emoji: '🎆' },
+  { id: 402, artistId: 4, title: '단독 콘서트 연습실', tag: 'REHEARSAL', emoji: '🎙' },
+  { id: 403, artistId: 4, title: '아트북 일러스트 공개', tag: 'ART', emoji: '🎨' },
+
+  // Velvet Static
+  { id: 501, artistId: 5, title: 'Ashlight EP 쇼케이스', tag: 'SHOWCASE', emoji: '🎸' },
+  { id: 502, artistId: 5, title: '롤링홀 리허설', tag: 'REHEARSAL', emoji: '🥁' },
+
+  // ORBITAL
+  { id: 601, artistId: 6, title: 'CYPHER 영상', tag: 'CYPHER', emoji: '🔥' },
+  { id: 602, artistId: 6, title: 'Blacklight MV 티저', tag: 'TEASER', emoji: '🎬' },
+  { id: 603, artistId: 6, title: 'NO CEILING 투어 일정', tag: 'TOUR', emoji: '🗺' },
+);
+
+LIVE_REPLAYS.push(
+  // Kagerō
+  { id: 201, artistId: 2, title: 'Mirage 레코딩 세션 비하인드', duration: '45:12', date: '04.18. 21:30', plays: '14.2K', likes: '38K', comments: 210, voiceOnly: false, membership: false },
+  { id: 202, artistId: 2, title: '심야 톡톡 · 깊은 밤의 이야기', duration: '1:12:45', date: '04.10. 23:00', plays: '22.1K', likes: '51K', comments: 388, voiceOnly: true, membership: false },
+  { id: 203, artistId: 2, title: 'SHINKAI 투어 리허설 엿보기', duration: '32:04', date: '04.05. 18:40', plays: '18.8K', likes: '42K', comments: 254, voiceOnly: false, membership: true },
+  { id: 204, artistId: 2, title: '어쿠스틱 라이브', duration: '28:16', date: '03.25. 20:00', plays: '9.4K', likes: '26K', comments: 142, voiceOnly: false, membership: false },
+
+  // NOIR7
+  { id: 301, artistId: 3, title: 'ENCORE 연습 현장 (멤버십 전용)', duration: '52:40', date: '04.19. 19:15', plays: '45.2K', likes: '188K', comments: 921, voiceOnly: false, membership: true },
+  { id: 302, artistId: 3, title: '카이의 야식 타임 🍜', duration: '41:22', date: '04.16. 23:40', plays: '38.1K', likes: '142K', comments: 684, voiceOnly: true, membership: false },
+  { id: 303, artistId: 3, title: 'SEVEN-TAKE 촬영 비하인드', duration: '18:55', date: '04.12. 17:20', plays: '22.4K', likes: '78K', comments: 412, voiceOnly: false, membership: false },
+  { id: 304, artistId: 3, title: '세븐츠 사랑해 💜', duration: '08:11', date: '04.08. 22:00', plays: '29.8K', likes: '98K', comments: 512, voiceOnly: true, membership: false },
+  { id: 305, artistId: 3, title: '데뷔 1500일 기념 방송', duration: '1:22:18', date: '04.01. 20:00', plays: '62.3K', likes: '210K', comments: 1184, voiceOnly: false, membership: false },
+
+  // hanabi*
+  { id: 401, artistId: 4, title: 'FIREWORKS 첫 번째 티저 공개', duration: '22:08', date: '04.20. 20:10', plays: '18.2K', likes: '42K', comments: 298, voiceOnly: false, membership: false },
+  { id: 402, artistId: 4, title: '딩동! 스페셜 커버곡 라이브', duration: '34:45', date: '04.14. 21:30', plays: '12.6K', likes: '28K', comments: 167, voiceOnly: true, membership: false },
+  { id: 403, artistId: 4, title: '콘서트 연습실 live', duration: '55:12', date: '04.05. 19:00', plays: '8.9K', likes: '19K', comments: 124, voiceOnly: false, membership: true },
+
+  // Velvet Static
+  { id: 501, artistId: 5, title: 'Ashlight 발매 전 첫 공개', duration: '18:40', date: '04.14. 22:00', plays: '5.4K', likes: '14K', comments: 88, voiceOnly: false, membership: false },
+  { id: 502, artistId: 5, title: '작업실 일상', duration: '41:18', date: '04.03. 23:15', plays: '3.8K', likes: '9.2K', comments: 52, voiceOnly: true, membership: false },
+
+  // ORBITAL
+  { id: 601, artistId: 6, title: 'GRAVITY 트랙 미리듣기 세션', duration: '38:22', date: '04.19. 22:30', plays: '24.1K', likes: '62K', comments: 441, voiceOnly: false, membership: true },
+  { id: 602, artistId: 6, title: 'Blacklight 레코딩 비하인드', duration: '25:04', date: '04.10. 20:00', plays: '19.2K', likes: '48K', comments: 312, voiceOnly: false, membership: false },
+  { id: 603, artistId: 6, title: '크루원 랜덤 Q&A', duration: '1:02:18', date: '04.02. 21:40', plays: '31.8K', likes: '82K', comments: 598, voiceOnly: true, membership: false },
+);
+
+MEDIA_EXTENDED.push(
+  // Kagerō
+  { id: 201, artistId: 2, title: 'Mirage Official MV', date: '2026.04.18', duration: '04:28', isNew: true, membership: false, kind: 'video' },
+  { id: 202, artistId: 2, title: 'Mirage Recording Session', date: '2026.04.12', duration: '08:14', isNew: true, membership: false, kind: 'video' },
+  { id: 203, artistId: 2, title: 'SHINKAI Tour Teaser', date: '2026.04.06', duration: '01:18', isNew: false, membership: false, kind: 'video' },
+  { id: 204, artistId: 2, title: '멤버 인터뷰 · Drummer Ren', date: '2026.03.28', duration: '12:42', isNew: false, membership: true, kind: 'video' },
+  { id: 205, artistId: 2, title: '라이브 하우스 단독 세션', date: '2026.03.20', duration: '22:15', isNew: false, membership: true, kind: 'video' },
+  { id: 206, artistId: 2, title: 'Acoustic Session · 終夜', date: '2026.03.10', duration: '05:33', isNew: false, membership: false, kind: 'video' },
+
+  // NOIR7
+  { id: 301, artistId: 3, title: "OUR WISH Concept Film", date: '2026.04.20', duration: '02:48', isNew: true, membership: false, kind: 'video' },
+  { id: 302, artistId: 3, title: "ENCORE IN SEOUL 리허설 Vlog", date: '2026.04.18', duration: '14:22', isNew: true, membership: true, kind: 'video' },
+  { id: 303, artistId: 3, title: "SEVEN-TAKE S2 EP.01", date: '2026.04.15', duration: '18:40', isNew: true, membership: false, kind: 'video' },
+  { id: 304, artistId: 3, title: "KAI's Practice Room", date: '2026.04.10', duration: '08:12', isNew: false, membership: true, kind: 'video' },
+  { id: 305, artistId: 3, title: 'Dance Practice · OUR WISH', date: '2026.04.05', duration: '03:54', isNew: false, membership: false, kind: 'video' },
+  { id: 306, artistId: 3, title: '팬미팅 비하인드 🎤', date: '2026.03.30', duration: '11:20', isNew: false, membership: true, kind: 'video' },
+
+  // hanabi*
+  { id: 401, artistId: 4, title: 'FIREWORKS Teaser #01', date: '2026.04.20', duration: '00:58', isNew: true, membership: false, kind: 'video' },
+  { id: 402, artistId: 4, title: 'BLOOM Concert Trailer', date: '2026.04.14', duration: '01:32', isNew: true, membership: false, kind: 'video' },
+  { id: 403, artistId: 4, title: '커버곡 · 딩동 (Acoustic)', date: '2026.04.08', duration: '04:12', isNew: false, membership: false, kind: 'video' },
+  { id: 404, artistId: 4, title: '스튜디오 풀영상', date: '2026.04.01', duration: '15:08', isNew: false, membership: true, kind: 'video' },
+
+  // Velvet Static
+  { id: 501, artistId: 5, title: 'Ashlight M/V', date: '2026.04.16', duration: '04:02', isNew: true, membership: false, kind: 'video' },
+  { id: 502, artistId: 5, title: '롤링홀 쇼케이스 티저', date: '2026.04.08', duration: '01:15', isNew: false, membership: false, kind: 'video' },
+  { id: 503, artistId: 5, title: 'Live Session · Night Drive', date: '2026.03.28', duration: '06:44', isNew: false, membership: true, kind: 'video' },
+
+  // ORBITAL
+  { id: 601, artistId: 6, title: 'Blacklight Official Teaser', date: '2026.04.18', duration: '00:48', isNew: true, membership: false, kind: 'video' },
+  { id: 602, artistId: 6, title: 'ORBITAL x OVERDRIVE CYPHER', date: '2026.04.13', duration: '07:22', isNew: true, membership: false, kind: 'video' },
+  { id: 603, artistId: 6, title: 'GRAVITY Track Preview', date: '2026.04.09', duration: '02:14', isNew: false, membership: true, kind: 'video' },
+  { id: 604, artistId: 6, title: '크루 스튜디오 데일리', date: '2026.04.02', duration: '11:08', isNew: false, membership: true, kind: 'video' },
+);
+
+FAN_POSTS.push(
+  // Kagerō
+  { id: 201, artistId: 2, author: '深海ノート', tag: '#Mirage_Release', body: 'Mirage 수록곡 전부 다 명작인데\n특히 3번 트랙 "終夜"는 진짜 지리는 수준\n이 밴드는 매번 스스로를 뛰어넘는다', likes: 422, comments: 58, timeAgo: '2h', hasGrid: false },
+  { id: 202, artistId: 2, author: 'blue_fade', body: '카게로 보컬 음색은 대체 불가능함\n저음부에서의 그 미묘한 떨림이\n곡 전체 분위기를 만든다', likes: 312, comments: 41, timeAgo: '4h' },
+  { id: 203, artistId: 2, author: '螢火', tag: '#SHINKAI_Tour', body: 'SHINKAI 투어 나고야 공 진짜 미쳤음\n앙코르에서 운 사람 손', likes: 512, comments: 128, timeAgo: '6h' },
+  { id: 204, artistId: 2, author: 'riku.k', body: '새 앨범 프리오더\n아직 안 한 사람 있어?', likes: 88, comments: 22, timeAgo: '8h' },
+
+  // NOIR7
+  { id: 301, artistId: 3, author: 'SEVEN♡SEVEN', tag: '#INTO_THE_LIGHT', body: '앙코르 서울 티켓팅 D-1\n심장이 멎을 것 같다\n이번엔 꼭 스탠딩 잡는다', likes: 2_481, comments: 312, timeAgo: '1h', hasGrid: true, gridCount: 4 },
+  { id: 302, artistId: 3, author: '세븐모음', body: '카이 요즘 너무 멋있어서\n심장이 남아나질 않아\n세븐츠들 다 같은 마음이지?', likes: 3_102, comments: 482, timeAgo: '3h' },
+  { id: 303, artistId: 3, author: 'light_07', tag: '#OUR_WISH', body: 'OUR WISH 컨셉포토 보고 기절함\n이번 콘셉트 진짜 미쳤음\n4월 25일만 기다린다', likes: 1_882, comments: 214, timeAgo: '5h', hasGrid: true, gridCount: 4 },
+  { id: 304, artistId: 3, author: 'N7archive', body: '데뷔 1500일 타임라인\n정리해봤습니다\n처음엔 몰랐던 애들이\n지금은 인생의 반 이상이 되어있네요', likes: 2_201, comments: 398, timeAgo: '7h' },
+
+  // hanabi*
+  { id: 401, artistId: 4, author: '작은불꽃', tag: '#FIREWORKS_PREORDER', body: 'FIREWORKS 프리오더 오픈!!\n한정반 꼭 사야되는데\n카드 한도 충전하러 갑니다 🔥', likes: 614, comments: 92, timeAgo: '30m' },
+  { id: 402, artistId: 4, author: 'hanabi_daily', body: '하나비 목소리는\n여름밤 불꽃 같아\n터지고 사라지지만\n오래 남는', likes: 422, comments: 58, timeAgo: '2h' },
+  { id: 403, artistId: 4, author: 'sparkle_9', body: 'BLOOM 콘서트\n첫 단콘인데 얼마나 떨릴까\n우리가 응원 제일 세게 할게요', likes: 388, comments: 44, timeAgo: '5h' },
+
+  // Velvet Static
+  { id: 501, artistId: 5, author: 'ashlight.', tag: '#Ashlight_EP', body: 'Ashlight EP\n전곡 가사 다 외웠습니다\n특히 "재 되는 밤" 후렴 진짜 미친 곡', likes: 182, comments: 34, timeAgo: '3h' },
+  { id: 502, artistId: 5, author: 'staticwave', body: '롤링홀 공연 티켓 잡았다\n드디어 처음으로 본다\n떨려서 잠이 안 옴', likes: 98, comments: 18, timeAgo: '6h' },
+
+  // ORBITAL
+  { id: 601, artistId: 6, author: 'lowgrav', tag: '#GRAVITY', body: 'GRAVITY 트랙리스트 보고\n바로 앨범 예판\n3, 7, 11번 각 미쳤음', likes: 1_022, comments: 214, timeAgo: '1h' },
+  { id: 602, artistId: 6, author: 'rap_diary', tag: '#CYPHER', body: 'ORBITAL x OVERDRIVE 사이퍼\n한국힙합 씬 다시 살림\n이번 콜라보 레전드', likes: 1_412, comments: 288, timeAgo: '4h' },
+  { id: 603, artistId: 6, author: 'orbit_crew', body: 'NO CEILING 투어 라인업 봤는데\n지방 공연도 많아서 좋음\n부산 공연에서 봅시다', likes: 488, comments: 82, timeAgo: '7h' },
+);
+
+ARTIST_POSTS.push(
+  // Kagerō
+  { id: 201, artistId: 2, author: 'REI', body: 'Mirage、\n迷いながら書いた。\n聴いてくれてありがとう。', likes: '2.1K', comments: 482, time: '04. 18. 20:00' },
+  { id: 202, artistId: 2, author: 'REN', body: 'ドラム、\n指の皮が剥けた。\nでも楽しい。\n投ー、またね。', likes: '1.4K', comments: 212, time: '04. 14. 23:45' },
+  { id: 203, artistId: 2, author: 'REI', body: '투어 시작 전\n팬 여러분에게 한 마디\n"너무 긴장하지 말고, 우리도 즐길게요"', likes: '1.8K', comments: 344, time: '04. 10. 18:22' },
+
+  // NOIR7
+  { id: 301, artistId: 3, author: 'KAI', body: 'ENCORE 준비 중...\n이번엔 진짜 다를 거야\n세븐츠 기대해도 좋아 💜', likes: '5.2K', comments: 892, time: '04. 19. 21:30' },
+  { id: 302, artistId: 3, author: 'JUNO', body: '연습실. 오늘도 늦게까지.\n데뷔 1500일이 지났지만\n여전히 처음처럼 떨린다.', likes: '4.8K', comments: 712, time: '04. 17. 22:40' },
+  { id: 303, artistId: 3, author: 'KAI', body: 'OUR WISH 컨셉포토\n다들 마음에 들었어?\n나는 이번 분위기가 제일 좋아.', likes: '6.1K', comments: 1024, time: '04. 14. 18:00' },
+  { id: 304, artistId: 3, author: 'HARU', body: '팬미팅 영상 다시 돌려봤어\n진짜 너무 소중한 시간이었다\n또 만들자 우리', likes: '3.9K', comments: 588, time: '04. 10. 20:15' },
+
+  // hanabi*
+  { id: 401, artistId: 4, author: 'hanabi*', body: 'FIREWORKS 프리오더 시작했어요!\n처음 해보는 2nd mini인데\n진짜 한 곡 한 곡 애정 담아 만들었어요\n한정반 꼭 보세요 🎆', likes: '1.8K', comments: 412, time: '04. 20. 19:00' },
+  { id: 402, artistId: 4, author: 'hanabi*', body: '오늘은 커버곡 녹음!\n힌트는... 여름! 밤! 불꽃!\n뭐일까요~?', likes: '1.2K', comments: 288, time: '04. 14. 21:30' },
+
+  // Velvet Static
+  { id: 501, artistId: 5, author: 'SEUNG', body: 'Ashlight EP 나왔습니다\n6곡 전부 다 직접 쓰고 녹음했어요\n꼭 헤드폰으로 들어주세요', likes: '512', comments: 88, time: '04. 16. 20:00' },
+  { id: 502, artistId: 5, author: 'DRUMMER_Jin', body: '롤링홀 공연 연습 중\n스틱 2개 부러짐\n그만큼 열심히 하고 있다는 뜻', likes: '288', comments: 44, time: '04. 12. 23:10' },
+
+  // ORBITAL
+  { id: 601, artistId: 6, author: 'LOW-G', body: 'GRAVITY 트랙리스트 공개\n이번 앨범은 진짜 모든 걸 쏟았다\n크루 전원 피 땀 눈물\n4월 26일 기다려라', likes: '3.4K', comments: 688, time: '04. 19. 22:00' },
+  { id: 602, artistId: 6, author: 'COSM', body: 'CYPHER 녹음하면서\n오랜만에 진짜 재밌었다\n다음 콜라보도 곧 나올 거니까\n기대해', likes: '2.8K', comments: 512, time: '04. 13. 20:30' },
+  { id: 603, artistId: 6, author: 'LOW-G', body: 'NO CEILING 투어\n작은 무대라도 전국 다 간다\n한 놈도 빠짐없이 만나러 간다', likes: '2.2K', comments: 412, time: '04. 01. 19:00' },
+);
+
+Object.assign(window, {
+  NOTICES, FAN_LETTERS, HIGHLIGHTS, LIVE_REPLAYS, MEDIA_EXTENDED,
+  JELLY_PACKS, HERO_SLIDES, ON_LIVE_NOW, FAN_POSTS, ARTIST_POSTS,
+});

--- a/src/main/resources/static/components/desktop-dm.jsx
+++ b/src/main/resources/static/components/desktop-dm.jsx
@@ -1,0 +1,507 @@
+// Connectfin — Desktop DM screen (3-column layout)
+// Layout: Thread list (left) · Active conversation (right)
+
+function DesktopDMScreen({ t, theme, onExit }) {
+  const [activeId, setActiveId] = React.useState(DM_THREADS[0]?.id || 1);
+  const [filter, setFilter] = React.useState('all'); // all | unread | subscribed
+
+  const activeThread = DM_THREADS.find(x => x.id === activeId) || DM_THREADS[0];
+  const activeArtist = ARTISTS.find(a => a.id === activeThread.artistId);
+
+  const filtered = DM_THREADS.filter(th => {
+    if (filter === 'unread') return (th.unread || 0) > 0;
+    if (filter === 'subscribed') return th.subscribed;
+    return true;
+  });
+
+  const dark = theme === 'dark';
+  const sidebarBg = dark ? '#0E1019' : '#FAFAFA';
+  const threadBg = dark ? 'rgba(20,22,36,0.55)' : '#fff';
+
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '340px 1fr',
+      height: 'calc(100vh - 56px)', color: t.text,
+    }}>
+      {/* ── Left: Thread list ── */}
+      <div style={{
+        borderRight: `1px solid ${t.line}`, background: sidebarBg,
+        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      }}>
+        <div style={{ padding: '20px 20px 14px', borderBottom: `1px solid ${t.line}` }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+            <div>
+              <div style={{ fontFamily: t.fontMono, fontSize: 10, letterSpacing: 1.2, color: t.textDim }}>DIRECT MESSAGE</div>
+              <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, letterSpacing: -0.3 }}>대화</div>
+            </div>
+            <button title="새 메시지" style={{
+              width: 34, height: 34, borderRadius: '50%', border: `1px solid ${t.line}`,
+              background: 'transparent', color: t.text, cursor: 'pointer',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+            }}>✎</button>
+          </div>
+
+          {/* Search */}
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 8, padding: '8px 14px',
+            borderRadius: 20, background: dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)',
+            border: `1px solid ${t.line}`,
+          }}>
+            <span style={{ color: t.textDim, fontSize: 13 }}>⌕</span>
+            <input placeholder="아티스트 검색" style={{
+              flex: 1, border: 'none', background: 'transparent', color: t.text,
+              fontSize: 13, outline: 'none',
+            }}/>
+          </div>
+
+          {/* Filters */}
+          <div style={{ display: 'flex', gap: 6, marginTop: 12 }}>
+            {[['all','전체'], ['unread','안 읽음'], ['subscribed','구독중']].map(([k, l]) => (
+              <button key={k} onClick={() => setFilter(k)} style={{
+                padding: '5px 12px', borderRadius: 14, border: 'none', cursor: 'pointer',
+                background: filter === k ? t.chip : 'transparent',
+                color: filter === k ? t.accent : t.textDim,
+                fontWeight: 700, fontSize: 11, fontFamily: t.fontMono, letterSpacing: 0.3,
+              }}>{l}</button>
+            ))}
+          </div>
+        </div>
+
+        {/* Thread list */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {filtered.length === 0 && (
+            <div style={{ padding: '40px 20px', textAlign: 'center', color: t.textDim, fontSize: 13 }}>
+              필터에 해당하는 대화가 없어요
+            </div>
+          )}
+          {filtered.map(th => {
+            const a = ARTISTS.find(x => x.id === th.artistId);
+            const active = th.id === activeId;
+            return (
+              <div key={th.id} onClick={() => setActiveId(th.id)} style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '14px 18px', cursor: 'pointer',
+                background: active ? (dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)') : 'transparent',
+                borderLeft: active ? `3px solid ${t.accent}` : '3px solid transparent',
+                borderBottom: `1px solid ${t.line}`,
+                transition: 'background 140ms',
+              }}
+                onMouseEnter={e => { if (!active) e.currentTarget.style.background = dark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)'; }}
+                onMouseLeave={e => { if (!active) e.currentTarget.style.background = 'transparent'; }}
+              >
+                <div style={{ position: 'relative', flexShrink: 0 }}>
+                  <div style={{
+                    width: 46, height: 46, borderRadius: '50%',
+                    background: `linear-gradient(135deg, ${a?.color1 || '#888'}, ${a?.color2 || '#444'})`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#fff', fontWeight: 800, fontSize: 14,
+                  }}>{a?.name?.slice(0, 2) || '??'}</div>
+                  {th.online && (
+                    <div style={{
+                      position: 'absolute', bottom: -1, right: -1,
+                      width: 12, height: 12, borderRadius: '50%',
+                      background: '#22C55E', border: `2.5px solid ${sidebarBg}`,
+                    }}/>
+                  )}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+                      <span style={{ fontWeight: 700, fontSize: 14, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {th.name}
+                      </span>
+                      {th.subscribed && <span style={{ fontSize: 10, color: t.accent2, flexShrink: 0 }}>✓</span>}
+                    </div>
+                    <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono, flexShrink: 0 }}>
+                      {th.time}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3 }}>
+                    <div style={{
+                      flex: 1, fontSize: 12, color: (th.unread || 0) > 0 ? t.text : t.textDim,
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      fontWeight: (th.unread || 0) > 0 ? 600 : 400,
+                    }}>
+                      {th.last}
+                    </div>
+                    {(th.unread || 0) > 0 && (
+                      <div style={{
+                        minWidth: 18, height: 18, borderRadius: 9,
+                        background: t.hot, color: '#fff',
+                        fontSize: 10, fontWeight: 800, padding: '0 5px',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      }}>{th.unread}</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{
+          padding: '12px 18px', borderTop: `1px solid ${t.line}`,
+          fontSize: 10, color: t.textDim, fontFamily: t.fontMono, letterSpacing: 0.3,
+        }}>
+          GET /dm/threads?cursor= · {DM_THREADS.length} threads cached
+        </div>
+      </div>
+
+      {/* ── Right: Active conversation ── */}
+      <DMConversationPanel
+        key={activeThread.id}
+        thread={activeThread} artist={activeArtist}
+        t={t} theme={theme}
+      />
+    </div>
+  );
+}
+
+function DMConversationPanel({ thread, artist, t, theme }) {
+  const dark = theme === 'dark';
+  const [messages, setMessages] = React.useState(() => INITIAL_DM_MESSAGES(thread, artist));
+  const [input, setInput] = React.useState('');
+  const [remaining, setRemaining] = React.useState(2);
+  const [showInfo, setShowInfo] = React.useState(false);
+  const nextId = React.useRef(100);
+  const listRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+  }, [messages]);
+
+  const send = () => {
+    if (!input.trim() || remaining <= 0) return;
+    setMessages(m => [...m, { id: nextId.current++, from: 'me', m: input, time: '방금' }]);
+    setInput('');
+    setRemaining(r => r - 1);
+  };
+
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: showInfo ? '1fr 320px' : '1fr',
+      background: dark ? '#080912' : '#F5F5F7',
+      overflow: 'hidden',
+    }}>
+      <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* Header */}
+        <div style={{
+          padding: '14px 24px', borderBottom: `1px solid ${t.line}`,
+          display: 'flex', alignItems: 'center', gap: 14,
+          background: dark ? 'rgba(14,16,25,0.7)' : '#fff',
+          backdropFilter: 'blur(20px)',
+        }}>
+          <div style={{ position: 'relative' }}>
+            <div style={{
+              width: 44, height: 44, borderRadius: '50%',
+              background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#fff', fontWeight: 800, fontSize: 13,
+            }}>{artist.name.slice(0, 2)}</div>
+            {thread.online && (
+              <div style={{
+                position: 'absolute', bottom: -1, right: -1,
+                width: 12, height: 12, borderRadius: '50%',
+                background: '#22C55E', border: `2.5px solid ${dark ? '#0E1019' : '#fff'}`,
+              }}/>
+            )}
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontWeight: 800, fontSize: 17, letterSpacing: -0.2 }}>{artist.name}</span>
+              <span style={{
+                fontSize: 9, fontWeight: 800, padding: '3px 7px', borderRadius: 4,
+                background: t.gradient, color: '#fff', letterSpacing: 0.5,
+              }}>ARTIST ✓</span>
+            </div>
+            <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+              {thread.online ? '● 온라인' : '마지막 접속 3시간 전'} · @{artist.name.toLowerCase()}
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <HeaderIconBtn t={t} title="검색">⌕</HeaderIconBtn>
+            <HeaderIconBtn t={t} title="음소거">🔕</HeaderIconBtn>
+            <HeaderIconBtn t={t} title="상세 정보" active={showInfo} onClick={() => setShowInfo(v => !v)}>ⓘ</HeaderIconBtn>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div ref={listRef} style={{
+          flex: 1, overflowY: 'auto',
+          padding: '24px 32px',
+          display: 'flex', flexDirection: 'column', gap: 10,
+        }}>
+          <div style={{
+            alignSelf: 'center', padding: '6px 14px', borderRadius: 14,
+            background: dark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)',
+            fontSize: 11, color: t.textDim, fontFamily: t.fontMono, letterSpacing: 0.3,
+            marginBottom: 8,
+          }}>🔒 1:1 암호화된 채널 · {thread.time}</div>
+
+          {messages.map((msg, i) => {
+            const isMe = msg.from === 'me';
+            const prev = messages[i - 1];
+            const grouped = prev && prev.from === msg.from;
+            return (
+              <div key={msg.id} style={{
+                display: 'flex', flexDirection: isMe ? 'row-reverse' : 'row',
+                alignItems: 'flex-end', gap: 10, marginTop: grouped ? 0 : 8,
+              }}>
+                {!isMe && (
+                  <div style={{
+                    width: 32, height: 32, borderRadius: '50%', flexShrink: 0,
+                    background: grouped ? 'transparent' : `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#fff', fontWeight: 800, fontSize: 10,
+                  }}>{!grouped && artist.name.slice(0, 2)}</div>
+                )}
+                <div style={{
+                  maxWidth: '58%',
+                  display: 'flex', flexDirection: 'column',
+                  alignItems: isMe ? 'flex-end' : 'flex-start',
+                }}>
+                  {!grouped && !isMe && (
+                    <div style={{ fontSize: 11, fontWeight: 700, color: t.textDim, marginBottom: 4, marginLeft: 2 }}>
+                      {artist.name}
+                    </div>
+                  )}
+                  <div style={{
+                    padding: '11px 16px',
+                    borderRadius: isMe ? '18px 18px 4px 18px' : '18px 18px 18px 4px',
+                    background: isMe
+                      ? t.gradient
+                      : (dark ? '#1A1D2A' : '#fff'),
+                    color: isMe ? '#fff' : t.text,
+                    fontSize: 14, lineHeight: 1.5,
+                    border: !isMe && !dark ? `1px solid ${t.line}` : 'none',
+                    boxShadow: !isMe && dark ? 'inset 0 0 0 1px rgba(255,255,255,0.06)' : 'none',
+                    wordBreak: 'break-word',
+                  }}>
+                    {msg.m}
+                  </div>
+                  <span style={{
+                    fontSize: 10, color: t.textMuted, fontFamily: t.fontMono,
+                    marginTop: 3, padding: '0 4px',
+                  }}>
+                    {msg.time}{isMe && ' · 읽음'}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Rate-limit hint */}
+        <div style={{
+          padding: '8px 24px',
+          background: remaining <= 1 ? (dark ? 'rgba(255,100,100,0.08)' : 'rgba(255,80,80,0.05)') : 'transparent',
+          borderTop: `1px solid ${t.line}`,
+          fontSize: 11, color: t.textDim, fontFamily: t.fontMono,
+          display: 'flex', alignItems: 'center', gap: 10,
+        }}>
+          <span style={{ color: remaining <= 1 ? t.hot : t.textDim }}>ⓘ</span>
+          <span>아티스트 답장 전 최대 3개까지 · 남은 횟수 <b style={{ color: remaining > 0 ? t.accent : t.hot }}>{remaining}</b>개</span>
+          <span style={{ marginLeft: 'auto', letterSpacing: 0.3 }}>
+            POST /dm/threads/{thread.id}/messages
+          </span>
+        </div>
+
+        {/* Composer */}
+        <div style={{
+          padding: '14px 24px 20px',
+          background: dark ? 'rgba(14,16,25,0.7)' : '#fff',
+          borderTop: `1px solid ${t.line}`,
+        }}>
+          <div style={{
+            display: 'flex', gap: 10, alignItems: 'flex-end',
+            padding: '8px 14px', borderRadius: 18,
+            border: `1px solid ${t.line}`,
+            background: dark ? 'rgba(255,255,255,0.04)' : '#F7F7FA',
+          }}>
+            <button style={composerBtn(t)} title="이모지">☺</button>
+            <button style={composerBtn(t)} title="이미지">🖼</button>
+            <button style={composerBtn(t)} title="스티커">🏷</button>
+            <textarea
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+              }}
+              disabled={remaining <= 0}
+              placeholder={remaining <= 0 ? '메시지 제한에 도달했어요' : `${artist.name}에게 메시지… (Enter로 전송, Shift+Enter 줄바꿈)`}
+              rows={1}
+              style={{
+                flex: 1, border: 'none', background: 'transparent', color: t.text,
+                fontSize: 14, outline: 'none', resize: 'none',
+                padding: '8px 4px', minHeight: 22, maxHeight: 120,
+                fontFamily: t.font,
+              }}
+            />
+            <button onClick={send} disabled={remaining <= 0 || !input.trim()} style={{
+              padding: '8px 18px', borderRadius: 12, border: 'none',
+              background: (remaining > 0 && input.trim()) ? t.gradient : (dark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'),
+              color: (remaining > 0 && input.trim()) ? '#fff' : t.textDim,
+              fontWeight: 800, fontSize: 13, cursor: (remaining > 0 && input.trim()) ? 'pointer' : 'not-allowed',
+              fontFamily: t.fontMono, letterSpacing: 0.5,
+            }}>SEND</button>
+          </div>
+        </div>
+      </div>
+
+      {/* Info sidebar */}
+      {showInfo && <DMInfoPanel thread={thread} artist={artist} t={t} theme={theme}/>}
+    </div>
+  );
+}
+
+function DMInfoPanel({ thread, artist, t, theme }) {
+  const dark = theme === 'dark';
+  return (
+    <div style={{
+      borderLeft: `1px solid ${t.line}`,
+      background: dark ? '#0E1019' : '#FAFAFA',
+      overflowY: 'auto', padding: 24,
+    }}>
+      <div style={{ textAlign: 'center', marginBottom: 20 }}>
+        <div style={{
+          width: 96, height: 96, borderRadius: '50%',
+          background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontWeight: 800, fontSize: 28, margin: '0 auto 12px',
+        }}>{artist.name.slice(0, 2)}</div>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, letterSpacing: -0.3 }}>{artist.name}</div>
+        <div style={{ fontSize: 12, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>{artist.genre}</div>
+      </div>
+
+      <div style={{
+        padding: 14, borderRadius: 12, marginBottom: 14,
+        border: `1px solid ${t.line}`,
+        background: dark ? 'rgba(20,22,36,0.55)' : '#fff',
+      }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1, color: t.textDim, fontFamily: t.fontMono, marginBottom: 8 }}>
+          SUBSCRIPTION
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 13 }}>
+          <span>DM Pass</span>
+          <span style={{ fontWeight: 700, color: t.accent }}>15일 남음</span>
+        </div>
+        <div style={{
+          marginTop: 10, height: 5, borderRadius: 3,
+          background: dark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+          overflow: 'hidden',
+        }}>
+          <div style={{ width: '50%', height: '100%', background: t.gradient }}/>
+        </div>
+        <button style={{
+          width: '100%', marginTop: 12, padding: '9px 0', borderRadius: 8, border: 'none',
+          background: t.chip, color: t.accent, fontWeight: 800, fontSize: 12, cursor: 'pointer',
+          fontFamily: t.fontMono, letterSpacing: 0.5,
+        }}>연장하기 · ₩9,900/월</button>
+      </div>
+
+      <InfoRow t={t} label="DM 시작일">2026.01.12</InfoRow>
+      <InfoRow t={t} label="총 주고받은 메시지">42</InfoRow>
+      <InfoRow t={t} label="이번 달 보낸 메시지">7 / 30</InfoRow>
+      <InfoRow t={t} label="알림">켜짐</InfoRow>
+      <InfoRow t={t} label="번역">자동 (ko ↔ jp)</InfoRow>
+
+      <div style={{ marginTop: 24 }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1, color: t.textDim, fontFamily: t.fontMono, marginBottom: 10 }}>
+          공유된 미디어
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 6 }}>
+          {[0,1,2,3,4,5].map(i => (
+            <div key={i} style={{
+              aspectRatio: '1', borderRadius: 6,
+              background: `linear-gradient(${i * 60}deg, ${artist.color1}, ${artist.color2})`,
+              opacity: 0.7,
+            }}/>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 24, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <button style={infoActionBtn(t, theme)}>🔕 알림 끄기</button>
+        <button style={infoActionBtn(t, theme)}>🚫 신고 & 차단</button>
+      </div>
+    </div>
+  );
+}
+
+function InfoRow({ t, label, children }) {
+  return (
+    <div style={{
+      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      padding: '10px 0', fontSize: 13, borderBottom: `1px solid ${t.line}`,
+    }}>
+      <span style={{ color: t.textDim }}>{label}</span>
+      <span style={{ color: t.text, fontWeight: 600 }}>{children}</span>
+    </div>
+  );
+}
+
+function HeaderIconBtn({ t, children, onClick, active, title }) {
+  const [h, setH] = React.useState(false);
+  return (
+    <button onClick={onClick} title={title}
+      onMouseEnter={() => setH(true)} onMouseLeave={() => setH(false)}
+      style={{
+        width: 38, height: 38, borderRadius: 10, border: 'none', cursor: 'pointer',
+        background: active ? t.chip : (h ? 'rgba(128,128,128,0.1)' : 'transparent'),
+        color: active ? t.accent : t.text,
+        fontSize: 16,
+      }}>{children}</button>
+  );
+}
+
+function composerBtn(t) {
+  return {
+    width: 34, height: 34, borderRadius: 8, border: 'none', cursor: 'pointer',
+    background: 'transparent', color: t.textDim,
+    fontSize: 16, display: 'flex', alignItems: 'center', justifyContent: 'center',
+  };
+}
+
+function infoActionBtn(t, theme) {
+  return {
+    padding: '10px 14px', borderRadius: 8, border: `1px solid ${t.line}`,
+    background: 'transparent', color: t.text, cursor: 'pointer',
+    fontSize: 12, fontWeight: 600, textAlign: 'left',
+    fontFamily: t.font,
+  };
+}
+
+function INITIAL_DM_MESSAGES(thread, artist) {
+  const base = {
+    1: [ // YUNA / LUMEN8
+      { id: 1, from: 'artist', m: '안녕! 오늘 하루도 수고 많았지 🫶', time: '어제 20:14' },
+      { id: 2, from: 'artist', m: '요즘 어떻게 지내?', time: '어제 20:14' },
+      { id: 3, from: 'me', m: '언니 저 오늘 시험 끝났어요!!! 진짜 살 거 같아요 😭', time: '어제 20:16' },
+      { id: 4, from: 'artist', m: '오~ 수고했어!! 이제 좀 쉬어', time: '어제 20:17' },
+      { id: 5, from: 'artist', m: '근데 우리 내일 라이브 있는데 올 수 있어?', time: '어제 20:17' },
+      { id: 6, from: 'me', m: '당연하죠!! 매일 챙겨봐요 🙌', time: '어제 20:18' },
+      { id: 7, from: 'artist', m: '오늘도 고마워 ⭐️', time: '방금' },
+    ],
+    2: [ // hanabi*
+      { id: 1, from: 'artist', m: 'やっほー！', time: '10분 전' },
+      { id: 2, from: 'artist', m: '새 앨범 프리오더 들어봤어?!', time: '3분 전' },
+      { id: 3, from: 'me', m: '하나비 짱!! 당연히 들었어요 🎆', time: '방금' },
+    ],
+    3: [ // Kagerō
+      { id: 1, from: 'artist', m: 'Mirage、\n聴いてくれてありがとう。', time: '1시간 전' },
+      { id: 2, from: 'me', m: '이번 앨범 최고예요 진짜', time: '1시간 전' },
+    ],
+    4: [ // NOIR7 KAI
+      { id: 1, from: 'artist', m: '앙코르 콘서트 곧이야 !! 준비 중이야', time: '2시간 전' },
+      { id: 2, from: 'artist', m: '이번엔 특별한 거 준비했어 😏', time: '2시간 전' },
+      { id: 3, from: 'me', m: '세븐츠 기대 만발이에요 💜', time: '1시간 전' },
+      { id: 4, from: 'artist', m: '현장에서 보자!', time: '30분 전' },
+    ],
+  };
+  return base[thread.id] || [
+    { id: 1, from: 'artist', m: `안녕 ${thread.name}입니다! 메시지 고마워요 🙌`, time: '방금' },
+  ];
+}
+
+Object.assign(window, { DesktopDMScreen });

--- a/src/main/resources/static/components/desktop-global.jsx
+++ b/src/main/resources/static/components/desktop-global.jsx
@@ -1,0 +1,390 @@
+// Connectfin — Desktop global screens: Home, Jelly Shop, Shop
+
+// ──────────────── Home ────────────────
+function DesktopHome({ t, theme, onArtistOpen, onOpenLive, onNavGlobal }) {
+  const [slideIdx, setSlideIdx] = React.useState(0);
+  React.useEffect(() => {
+    const id = setInterval(() => setSlideIdx(i => (i + 1) % HERO_SLIDES.length), 4500);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div style={{ maxWidth: 1200, margin: '0 auto', padding: '24px 24px 60px' }}>
+      {/* Hero carousel (2-up) */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 14 }}>
+        {HERO_SLIDES.slice(0, 2).map(s => <HeroCard key={s.id} slide={s} t={t}/>)}
+      </div>
+
+      {/* Pagination dots */}
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 6, marginBottom: 24 }}>
+        {HERO_SLIDES.map((_, i) => (
+          <div key={i} style={{
+            width: i === slideIdx ? 18 : 6, height: 6, borderRadius: 3,
+            background: i === slideIdx ? t.text : t.textMuted, transition: 'all 200ms',
+          }}/>
+        ))}
+      </div>
+
+      {/* Find artists bar */}
+      <div style={{
+        padding: '14px 20px', borderRadius: 12, border: `1px solid ${t.line}`,
+        background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+        display: 'flex', alignItems: 'center', gap: 14, marginBottom: 20, cursor: 'pointer',
+      }}>
+        <div style={{
+          width: 48, height: 48, borderRadius: '50%',
+          background: theme === 'dark' ? '#0A0B10' : '#F3DEFF',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 22, color: t.textDim,
+        }}>+</div>
+        <span style={{ fontSize: 14, color: t.textDim }}>내가 좋아하는 아티스트를 찾아보세요!</span>
+      </div>
+
+      {/* On LIVE */}
+      <div style={{
+        padding: 20, borderRadius: 12, border: `1px solid ${t.line}`,
+        background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface, marginBottom: 20,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>On LIVE</div>
+          <div style={{
+            padding: '1px 8px', borderRadius: 10, background: t.hot,
+            color: '#fff', fontSize: 11, fontWeight: 800,
+          }}>{ON_LIVE_NOW.length}</div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 14 }}>
+          {ON_LIVE_NOW.map(live => {
+            const a = ARTISTS.find(x => x.id === live.artistId);
+            return <OnLiveCard key={live.id} live={live} artist={a} t={t} onOpen={() => onOpenLive(live.artistId)}/>;
+          })}
+        </div>
+      </div>
+
+      {/* DM pool */}
+      <div style={{
+        padding: 20, borderRadius: 12, border: `1px solid ${t.line}`,
+        background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>아티스트와 DM을 나눠 보세요!</div>
+          <span style={{ fontSize: 12, color: t.textDim, cursor: 'pointer' }}>↻</span>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 10 }}>
+          {ARTISTS.slice(0, 6).map(a => (
+            <div key={a.id} onClick={() => onArtistOpen(a.id)} style={{
+              padding: '10px 12px', borderRadius: 24, border: `1px solid ${t.line}`,
+              display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer',
+              background: theme === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.7)',
+            }}>
+              <ArtistAvatar artist={a} size={28} t={t}/>
+              <span style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{a.name}</span>
+            </div>
+          ))}
+          <div style={{
+            padding: '10px 12px', borderRadius: 24, border: `1px solid ${t.line}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, cursor: 'pointer',
+            fontSize: 12, color: t.textDim, fontFamily: t.fontMono,
+          }}>전체보기 →</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HeroCard({ slide, t }) {
+  return (
+    <div style={{
+      aspectRatio: '16/9', borderRadius: 14, overflow: 'hidden', position: 'relative',
+      background: `linear-gradient(135deg, ${slide.color1}, ${slide.color2})`,
+      cursor: 'pointer',
+    }}>
+      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(45deg, rgba(0,0,0,0.15) 0%, transparent 60%)' }}/>
+      <div style={{
+        position: 'absolute', top: 20, left: 20, color: slide.textDark ? '#111' : '#fff',
+      }}>
+        <div style={{ fontFamily: t.fontMono, fontSize: 10, fontWeight: 800, letterSpacing: 1, opacity: 0.85, marginBottom: 4 }}>{slide.artist}</div>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 26, fontWeight: 900, letterSpacing: -0.8, lineHeight: 1.1, whiteSpace: 'pre-line' }}>{slide.title}</div>
+        <div style={{ fontSize: 12, marginTop: 8, opacity: 0.8 }}>{slide.body}</div>
+      </div>
+      <div style={{
+        position: 'absolute', bottom: -20, right: -20, width: 140, height: 140, borderRadius: 24,
+        background: slide.textDark ? 'rgba(255,255,255,0.4)' : 'rgba(255,255,255,0.15)',
+        transform: 'rotate(12deg)',
+      }}/>
+      <div style={{
+        position: 'absolute', bottom: 30, right: 30,
+        fontFamily: 'ui-monospace, monospace', fontSize: 9, color: slide.textDark ? '#111' : '#fff',
+        opacity: 0.6, letterSpacing: 0.5,
+      }}>[{slide.kind}]</div>
+    </div>
+  );
+}
+
+function OnLiveCard({ live, artist, t, onOpen }) {
+  return (
+    <div onClick={onOpen} style={{ cursor: 'pointer' }}>
+      <div style={{
+        position: 'relative', aspectRatio: '16/10', borderRadius: 10, overflow: 'hidden',
+        background: live.kind === 'voice'
+          ? `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`
+          : `repeating-linear-gradient(45deg, ${artist.color1} 0 22px, ${artist.color2} 22px 44px)`,
+      }}>
+        <div style={{
+          position: 'absolute', top: 10, left: 10, padding: '3px 8px', borderRadius: 5,
+          background: live.status === 'LIVE' ? t.hot : t.accent,
+          color: '#fff', fontSize: 10, fontWeight: 800, display: 'flex', alignItems: 'center', gap: 4,
+        }}>
+          {live.status === 'LIVE' && <span style={{ width: 5, height: 5, borderRadius: '50%', background: '#fff' }}/>}
+          {live.status}
+        </div>
+        {live.kind === 'voice' && (
+          <div style={{
+            position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: 'rgba(255,255,255,0.9)', fontSize: 32,
+          }}>{live.group}</div>
+        )}
+      </div>
+      <div style={{ marginTop: 10, fontWeight: 700, fontSize: 14 }}>{live.title}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4, fontSize: 11, color: t.textDim }}>
+        <ArtistAvatar artist={artist} size={16} t={t}/>
+        {live.host}
+        <span>·</span>
+        <span>{live.group}</span>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────── Jelly Shop ────────────────
+function DesktopJellyShop({ t, theme }) {
+  const [tab, setTab] = React.useState('general');
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '260px 1fr', maxWidth: 1200, margin: '0 auto', padding: '24px 24px 60px', gap: 32 }}>
+      {/* Left summary */}
+      <div>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, letterSpacing: -0.4, marginBottom: 20 }}>Jelly Shop</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+          <span style={{ fontSize: 24 }}>🍮</span>
+          <span style={{ fontSize: 14, color: t.textDim }}>My Jelly</span>
+        </div>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 48, fontWeight: 800, letterSpacing: -1, marginBottom: 28 }}>142</div>
+
+        {[
+          { label: '충전젤리', value: '120' },
+          { label: '적립젤리', value: '22' },
+        ].map(row => (
+          <div key={row.label} style={{
+            display: 'flex', justifyContent: 'space-between', padding: '12px 0',
+            borderBottom: `1px solid ${t.line}`, fontSize: 13,
+          }}>
+            <span style={{ color: t.textDim }}>{row.label}</span>
+            <span style={{ fontWeight: 700 }}>{row.value}</span>
+          </div>
+        ))}
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 0' }}>
+          <span style={{ color: t.textDim, fontSize: 13 }}>충전한도</span>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontFamily: t.fontDisplay, fontSize: 20, fontWeight: 800 }}>1,500</div>
+            <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono }}>최대 1,500</div>
+          </div>
+        </div>
+
+        <div style={{
+          marginTop: 40, paddingTop: 20, borderTop: `1px solid ${t.line}`,
+          fontFamily: t.fontMono, fontSize: 10, color: t.textMuted, letterSpacing: 0.5,
+        }}>
+          CONNECTFIN
+          <div style={{ fontSize: 9, marginTop: 2 }}>© 2026 Connectfin Inc.</div>
+        </div>
+      </div>
+
+      {/* Right content */}
+      <div>
+        <div style={{ display: 'flex', gap: 24, borderBottom: `1px solid ${t.line}`, marginBottom: 24 }}>
+          {[
+            { k: 'intro', label: '소개' },
+            { k: 'general', label: '일반 충전' },
+            { k: 'auto', label: '자동 충전' },
+            { k: 'history', label: '조회' },
+            { k: 'faq', label: 'FAQ' },
+          ].map(x => (
+            <button key={x.k} onClick={() => setTab(x.k)} style={{
+              padding: '12px 0', background: 'transparent', border: 'none',
+              borderBottom: tab === x.k ? `2px solid ${t.text}` : '2px solid transparent',
+              color: tab === x.k ? t.text : t.textDim,
+              fontWeight: tab === x.k ? 800 : 500, fontSize: 14, cursor: 'pointer', fontFamily: t.font,
+            }}>{x.label}</button>
+          ))}
+        </div>
+
+        {tab === 'general' && <JellyGeneralRecharge t={t} theme={theme}/>}
+        {tab === 'auto' && <JellyAutoRecharge t={t} theme={theme}/>}
+        {tab === 'intro' && <JellyIntro t={t}/>}
+        {tab === 'history' && <JellyHistory t={t}/>}
+        {tab === 'faq' && <JellyFAQ t={t}/>}
+      </div>
+    </div>
+  );
+}
+
+function JellyGeneralRecharge({ t, theme }) {
+  return (
+    <div>
+      <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginBottom: 20 }}>일반 충전</div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {JELLY_PACKS.map(p => (
+          <div key={p.jelly} style={{
+            padding: '14px 20px', border: p.best ? `1.5px solid ${t.ok}` : `1px solid ${t.line}`, borderRadius: 10,
+            background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+            display: 'flex', alignItems: 'center', gap: 16, cursor: 'pointer', position: 'relative',
+          }}>
+            {p.best && (
+              <div style={{
+                position: 'absolute', top: -10, left: 20, padding: '3px 10px', borderRadius: 10,
+                background: t.ok, color: theme === 'dark' ? '#071014' : '#fff',
+                fontSize: 11, fontWeight: 800,
+              }}>👍 Best Offer</div>
+            )}
+            <div style={{
+              width: 40, height: 40, borderRadius: '50%',
+              background: p.jelly >= 160 ? '#FFC857' : p.jelly >= 60 ? '#22D3EE' : '#FBBF24',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 20,
+            }}>🍮</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: t.fontDisplay, fontSize: 18, fontWeight: 800 }}>젤리 {p.jelly}</div>
+              {p.bonus > 0 && (
+                <div style={{ fontSize: 11, color: t.textDim }}>
+                  적립젤리 <span style={{ color: t.accent2, fontWeight: 800 }}>{p.bonus}</span>
+                </div>
+              )}
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: 14, fontWeight: 700 }}>{p.price}</div>
+              {p.benefit && (
+                <div style={{
+                  marginTop: 4, display: 'inline-block', padding: '2px 6px', borderRadius: 4,
+                  background: t.chip, color: t.hot, fontSize: 10, fontWeight: 800,
+                }}>{p.benefit}</div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 20, fontSize: 11, color: t.textDim, lineHeight: 1.6, fontFamily: t.fontMono }}>
+        · 젤리는 Connectfin 서비스 내에서 사용 가능한 결제수단입니다.<br/>
+        · 충전젤리는 환불이 가능하나, 적립젤리는 환불 대상이 아닙니다.<br/>
+        · GET /me/jelly · POST /jelly/recharge (idempotency-key 필수)
+      </div>
+    </div>
+  );
+}
+
+function JellyAutoRecharge({ t, theme }) {
+  return (
+    <div>
+      <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginBottom: 20 }}>자동 충전</div>
+      <button style={{
+        padding: '8px 16px', borderRadius: 18, border: `1px solid ${t.line}`,
+        background: 'transparent', color: t.text, fontSize: 12, fontWeight: 700, cursor: 'pointer', marginBottom: 14,
+        fontFamily: t.font,
+      }}>자동 결제 수단 관리</button>
+      <div style={{
+        padding: '20px', border: `1px dashed ${t.lineStrong}`, borderRadius: 12,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10,
+        color: t.textDim, cursor: 'pointer', fontSize: 13, marginBottom: 20,
+      }}>
+        <span style={{
+          width: 22, height: 22, borderRadius: '50%', background: t.ok,
+          color: theme === 'dark' ? '#071014' : '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 14, fontWeight: 800,
+        }}>+</span>
+        젤리 자동 결제 수단 추가
+      </div>
+      <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 10 }}>자동 결제 서비스 유의 사항</div>
+      <ul style={{ paddingLeft: 18, color: t.textDim, fontSize: 12, lineHeight: 1.8, margin: 0 }}>
+        <li>젤리 자동 결제 수단은 최대 5개까지 등록 가능하며, 유효한 결제 수단을 등록하여야 합니다.</li>
+        <li>젤리 자동 결제 수단은 젤리와 관련된 자동 결제 및 충전 서비스만을 지원합니다.</li>
+        <li>젤리 자동 결제 수단이 등록되지 않은 상태이거나, 등록한 젤리 자동 결제 수단으로 결제가 불가능한 경우 젤리 자동 결제 및 충전 서비스가 진행되지 않습니다.</li>
+        <li>Connectfin 계정 탈퇴 시, 등록한 자동 결제 수단은 즉시 비활성화됩니다.</li>
+      </ul>
+    </div>
+  );
+}
+
+function JellyIntro({ t }) {
+  return (
+    <div style={{ color: t.textDim, fontSize: 13, lineHeight: 1.7 }}>
+      🍮 <b style={{ color: t.text }}>Jelly</b>는 Connectfin 내에서 사용할 수 있는 가상 결제수단입니다.<br/><br/>
+      · 아티스트에게 팬레터를 보낼 때<br/>
+      · 멤버십 전용 컨텐츠를 결제할 때<br/>
+      · Raffle 응모 · DM 구독 갱신 등에 사용됩니다.<br/><br/>
+      <span style={{ fontFamily: t.fontMono, fontSize: 11 }}>
+        · 충전한도 월 1,500 / 1회 충전 최대 240<br/>
+        · 결제 이력은 "조회" 탭에서 확인할 수 있습니다.
+      </span>
+    </div>
+  );
+}
+
+function JellyHistory({ t }) {
+  return (
+    <div style={{ color: t.textDim, fontSize: 13 }}>
+      최근 90일 이내 거래 내역이 없습니다.
+      <div style={{ fontFamily: t.fontMono, fontSize: 11, marginTop: 16, opacity: 0.7 }}>
+        GET /me/jelly/ledger?cursor=...
+      </div>
+    </div>
+  );
+}
+
+function JellyFAQ({ t }) {
+  const items = [
+    { q: '젤리는 환불이 가능한가요?', a: '충전젤리는 환불이 가능하며, 적립젤리는 환불 대상이 아닙니다.' },
+    { q: '자동 충전은 어떻게 설정하나요?', a: '자동 충전 탭에서 결제 수단을 등록한 후 활성화할 수 있습니다.' },
+    { q: '결제 오류가 발생했어요.', a: '일시적인 네트워크 오류인 경우가 많습니다. 다시 시도해주세요.' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {items.map((it, i) => (
+        <div key={i} style={{ padding: 14, border: `1px solid ${t.line}`, borderRadius: 10 }}>
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>Q. {it.q}</div>
+          <div style={{ fontSize: 12, color: t.textDim }}>{it.a}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ──────────────── Shop (external stub) ────────────────
+function DesktopShop({ t, theme }) {
+  return (
+    <div style={{ maxWidth: 1200, margin: '0 auto', padding: '60px 24px', textAlign: 'center' }}>
+      <div style={{ fontSize: 64, marginBottom: 20 }}>🛍</div>
+      <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, marginBottom: 10 }}>Connectfin Shop</div>
+      <div style={{ color: t.textDim, fontSize: 14, marginBottom: 30 }}>
+        공식 MD 상품과 한정 아이템을 만나보세요
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16, textAlign: 'left' }}>
+        {ARTISTS.slice(0, 8).map(a => (
+          <div key={a.id} style={{
+            aspectRatio: '3/4', borderRadius: 12, overflow: 'hidden', position: 'relative',
+            background: `linear-gradient(135deg, ${a.color1}, ${a.color2})`,
+            cursor: 'pointer',
+          }}>
+            <div style={{ position: 'absolute', bottom: 14, left: 14, right: 14, color: '#fff' }}>
+              <div style={{ fontSize: 10, opacity: 0.8, letterSpacing: 1, fontFamily: t.fontMono }}>OFFICIAL MD</div>
+              <div style={{ fontWeight: 800, fontSize: 15, marginTop: 2 }}>{a.name}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  DesktopHome, DesktopJellyShop, DesktopShop,
+});

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -1,0 +1,563 @@
+// Connectfin — Desktop artist profile (8 tabs)
+
+// Artist cover hero (top banner with gradient)
+function ArtistCoverBanner({ artist, t, theme }) {
+  return (
+    <div style={{
+      height: 180, position: 'relative', overflow: 'hidden',
+      borderBottom: `1px solid ${t.line}`,
+      background: `repeating-linear-gradient(135deg, ${artist.color1} 0 40px, ${artist.color2} 40px 80px)`,
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'linear-gradient(180deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.45) 100%)',
+      }}/>
+      <div style={{
+        position: 'absolute', bottom: 16, left: 24, color: '#fff',
+      }}>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.5 }}>{artist.name}.</div>
+        <div style={{ fontSize: 12, opacity: 0.85, fontFamily: t.fontMono, letterSpacing: 0.3 }}>
+          가입하고 최신 소식을 받아보세요!
+        </div>
+      </div>
+      <button style={{
+        position: 'absolute', bottom: 20, right: 24,
+        padding: '8px 16px', borderRadius: 10, border: 'none',
+        background: '#fff', color: '#111', fontWeight: 800, fontSize: 13, cursor: 'pointer',
+      }}>가입하기</button>
+    </div>
+  );
+}
+
+// Main desktop profile router
+function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive, onOpenDM, onOpenMembership }) {
+  let body;
+  if (tab === 'highlight') body = <TabHighlight t={t} theme={theme} artist={artist} onNavProfile={onNavProfile}/>;
+  else if (tab === 'fan') body = <TabFan t={t} theme={theme} artist={artist}/>;
+  else if (tab === 'artist') body = <TabArtistPosts t={t} theme={theme} artist={artist}/>;
+  else if (tab === 'fanletter') body = <TabFanLetter t={t} theme={theme} artist={artist}/>;
+  else if (tab === 'media') body = <TabMedia t={t} theme={theme} artist={artist}/>;
+  else if (tab === 'live') body = <TabLive t={t} theme={theme} artist={artist} onOpenLive={onOpenLive}/>;
+  else if (tab === 'notice') body = <TabNotice t={t} theme={theme} artist={artist}/>;
+  else if (tab === 'shop') body = <TabShop t={t} theme={theme} artist={artist}/>;
+
+  return (
+    <div>
+      <ArtistCoverBanner artist={artist} t={t} theme={theme}/>
+      <div style={{ display: 'flex', maxWidth: 1320, margin: '0 auto', padding: '20px 24px 60px', gap: 24 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>{body}</div>
+        <DesktopRightSidebar t={t} theme={theme} artist={artist} onOpenDM={onOpenDM} onOpenMembership={onOpenMembership}/>
+      </div>
+    </div>
+  );
+}
+
+// ────────── HIGHLIGHT (summary) ──────────
+function TabHighlight({ t, theme, artist, onNavProfile }) {
+  const notices = NOTICES.filter(n => n.artistId === artist.id).slice(0, 5);
+  const artistPost = ARTIST_POSTS.find(p => p.artistId === artist.id);
+  const fanPosts = FAN_POSTS.filter(p => p.artistId === artist.id).slice(2, 8);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      {/* Notice preview */}
+      <Section t={t} theme={theme}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 14 }}>
+          <span style={{ fontSize: 16 }}>📢</span>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>Notice</div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {notices.map(n => (
+            <div key={n.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+              <span style={{ color: t.textDim }}>·</span>
+              <span style={{ flex: 1 }}>{n.title}</span>
+              {n.pinned && <span style={{ fontSize: 10, color: t.hot }}>📍</span>}
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* From artist */}
+      <Section t={t} theme={theme}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>From {artist.name}.</div>
+          <button onClick={() => onNavProfile('artist')} style={linkBtn(t)}>더 보기 →</button>
+        </div>
+        {artistPost && <ArtistPostCard post={artistPost} artist={artist} t={t} inline/>}
+      </Section>
+
+      {/* Fan posts grid */}
+      <Section t={t} theme={theme}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>Fan Posts</div>
+          <button onClick={() => onNavProfile('fan')} style={linkBtn(t)}>더 보기 →</button>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          {fanPosts.map(p => <FanPostMiniCard key={p.id} post={p} artist={artist} t={t}/>)}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+// ────────── FAN (팬 포스트 타임라인) ──────────
+function TabFan({ t, theme, artist }) {
+  const posts = FAN_POSTS.filter(p => p.artistId === artist.id);
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+        <Chip t={t} active>전체</Chip>
+        <Chip t={t}><span>🔥</span> Hot</Chip>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {posts.map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
+      </div>
+    </div>
+  );
+}
+
+// ────────── ARTIST (아티스트 포스트 타임라인) ──────────
+function TabArtistPosts({ t, theme, artist }) {
+  const posts = ARTIST_POSTS.filter(p => p.artistId === artist.id);
+  return (
+    <div>
+      {/* Moments (hero horizontal) */}
+      <Section t={t} theme={theme} style={{ marginBottom: 16 }}>
+        <div style={{ fontWeight: 800, fontSize: 15, marginBottom: 12 }}>Moments</div>
+        <div style={{ display: 'flex', gap: 10, overflowX: 'auto', paddingBottom: 4 }}>
+          {HIGHLIGHTS.filter(h => h.artistId === artist.id).slice(0, 6).map(h => (
+            <div key={h.id} style={{
+              flexShrink: 0, width: 120, height: 180, borderRadius: 14, overflow: 'hidden', position: 'relative',
+              background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+              cursor: 'pointer',
+            }}>
+              <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.6))' }}/>
+              <div style={{ position: 'absolute', bottom: 6, left: 8, color: '#fff', fontSize: 11, fontWeight: 700 }}>{artist.name}</div>
+              <div style={{ position: 'absolute', top: 6, left: 8, fontSize: 18 }}>{h.emoji}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {posts.map(p => <ArtistPostCard key={p.id} post={p} artist={artist} t={t}/>)}
+      </div>
+    </div>
+  );
+}
+
+// ────────── FAN LETTER (텍스처 카드 그리드) ──────────
+function TabFanLetter({ t, theme, artist }) {
+  const letters = FAN_LETTERS.filter(l => l.artistId === artist.id);
+  const [selected, setSelected] = React.useState(null);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+        <Chip t={t} active>전체</Chip>
+        <Chip t={t}><span>🔥</span> Hot</Chip>
+        <div style={{ flex: 1 }}/>
+        <Chip t={t}>🌐 한국어</Chip>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+        {letters.map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => setSelected(l)}/>)}
+      </div>
+
+      {selected && <FanLetterModal letter={selected} artist={artist} t={t} theme={theme} onClose={() => setSelected(null)}/>}
+    </div>
+  );
+}
+
+function FanLetterCard({ letter, artist, t, theme, onClick }) {
+  const dark = theme === 'dark';
+  const texture = (() => {
+    if (letter.texture === 'notepad') {
+      return {
+        background: '#F8F2E4',
+        backgroundImage: `repeating-linear-gradient(180deg, transparent 0 32px, rgba(120,100,70,0.22) 32px 33px)`,
+        color: '#3a2f1f',
+        fontFamily: 'ui-monospace, "Courier New", monospace',
+      };
+    }
+    if (letter.texture === 'blackboard') {
+      return {
+        background: '#1b2820',
+        color: '#f4e8c1',
+        fontFamily: '"Space Grotesk", serif',
+      };
+    }
+    if (letter.texture === 'hearts') {
+      return {
+        background: `linear-gradient(180deg, #f0e6ff 0%, #e0d0ff 100%)`,
+        backgroundImage: `radial-gradient(circle at 20% 30%, rgba(255,255,255,0.9) 6px, transparent 7px), radial-gradient(circle at 70% 70%, rgba(255,255,255,0.85) 8px, transparent 9px), radial-gradient(circle at 85% 20%, rgba(255,255,255,0.8) 5px, transparent 6px), radial-gradient(circle at 30% 85%, rgba(255,255,255,0.9) 7px, transparent 8px), linear-gradient(180deg, #f0e6ff 0%, #e0d0ff 100%)`,
+        color: '#4a2d6e',
+      };
+    }
+    if (letter.texture === 'balloon') {
+      return {
+        background: 'linear-gradient(135deg, #ffeef6 0%, #fde5f0 100%)',
+        color: '#8B2D5C',
+        fontFamily: t.fontDisplay,
+        fontWeight: 800,
+      };
+    }
+    if (letter.texture === 'grid') {
+      return {
+        background: '#fff9ef',
+        backgroundImage: `linear-gradient(rgba(180,140,80,0.2) 1px, transparent 1px), linear-gradient(90deg, rgba(180,140,80,0.2) 1px, transparent 1px)`,
+        backgroundSize: '20px 20px',
+        color: '#4a3820',
+      };
+    }
+    return { background: '#fff', color: '#111' };
+  })();
+
+  return (
+    <div onClick={onClick} style={{
+      cursor: 'pointer', borderRadius: 12, overflow: 'hidden',
+      border: `1px solid ${t.line}`, background: dark ? '#141624' : t.surface,
+    }}>
+      <div style={{
+        aspectRatio: '3/4', padding: '20px 18px', position: 'relative',
+        ...texture,
+        fontSize: 11, lineHeight: 1.6, whiteSpace: 'pre-line',
+        overflow: 'hidden',
+      }}>
+        {letter.body}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', fontSize: 12 }}>
+        <ArtistAvatar artist={artist} size={20} t={t}/>
+        <span style={{ color: t.textDim }}>To. {artist.name}</span>
+        <span style={{ marginLeft: 'auto', color: t.textDim, fontFamily: t.fontMono, fontSize: 10 }}>· {letter.author}</span>
+      </div>
+    </div>
+  );
+}
+
+function FanLetterModal({ letter, artist, t, theme, onClose }) {
+  return (
+    <div onClick={onClose} style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 200,
+      display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 30,
+    }}>
+      <div onClick={e => e.stopPropagation()} style={{
+        width: 480, maxHeight: '85vh', overflowY: 'auto',
+        background: theme === 'dark' ? '#141624' : t.surface,
+        borderRadius: 16, border: `1px solid ${t.lineStrong}`,
+        color: t.text, padding: 28,
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <ArtistAvatar artist={artist} size={32} t={t}/>
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 14 }}>To. {artist.name}</div>
+              <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>From. {letter.author}</div>
+            </div>
+          </div>
+          <button onClick={onClose} style={{ background: 'transparent', border: 'none', color: t.text, fontSize: 22, cursor: 'pointer' }}>×</button>
+        </div>
+        <div style={{ whiteSpace: 'pre-line', lineHeight: 1.7, fontSize: 14 }}>
+          {letter.body}
+        </div>
+        <div style={{ display: 'flex', gap: 10, marginTop: 18 }}>
+          <button style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: `1px solid ${t.line}`, background: 'transparent', color: t.text, cursor: 'pointer', fontWeight: 700, fontSize: 12 }}>♡ 공감하기</button>
+          <button style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: 'none', background: t.gradient, color: '#fff', cursor: 'pointer', fontWeight: 800, fontSize: 12 }}>🌐 번역 보기</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ────────── MEDIA (최신 + 멤버십 2단) ──────────
+function TabMedia({ t, theme, artist }) {
+  const latest = MEDIA_EXTENDED.filter(m => m.artistId === artist.id).slice(0, 6);
+  const membership = MEDIA_EXTENDED.filter(m => m.artistId === artist.id && m.membership).slice(0, 4);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <Chip t={t} active><span style={{ fontSize: 10 }}>🏠</span></Chip>
+        <Chip t={t}>멤버십</Chip>
+        <Chip t={t}>전체</Chip>
+        <div style={{ flex: 1 }}/>
+        <Chip t={t}>⇅ 필터</Chip>
+      </div>
+
+      <Section t={t} theme={theme}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 14 }}>최신</div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
+          {latest.map(m => <MediaCard key={m.id} media={m} artist={artist} t={t}/>)}
+        </div>
+        <button style={moreBtn(t)}>더 보기</button>
+      </Section>
+
+      <Section t={t} theme={theme}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <span style={{ color: t.accent2 }}>✦</span>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>멤버십</div>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+          <div style={{ fontSize: 12, color: t.textDim }}>최신</div>
+          <button style={linkBtn(t)}>더 보기 →</button>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 }}>
+          {membership.map(m => <MediaCard key={m.id} media={m} artist={artist} t={t} small/>)}
+        </div>
+        <div style={{
+          marginTop: 14, padding: '12px', textAlign: 'center',
+          border: `1px solid ${t.line}`, borderRadius: 10, fontSize: 12, color: t.textDim,
+        }}>
+          지금 멤버십에 가입하고 혜택 누리기
+          <button style={{ ...moreBtn(t), marginTop: 8 }}>멤버십 가입하기</button>
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function MediaCard({ media, artist, t, small }) {
+  return (
+    <div style={{ cursor: 'pointer', fontFamily: t.font }}>
+      <div style={{ position: 'relative', borderRadius: 10, overflow: 'hidden', aspectRatio: '16/10', background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})` }}>
+        {media.membership && (
+          <div style={{ position: 'absolute', top: 8, left: 8, padding: '3px 6px', borderRadius: 4, background: t.accent2, color: '#fff', fontSize: 10, fontWeight: 800 }}>
+            M
+          </div>
+        )}
+        <div style={{ position: 'absolute', bottom: 8, right: 8, padding: '2px 6px', borderRadius: 4, background: 'rgba(0,0,0,0.7)', color: '#fff', fontSize: 10, fontFamily: t.fontMono }}>
+          {media.duration}
+        </div>
+      </div>
+      <div style={{ marginTop: 8, fontSize: small ? 12 : 13, fontWeight: 600, lineHeight: 1.4, color: t.text, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+        {media.title}
+      </div>
+      {media.isNew && <div style={{ display: 'inline-block', marginTop: 4, padding: '1px 6px', background: t.hot, color: '#fff', fontSize: 9, fontWeight: 800, borderRadius: 3 }}>NEW</div>}
+      <div style={{ fontSize: 11, color: t.textDim, marginTop: 2, fontFamily: t.fontMono }}>{media.date}</div>
+    </div>
+  );
+}
+
+// ────────── LIVE (리플레이 그리드) ──────────
+function TabLive({ t, theme, artist, onOpenLive }) {
+  const replays = LIVE_REPLAYS.filter(r => r.artistId === artist.id);
+  return (
+    <div>
+      <Section t={t} theme={theme}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+          <div style={{ fontWeight: 800, fontSize: 15 }}>LIVE Replay</div>
+          <div style={{ display: 'flex', gap: 8, fontSize: 11, color: t.textDim }}>
+            <span>최신순 ▾</span>
+            <span>전체 연도 ▾</span>
+          </div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 14 }}>
+          {replays.map(r => <LiveReplayCard key={r.id} replay={r} artist={artist} t={t} onOpen={() => onOpenLive(artist.id)}/>)}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function LiveReplayCard({ replay, artist, t, onOpen }) {
+  return (
+    <div onClick={onOpen} style={{ cursor: 'pointer' }}>
+      <div style={{
+        position: 'relative', aspectRatio: '16/10', borderRadius: 10, overflow: 'hidden',
+        background: replay.voiceOnly
+          ? `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`
+          : `repeating-linear-gradient(45deg, ${artist.color1} 0 20px, ${artist.color2} 20px 40px)`,
+      }}>
+        {replay.membership && (
+          <div style={{ position: 'absolute', top: 8, left: 8, padding: '3px 6px', borderRadius: 4, background: t.accent2, color: '#fff', fontSize: 10, fontWeight: 800 }}>M</div>
+        )}
+        {replay.voiceOnly && (
+          <div style={{
+            position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            flexDirection: 'column', gap: 8, color: 'rgba(255,255,255,0.8)',
+          }}>
+            <span style={{ fontSize: 40 }}>🎙</span>
+            <span style={{ fontSize: 14, fontWeight: 800, fontFamily: t.fontDisplay }}>Voice Only</span>
+          </div>
+        )}
+        <div style={{ position: 'absolute', bottom: 8, right: 8, padding: '2px 6px', borderRadius: 4, background: 'rgba(0,0,0,0.7)', color: '#fff', fontSize: 10, fontFamily: t.fontMono }}>
+          {replay.duration}
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, fontSize: 12 }}>
+        <ArtistAvatar artist={artist} size={22} t={t}/>
+        <span style={{ fontWeight: 700 }}>{artist.name}.</span>
+        <span style={{ color: t.textDim, fontFamily: t.fontMono }}>{replay.date} · cc</span>
+      </div>
+      <div style={{ fontSize: 13, marginTop: 4, fontWeight: 600, color: t.text }}>{replay.title}</div>
+      <div style={{ fontSize: 11, color: t.textDim, marginTop: 4, fontFamily: t.fontMono, letterSpacing: 0.3 }}>
+        재생 {replay.plays} · 좋아요 {replay.likes} · 댓글 {replay.comments}
+      </div>
+    </div>
+  );
+}
+
+// ────────── NOTICE ──────────
+function TabNotice({ t, theme, artist }) {
+  const notices = NOTICES.filter(n => n.artistId === artist.id);
+  return (
+    <div style={{ border: `1px solid ${t.line}`, borderRadius: 12, overflow: 'hidden' }}>
+      {notices.map((n, i) => (
+        <div key={n.id} style={{
+          padding: '18px 20px', borderBottom: i === notices.length - 1 ? 'none' : `1px solid ${t.line}`,
+          display: 'flex', flexDirection: 'column', gap: 4, cursor: 'pointer',
+          background: theme === 'dark' ? 'transparent' : 'rgba(255,255,255,0.5)',
+        }}>
+          <div style={{ fontSize: 14, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+            {n.pinned && <span style={{ fontSize: 10, padding: '2px 6px', background: t.hot, color: '#fff', borderRadius: 3, fontWeight: 800 }}>📌</span>}
+            <span>{n.title}</span>
+          </div>
+          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{n.date}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ────────── SHOP (external placeholder) ──────────
+function TabShop({ t, theme, artist }) {
+  return (
+    <Section t={t} theme={theme}>
+      <div style={{ textAlign: 'center', padding: '60px 20px' }}>
+        <div style={{ fontSize: 48, marginBottom: 14 }}>🛍</div>
+        <div style={{ fontWeight: 800, fontSize: 18, marginBottom: 6 }}>Connectfin Shop</div>
+        <div style={{ fontSize: 13, color: t.textDim, marginBottom: 18 }}>
+          {artist.name} 공식 상품을 외부 샵에서 확인하세요.
+        </div>
+        <button style={{
+          padding: '12px 28px', borderRadius: 10, border: 'none',
+          background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 13, cursor: 'pointer',
+        }}>Shop 바로가기 ↗</button>
+      </div>
+    </Section>
+  );
+}
+
+// ────────── Shared pieces ──────────
+function Section({ t, theme, children, style }) {
+  return (
+    <div style={{
+      border: `1px solid ${t.line}`, borderRadius: 12,
+      background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+      padding: 18, ...style,
+    }}>{children}</div>
+  );
+}
+
+function Chip({ t, active, children }) {
+  return (
+    <button style={{
+      padding: '6px 14px', borderRadius: 16, border: active ? 'none' : `1px solid ${t.line}`,
+      background: active ? (t.name === 'Y2K Pop' ? t.hot : t.hot) : 'transparent',
+      color: active ? '#fff' : t.text, fontSize: 12, fontWeight: 700, cursor: 'pointer',
+      fontFamily: t.font, display: 'inline-flex', alignItems: 'center', gap: 4,
+    }}>{children}</button>
+  );
+}
+
+function linkBtn(t) {
+  return {
+    background: 'transparent', border: 'none', color: t.textDim,
+    fontSize: 12, cursor: 'pointer', fontFamily: t.fontMono, letterSpacing: 0.3,
+  };
+}
+
+function moreBtn(t) {
+  return {
+    width: '100%', marginTop: 14, padding: '10px 0', borderRadius: 20,
+    border: `1px solid ${t.line}`, background: 'transparent', color: t.text,
+    fontWeight: 600, fontSize: 12, cursor: 'pointer', fontFamily: t.font,
+  };
+}
+
+function ArtistPostCard({ post, artist, t, inline }) {
+  return (
+    <div style={{ padding: inline ? 0 : 18, border: inline ? 'none' : `1px solid ${t.line}`, borderRadius: 12, background: inline ? 'transparent' : 'transparent' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+        <ArtistAvatar artist={artist} size={36} t={t}/>
+        <div>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>{artist.name}.</div>
+          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{post.time}</div>
+        </div>
+      </div>
+      <div style={{ fontSize: 14, lineHeight: 1.6, whiteSpace: 'pre-line', color: t.text }}>{post.body}</div>
+      <div style={{ display: 'flex', gap: 4, marginTop: 10, fontSize: 11, color: t.textDim }}>
+        <span style={{ cursor: 'pointer', fontFamily: t.fontMono }}>번역 보기</span>
+      </div>
+      <div style={{ display: 'flex', gap: 16, marginTop: 12, fontSize: 12, color: t.textDim }}>
+        <span>♡ {post.likes}</span>
+        <span>💬 {post.comments}</span>
+      </div>
+    </div>
+  );
+}
+
+function FanPostFullCard({ post, artist, t, theme }) {
+  return (
+    <div style={{
+      padding: 18, border: `1px solid ${t.line}`, borderRadius: 12,
+      background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+        <div style={{
+          width: 32, height: 32, borderRadius: '50%',
+          background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontWeight: 800, fontSize: 11,
+        }}>{post.author.slice(0, 2)}</div>
+        <div>
+          <div style={{ fontWeight: 700, fontSize: 13 }}>{post.author} <span style={{ color: t.accent2 }}>✓✓</span></div>
+          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{post.timeAgo}</div>
+        </div>
+      </div>
+      {post.tag && <div style={{ color: t.hot, fontSize: 13, fontWeight: 700, marginBottom: 4 }}>{post.tag}</div>}
+      <div style={{ fontSize: 13, lineHeight: 1.55, whiteSpace: 'pre-line', color: t.text }}>{post.body}</div>
+      {post.hasGrid && (
+        <div style={{ display: 'grid', gridTemplateColumns: `repeat(${post.gridCount}, 1fr)`, gap: 4, marginTop: 12 }}>
+          {[...Array(post.gridCount)].map((_, i) => (
+            <div key={i} style={{
+              aspectRatio: '3/5', borderRadius: 6, overflow: 'hidden',
+              background: i % 2 === 0
+                ? `linear-gradient(180deg, #FFB5D8, #FF8AC5)`
+                : `linear-gradient(180deg, #B5E3D8, #8AD4C3)`,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: 'rgba(255,255,255,0.9)', fontSize: 9, fontWeight: 700,
+              fontFamily: t.fontMono,
+            }}>PHOTO</div>
+          ))}
+        </div>
+      )}
+      <div style={{ fontSize: 11, color: t.textDim, marginTop: 8, fontFamily: t.fontMono }}>번역 보기</div>
+      <div style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: 12, color: t.textDim }}>
+        <span>♡ {post.likes}</span>
+        {post.comments !== null && <span>💬 {post.comments}</span>}
+      </div>
+    </div>
+  );
+}
+
+function FanPostMiniCard({ post, artist, t }) {
+  return (
+    <div style={{ display: 'flex', gap: 10, padding: 10, borderRadius: 8, border: `1px solid ${t.line}`, cursor: 'pointer' }}>
+      <div style={{
+        width: 40, height: 40, borderRadius: '50%', flexShrink: 0,
+        background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+      }}/>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 11, fontWeight: 700, marginBottom: 2 }}>{post.author}</div>
+        <div style={{ fontSize: 11, color: t.text, lineHeight: 1.4, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+          {post.body}
+        </div>
+        <div style={{ fontSize: 10, color: t.textDim, marginTop: 4 }}>좋아요 {post.likes}</div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  DesktopArtistProfile, ArtistCoverBanner,
+});

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -1,0 +1,275 @@
+// Connectfin — Desktop shell: global nav + content column + right sidebar
+
+function DesktopShell({ t, theme, children, activeArtist, onNavGlobal, globalView, onArtistOpen, onNavProfile, profileTab }) {
+  return (
+    <div style={{
+      minHeight: '100vh', width: '100%', background: t.bg, color: t.text,
+      fontFamily: t.font, display: 'flex',
+    }}>
+      <DesktopLeftNav t={t} theme={theme} globalView={globalView} onNavGlobal={onNavGlobal} onArtistOpen={onArtistOpen}/>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        <DesktopTopbar t={t} theme={theme} activeArtist={activeArtist} globalView={globalView} profileTab={profileTab} onNavProfile={onNavProfile}/>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ───────── Left nav ─────────
+function DesktopLeftNav({ t, theme, globalView, onNavGlobal, onArtistOpen }) {
+  const dark = theme === 'dark';
+  return (
+    <aside style={{
+      width: 240, flexShrink: 0, borderRight: `1px solid ${t.line}`,
+      padding: '18px 16px', position: 'sticky', top: 0, height: '100vh',
+      overflowY: 'auto', background: dark ? 'rgba(10,11,16,0.5)' : 'rgba(255,255,255,0.5)',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '4px 8px 18px' }}>
+        <Infinity8 size={26} color={t.accent} color2={t.accent2} stroke={8}/>
+        <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18, letterSpacing: -0.4 }}>Connectfin</div>
+      </div>
+
+      <NavItem t={t} icon="⌂" label="홈" active={globalView === 'home'} onClick={() => onNavGlobal('home')}/>
+      <NavItem t={t} icon="✉" label="DM" active={globalView === 'dm'} onClick={() => onNavGlobal('dm')}/>
+      <NavItem t={t} icon="⋯" label="더보기" />
+
+      <NavSection t={t} label="내 커뮤니티"/>
+      {ARTISTS.slice(0, 6).map(a => (
+        <NavArtist key={a.id} artist={a} t={t} onClick={() => onArtistOpen(a.id)}/>
+      ))}
+      <NavItem t={t} icon="⊕" label="커뮤니티 찾기"/>
+
+      <NavSection t={t} label="서비스 바로가기"/>
+      <NavItem t={t} icon="🛍" label="Shop" onClick={() => onNavGlobal('shop')} active={globalView === 'shop'}/>
+      <NavItem t={t} icon="🍮" label="Jelly Shop" onClick={() => onNavGlobal('jelly')} active={globalView === 'jelly'}/>
+
+      <div style={{
+        marginTop: 20, padding: 12, borderRadius: 10, border: `1px dashed ${t.line}`,
+        fontFamily: t.fontMono, fontSize: 10, color: t.textMuted, lineHeight: 1.5, letterSpacing: 0.3,
+      }}>
+        DEV NOTE<br/>
+        좌측 네비 = user.subscribed_communities
+        <br/>GET /me/communities
+      </div>
+    </aside>
+  );
+}
+
+function NavItem({ icon, label, active, onClick, t }) {
+  return (
+    <button onClick={onClick} style={{
+      display: 'flex', alignItems: 'center', gap: 12, width: '100%', textAlign: 'left',
+      padding: '9px 10px', borderRadius: 10,
+      background: active ? t.chip : 'transparent',
+      color: active ? t.accent : t.text,
+      border: 'none', cursor: onClick ? 'pointer' : 'default',
+      fontSize: 14, fontWeight: active ? 700 : 500, fontFamily: t.font, marginBottom: 2,
+    }}>
+      <span style={{ fontSize: 16, width: 20, textAlign: 'center' }}>{icon}</span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function NavSection({ label, t }) {
+  return (
+    <div style={{
+      fontFamily: t.fontMono, fontSize: 10, letterSpacing: 1,
+      color: t.textMuted, padding: '18px 10px 8px',
+    }}>{label.toUpperCase()}</div>
+  );
+}
+
+function NavArtist({ artist, t, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      display: 'flex', alignItems: 'center', gap: 10, width: '100%', textAlign: 'left',
+      padding: '6px 10px', borderRadius: 10, background: 'transparent',
+      color: t.text, border: 'none', cursor: 'pointer',
+      fontSize: 13, fontWeight: 600, fontFamily: t.font, marginBottom: 2, position: 'relative',
+    }}>
+      <ArtistAvatar artist={artist} size={22} t={t}/>
+      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{artist.name}</span>
+      {artist.live && (
+        <span style={{
+          width: 6, height: 6, borderRadius: '50%', background: t.hot,
+          boxShadow: `0 0 8px ${t.hot}`, animation: 'connectfin-pulse 1.2s ease-in-out infinite',
+        }}/>
+      )}
+    </button>
+  );
+}
+
+// ───────── Top bar (profile tabs live here when on artist page) ─────────
+function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile }) {
+  const dark = theme === 'dark';
+  return (
+    <header style={{
+      height: 56, flexShrink: 0, display: 'flex', alignItems: 'center',
+      padding: '0 24px', borderBottom: `1px solid ${t.line}`,
+      position: 'sticky', top: 0, zIndex: 20,
+      background: dark ? 'rgba(10,11,16,0.72)' : 'rgba(255,255,255,0.8)',
+      backdropFilter: 'blur(20px)',
+    }}>
+      {globalView === 'artist' && activeArtist ? (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 160 }}>
+            <ArtistAvatar artist={activeArtist} size={28} t={t}/>
+            <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 16 }}>{activeArtist.name}</div>
+            <button style={{
+              padding: '4px 10px', borderRadius: 14, border: 'none',
+              background: t.chip, color: t.accent, fontSize: 11, fontWeight: 700, cursor: 'pointer',
+              fontFamily: t.fontMono, letterSpacing: 0.3,
+            }}>+ 가입하기</button>
+          </div>
+          <nav style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 24, flex: 1 }}>
+            {PROFILE_TABS.map(tab => {
+              const active = profileTab === tab.k;
+              return (
+                <button key={tab.k} onClick={() => onNavProfile(tab.k)} style={{
+                  padding: '18px 14px', background: 'transparent', border: 'none',
+                  borderBottom: active ? `2px solid ${t.accent}` : '2px solid transparent',
+                  color: active ? t.accent : t.text,
+                  fontSize: 14, fontWeight: active ? 800 : 600, cursor: 'pointer',
+                  fontFamily: t.font,
+                }}>
+                  {tab.label}{tab.external && <span style={{ fontSize: 10, marginLeft: 4, opacity: 0.6 }}>↗</span>}
+                </button>
+              );
+            })}
+          </nav>
+        </>
+      ) : (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 17, fontWeight: 800 }}>
+            {globalView === 'home' ? '홈' : globalView === 'jelly' ? 'Jelly Shop' : globalView === 'shop' ? 'Shop' : globalView === 'dm' ? 'DM' : globalView === 'live' ? 'LIVE' : ''}
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginLeft: 'auto' }}>
+        <span style={{ fontFamily: t.fontMono, fontSize: 11, color: t.textDim }}>142 🍮</span>
+        <span style={{ fontSize: 18, cursor: 'pointer' }}>🔔</span>
+        <div style={{
+          width: 30, height: 30, borderRadius: '50%', background: t.gradient,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontWeight: 800, fontSize: 12, cursor: 'pointer',
+        }}>ME</div>
+      </div>
+    </header>
+  );
+}
+
+const PROFILE_TABS = [
+  { k: 'highlight', label: 'Highlight' },
+  { k: 'fan', label: 'Fan' },
+  { k: 'artist', label: 'Artist' },
+  { k: 'fanletter', label: 'Fan Letter' },
+  { k: 'media', label: 'Media' },
+  { k: 'live', label: 'LIVE' },
+  { k: 'notice', label: 'Notice' },
+  { k: 'shop', label: 'Shop', external: true },
+];
+
+// ───────── Right sidebar ─────────
+function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
+  const dark = theme === 'dark';
+  return (
+    <aside style={{ width: 320, flexShrink: 0, padding: '20px 20px 20px 0', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      {/* Digital membership */}
+      <div style={{
+        borderRadius: 14, padding: 18, border: `1px solid ${t.line}`,
+        background: dark ? '#141624' : t.surface,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <div style={{ width: 20, height: 20, borderRadius: 6, background: t.accent2, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, color: '#fff' }}>D</div>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>{artist?.name}. Digital membership</div>
+        </div>
+        <div style={{ fontSize: 12, color: t.textDim, lineHeight: 1.5, marginBottom: 12 }}>
+          디지털 멤버십에 가입하고 다양한 혜택을 즐겨보세요.
+        </div>
+        <button onClick={onOpenMembership} style={{
+          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+          background: t.accent2, color: dark ? '#071014' : '#fff',
+          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+        }}>디지털 멤버십 가입하기</button>
+      </div>
+
+      {/* Premium membership */}
+      <div style={{
+        borderRadius: 14, padding: 18, border: `1px solid ${t.line}`,
+        background: dark ? '#141624' : t.surface,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <div style={{ width: 20, height: 20, borderRadius: 6, background: t.accent, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, color: '#fff' }}>M</div>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>{artist?.name}. Membership</div>
+        </div>
+        <div style={{ fontSize: 12, color: t.textDim, lineHeight: 1.5, marginBottom: 12 }}>
+          지금 멤버십에 가입하고 특별한 혜택을 누려보세요.
+        </div>
+        <button onClick={onOpenMembership} style={{
+          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+          background: t.accent2, color: dark ? '#071014' : '#fff',
+          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+        }}>멤버십 가입하기</button>
+      </div>
+
+      {/* DM widget */}
+      <div style={{
+        borderRadius: 14, padding: 18, border: `1px solid ${t.line}`,
+        background: dark ? '#141624' : t.surface,
+      }}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 10 }}>Connectfin DM</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+          <ArtistAvatar artist={artist || ARTISTS[0]} size={32} t={t}/>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontWeight: 700, fontSize: 13 }}>{artist?.name || ARTISTS[0].name}.</div>
+            <div style={{
+              display: 'inline-block', padding: '3px 10px', borderRadius: 12,
+              background: t.accent2, color: dark ? '#071014' : '#fff',
+              fontSize: 11, fontWeight: 700, marginTop: 2,
+            }}>지금 뭐해?</div>
+          </div>
+        </div>
+        <button onClick={onOpenDM} style={{
+          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+          background: t.accent2, color: dark ? '#071014' : '#fff',
+          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+        }}>DM 시작하기</button>
+      </div>
+
+      {/* About artist */}
+      {artist && (
+        <div style={{
+          borderRadius: 14, padding: 18, border: `1px solid ${t.line}`,
+          background: dark ? '#141624' : t.surface,
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+            <ArtistAvatar artist={artist} size={36} t={t}/>
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 15 }}>{artist.name}</div>
+              <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono, letterSpacing: 0.3 }}>
+                {artist.genre}
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 10, fontSize: 12, color: t.textDim }}>
+            <span>▶ YouTube</span>
+            <span>✖ X</span>
+            <span>◐ IG</span>
+          </div>
+          <div style={{ fontSize: 12, color: t.textDim, lineHeight: 1.55 }}>
+            팬과 아티스트가 가장 가까운 거리에서 연결되는 디지털 경험.
+            {artist.stage}의 무대 뒤 순간들, 새로운 이야기들을 Connectfin에서 만나보세요.
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+Object.assign(window, {
+  DesktopShell, DesktopRightSidebar, PROFILE_TABS,
+});

--- a/src/main/resources/static/components/ios-frame.jsx
+++ b/src/main/resources/static/components/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/src/main/resources/static/components/screens-main.jsx
+++ b/src/main/resources/static/components/screens-main.jsx
@@ -1,0 +1,447 @@
+// Connectfin — Home, Artist, Media, Community, Membership, Login screens
+
+function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }) {
+  const liveArtists = ARTISTS.filter(a => a.live && liveOn);
+  const [viewers, setViewers] = React.useState(liveArtists.map(a => a.viewers));
+
+  React.useEffect(() => {
+    if (!liveOn) return;
+    const id = setInterval(() => {
+      setViewers(prev => prev.map((v, i) => Math.max(1000, v + Math.round((Math.random() - 0.4) * 120 * speed))));
+    }, 900 / speed);
+    return () => clearInterval(id);
+  }, [speed, liveOn]);
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 54, paddingBottom: 96 }}>
+      {/* Header */}
+      <div style={{ padding: '14px 20px 10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Infinity8 size={36} color={t.accent} color2={t.accent2} stroke={7}/>
+          <span style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 22, letterSpacing: -0.6 }}>
+            Connectfin
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center', color: t.textDim }}>
+          <span style={{ fontSize: 20 }}>⌕</span>
+          <span style={{ fontSize: 20, position: 'relative' }}>
+            ⚑
+            <span style={{ position: 'absolute', top: -2, right: -4, width: 8, height: 8, borderRadius: '50%', background: t.hot }}/>
+          </span>
+        </div>
+      </div>
+
+      {/* Following strip */}
+      <div style={{ padding: '6px 0 10px', overflowX: 'auto' }}>
+        <div style={{ display: 'flex', gap: 14, padding: '0 20px' }}>
+          {ARTISTS.map(a => (
+            <button key={a.id} onClick={() => onOpenArtist(a.id)} style={{
+              background: 'transparent', border: 'none', padding: 0, cursor: 'pointer',
+              display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6,
+              flexShrink: 0,
+            }}>
+              <ArtistAvatar artist={a} size={56} live={a.live && liveOn} ring t={t}/>
+              <span style={{ fontSize: 11, color: t.textDim, fontWeight: 600, maxWidth: 62, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {a.name}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Live carousel */}
+      {liveArtists.length > 0 && (
+        <div style={{ padding: '8px 20px 20px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 10 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: t.hot, boxShadow: `0 0 10px ${t.hot}` }}/>
+              <span style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18, letterSpacing: -0.4 }}>LIVE NOW</span>
+            </div>
+            <span style={{ fontSize: 12, color: t.textDim, fontFamily: t.fontMono }}>{liveArtists.length} streams</span>
+          </div>
+          <div style={{ display: 'flex', gap: 12, overflowX: 'auto', scrollSnapType: 'x mandatory', margin: '0 -20px', padding: '0 20px' }}>
+            {liveArtists.map((a, i) => (
+              <div key={a.id} onClick={() => onOpenLive(a.id)} style={{
+                flexShrink: 0, width: 260, cursor: 'pointer', scrollSnapAlign: 'start',
+              }}>
+                <MediaPlaceholder artist={a} kind="LIVE" label={`${a.stage} — Live`} aspect="16/11" t={t}/>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <ArtistAvatar artist={a} size={28} t={t}/>
+                    <div>
+                      <div style={{ fontSize: 13, fontWeight: 700 }}>{a.stage}</div>
+                      <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono }}>
+                        👁 {viewers[i]?.toLocaleString() || '—'}
+                      </div>
+                    </div>
+                  </div>
+                  <span style={{
+                    fontSize: 10, fontWeight: 800, padding: '3px 8px', borderRadius: 6,
+                    background: t.liveGradient, color: '#fff', letterSpacing: 0.5,
+                  }}>LIVE</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Feed */}
+      <div style={{ padding: '0 20px' }}>
+        <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18, letterSpacing: -0.4, marginBottom: 10 }}>
+          Today's Feed
+        </div>
+        {FEED_POSTS.map(post => {
+          const a = ARTISTS.find(x => x.id === post.artistId);
+          const isArtist = post.type === 'artist';
+          return (
+            <div key={post.id} style={{
+              background: t.surface, borderRadius: 20, padding: 16, marginBottom: 12,
+              border: isArtist ? `1px solid ${t.accent}40` : `1px solid ${t.line}`,
+              position: 'relative', overflow: 'hidden',
+            }}>
+              {post.pinned && (
+                <div style={{
+                  position: 'absolute', top: 0, right: 0,
+                  fontSize: 9, fontWeight: 800, padding: '3px 10px',
+                  background: t.gradient, color: '#fff',
+                  borderBottomLeftRadius: 10, letterSpacing: 0.5,
+                  fontFamily: t.fontMono,
+                }}>📌 PINNED</div>
+              )}
+              <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 10 }}>
+                <ArtistAvatar artist={a} size={40} t={t}/>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <span style={{ fontWeight: 700, fontSize: 14 }}>{post.author}</span>
+                    {isArtist && (
+                      <span style={{
+                        fontSize: 9, fontWeight: 800,
+                        padding: '2px 6px', borderRadius: 4,
+                        background: t.gradient, color: '#fff', letterSpacing: 0.4,
+                      }}>ARTIST ✓</span>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+                    {post.authorRole} · {post.time}
+                  </div>
+                </div>
+                <span style={{ color: t.textMuted }}>⋯</span>
+              </div>
+              <div style={{ fontSize: 14, lineHeight: 1.55, marginBottom: 12, color: t.text }}>
+                {post.body}
+              </div>
+              {post.id === 101 && <MediaPlaceholder artist={a} kind="IMAGE" label="백스테이지 컷 · 3장" aspect="4/3" t={t}/>}
+              <div style={{ display: 'flex', gap: 18, marginTop: 12, fontSize: 12, color: t.textDim }}>
+                <span>♡ {post.likes.toLocaleString()}</span>
+                <span>💬 {post.comments.toLocaleString()}</span>
+                <span style={{ marginLeft: 'auto', color: t.accent, fontWeight: 600 }}>#{a.name}</span>
+              </div>
+            </div>
+          );
+        })}
+        <div style={{ textAlign: 'center', padding: 20, color: t.textMuted, fontFamily: t.fontMono, fontSize: 11 }}>
+          — Cursor: id &lt; 101 —
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ArtistScreen({ t, theme, artistId, onBack, onOpenLive, onOpenDM }) {
+  const a = ARTISTS.find(x => x.id === artistId) || ARTISTS[0];
+  const [tab, setTab] = React.useState('feed');
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingBottom: 96 }}>
+      {/* Cover */}
+      <div style={{ position: 'relative', height: 240 }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `repeating-linear-gradient(45deg, ${a.color1} 0 22px, ${a.color2} 22px 44px)`,
+        }}/>
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `linear-gradient(180deg, rgba(0,0,0,0.25) 0%, ${t.bg} 100%)`,
+        }}/>
+        <button onClick={onBack} style={{
+          position: 'absolute', top: 60, left: 16,
+          width: 36, height: 36, borderRadius: '50%',
+          background: 'rgba(0,0,0,0.5)', color: '#fff',
+          border: 'none', fontSize: 18, cursor: 'pointer', backdropFilter: 'blur(10px)',
+        }}>←</button>
+        <div style={{ position: 'absolute', top: 60, right: 16, display: 'flex', gap: 8 }}>
+          <div style={{
+            padding: '6px 12px', borderRadius: 20,
+            background: 'rgba(0,0,0,0.5)', color: '#fff',
+            fontSize: 11, fontFamily: t.fontMono, backdropFilter: 'blur(10px)',
+          }}>👥 {a.followers}</div>
+        </div>
+      </div>
+
+      {/* Profile */}
+      <div style={{ padding: '0 20px', marginTop: -60, position: 'relative' }}>
+        <ArtistAvatar artist={a} size={104} ring t={t}/>
+        <div style={{ marginTop: 14 }}>
+          <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 32, letterSpacing: -1 }}>
+            {a.name} {a.live && <span style={{
+              fontSize: 11, fontWeight: 800, padding: '4px 10px',
+              background: t.liveGradient, color: '#fff', borderRadius: 6,
+              marginLeft: 8, verticalAlign: 'middle', letterSpacing: 0.5,
+            }}>● LIVE</span>}
+          </div>
+          <div style={{ fontSize: 13, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+            {a.stage} · {a.genre} · {a.members} members
+          </div>
+          <div style={{ fontSize: 14, lineHeight: 1.6, marginTop: 12, color: t.text }}>
+            매일의 순간을 무한히 연결하는 공식 공간. 새 앨범, 라이브, 비하인드 — 모든 소식은 여기서.
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+            <button style={{
+              flex: 1, padding: '12px 0', borderRadius: 14, border: 'none',
+              background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 14, cursor: 'pointer',
+              fontFamily: t.font,
+            }}>FOLLOWING ✓</button>
+            <button onClick={() => onOpenDM(a.id)} style={{
+              padding: '12px 20px', borderRadius: 14, border: `1px solid ${t.lineStrong}`,
+              background: t.surface, color: t.text, fontWeight: 700, fontSize: 14, cursor: 'pointer',
+              fontFamily: t.font,
+            }}>💌 DM</button>
+            {a.live && (
+              <button onClick={() => onOpenLive(a.id)} style={{
+                padding: '12px 20px', borderRadius: 14, border: 'none',
+                background: t.liveGradient, color: '#fff', fontWeight: 800, fontSize: 14, cursor: 'pointer',
+                fontFamily: t.font,
+              }}>▶ LIVE</button>
+            )}
+          </div>
+        </div>
+
+        {/* Membership card */}
+        <div style={{
+          marginTop: 18, borderRadius: 18, padding: 16,
+          background: t.gradient, color: '#fff', position: 'relative', overflow: 'hidden',
+        }}>
+          <div style={{ position: 'absolute', right: -20, top: -20, opacity: 0.2 }}>
+            <Infinity8 size={140} color="#fff" color2="#fff" stroke={14}/>
+          </div>
+          <div style={{ fontSize: 11, fontFamily: t.fontMono, opacity: 0.85, letterSpacing: 0.5 }}>FAN MEMBERSHIP</div>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginTop: 4 }}>
+            {a.name} Fan Club
+          </div>
+          <div style={{ fontSize: 12, marginTop: 4, opacity: 0.9 }}>팬레터 · 전용 DM방 · 래플 우선 응모</div>
+          <div style={{ marginTop: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18 }}>
+              9 <span style={{ fontSize: 11, opacity: 0.8 }}>JELLY / 월</span>
+            </div>
+            <button style={{
+              padding: '8px 16px', borderRadius: 10, border: 'none',
+              background: 'rgba(255,255,255,0.22)', color: '#fff', fontWeight: 700, fontSize: 12, cursor: 'pointer',
+              backdropFilter: 'blur(10px)',
+            }}>가입하기</button>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: 24, marginTop: 20, borderBottom: `1px solid ${t.line}` }}>
+          {['feed', 'artist', 'media', 'live'].map(k => (
+            <button key={k} onClick={() => setTab(k)} style={{
+              background: 'transparent', border: 'none', padding: '10px 0',
+              color: tab === k ? t.text : t.textDim,
+              fontWeight: tab === k ? 800 : 600, fontSize: 14, cursor: 'pointer',
+              borderBottom: tab === k ? `2px solid ${t.accent}` : '2px solid transparent',
+              fontFamily: t.font, letterSpacing: -0.2,
+            }}>
+              {k === 'feed' ? 'Feed' : k === 'artist' ? 'Artist' : k === 'media' ? 'Media' : 'Live'}
+            </button>
+          ))}
+        </div>
+
+        {/* Grid */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 4, marginTop: 12 }}>
+          {Array.from({ length: 9 }, (_, i) => (
+            <div key={i} style={{ aspectRatio: '1/1', background:
+              `repeating-linear-gradient(${i*20}deg, ${a.color1} 0 10px, ${a.color2} 10px 20px)`,
+              borderRadius: 6, position: 'relative', overflow: 'hidden',
+            }}>
+              <div style={{
+                position: 'absolute', bottom: 4, right: 6,
+                fontFamily: t.fontMono, fontSize: 9, color: '#fff',
+                background: 'rgba(0,0,0,0.5)', padding: '1px 4px', borderRadius: 3,
+              }}>{i+1}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MediaScreen({ t, onBack }) {
+  const [filter, setFilter] = React.useState('all');
+  const filtered = filter === 'all' ? MEDIA : MEDIA.filter(m => m.kind === filter);
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
+      <div style={{ padding: '0 20px 12px' }}>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.8 }}>Media</div>
+        <div style={{ fontSize: 13, color: t.textDim, marginTop: 2 }}>공식 MV · 비하인드 · 팬캠까지</div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, padding: '0 20px 16px', overflowX: 'auto' }}>
+        {['all','video','photo'].map(k => (
+          <button key={k} onClick={() => setFilter(k)} style={{
+            padding: '6px 14px', borderRadius: 20,
+            background: filter === k ? t.gradient : 'transparent',
+            color: filter === k ? '#fff' : t.textDim,
+            border: filter === k ? 'none' : `1px solid ${t.line}`,
+            fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: t.font,
+            textTransform: 'uppercase', letterSpacing: 0.5,
+          }}>{k}</button>
+        ))}
+      </div>
+      <div style={{ padding: '0 20px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+        {filtered.map(m => {
+          const a = ARTISTS.find(x => x.id === m.artistId);
+          return (
+            <div key={m.id}>
+              <MediaPlaceholder artist={a} kind={m.kind} label={m.title} aspect={m.kind === 'video' ? '3/4' : '1/1'} t={t}/>
+              <div style={{ marginTop: 6, fontSize: 12, fontWeight: 700, lineHeight: 1.3 }}>
+                {m.title}
+              </div>
+              <div style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono, marginTop: 2 }}>
+                {m.duration ? `${m.duration} · ${m.views} views` : `${m.daysAgo}d ago`}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function MembershipScreen({ t, onOpenRaffles }) {
+  const tiers = [
+    { name: 'Free', price: '0', subs: ['팬 포스트 열람', '아티스트 포스트 리액션'], color: t.surface2, text: t.text },
+    { name: 'Fan Membership', price: '9', subs: ['팬레터 작성 ✍', '멤버 전용 포스트', '래플 기본 응모'], color: t.gradient, text: '#fff', hot: true },
+    { name: 'DM Subscription', price: '15', subs: ['1:1 DM 송수신 💬', 'Fan Membership 포함', '래플 가중치 ×2'], color: t.liveGradient, text: '#fff' },
+  ];
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
+      <div style={{ padding: '0 20px 16px' }}>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.8 }}>Membership</div>
+        <div style={{ fontSize: 13, color: t.textDim, marginTop: 2 }}>젤리로 결제 · 1 Jelly = 300 KRW</div>
+      </div>
+
+      {/* Wallet */}
+      <div style={{ margin: '0 20px 20px', borderRadius: 20, padding: 16, background: t.surface, border: `1px solid ${t.line}` }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono, letterSpacing: 0.5 }}>JELLY WALLET</div>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginTop: 4 }}>
+              <span style={{ fontFamily: t.fontDisplay, fontSize: 32, fontWeight: 800, background: t.gradient, WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+                142
+              </span>
+              <span style={{ fontSize: 14, color: t.textDim, fontWeight: 700 }}>🍮 Jelly</span>
+            </div>
+            <div style={{ fontSize: 11, color: t.textMuted, fontFamily: t.fontMono }}>≈ 42,600 KRW · Auto-charge ON</div>
+          </div>
+          <button style={{
+            padding: '10px 18px', borderRadius: 12, border: 'none',
+            background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 13, cursor: 'pointer',
+          }}>+ 충전</button>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 20px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {tiers.map(tier => (
+          <div key={tier.name} style={{
+            background: tier.color, color: tier.text, borderRadius: 20, padding: 18,
+            position: 'relative', overflow: 'hidden',
+            border: tier.name === 'Free' ? `1px solid ${t.line}` : 'none',
+          }}>
+            {tier.hot && (
+              <div style={{
+                position: 'absolute', top: 12, right: 12,
+                fontSize: 9, fontWeight: 800, padding: '3px 8px', borderRadius: 4,
+                background: 'rgba(255,255,255,0.22)', color: '#fff', letterSpacing: 0.5,
+              }}>POPULAR</div>
+            )}
+            <div style={{ fontFamily: t.fontDisplay, fontSize: 20, fontWeight: 800, letterSpacing: -0.4 }}>{tier.name}</div>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, marginTop: 4 }}>
+              <span style={{ fontFamily: t.fontDisplay, fontSize: 30, fontWeight: 800 }}>{tier.price}</span>
+              <span style={{ fontSize: 11, opacity: 0.85 }}>JELLY/월</span>
+            </div>
+            <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {tier.subs.map(s => (
+                <div key={s} style={{ fontSize: 13 }}>✓ {s}</div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Raffle promo */}
+      <div style={{ margin: '20px 20px 0', padding: 16, borderRadius: 18, background: t.surface, border: `1px dashed ${t.accent}` }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <div style={{ fontSize: 11, color: t.accent, fontFamily: t.fontMono, fontWeight: 700, letterSpacing: 0.5 }}>🎰 RAFFLE</div>
+            <div style={{ fontWeight: 800, fontSize: 15, marginTop: 2 }}>LUMEN8 DM 30일권</div>
+            <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>진행중 · 남은시간 02:14:58 · 당첨 5명</div>
+          </div>
+          <button onClick={onOpenRaffles} style={{
+            padding: '8px 14px', borderRadius: 10, border: `1px solid ${t.accent}`,
+            background: 'transparent', color: t.accent, fontWeight: 800, fontSize: 12, cursor: 'pointer',
+          }}>응모</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LoginScreen({ t, onLogin }) {
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', padding: '100px 28px 40px' }}>
+      <div style={{ marginBottom: 40 }}>
+        <Infinity8 size={72} color={t.accent} color2={t.accent2} stroke={7}/>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 40, fontWeight: 800, letterSpacing: -1.2, marginTop: 16 }}>
+          Connectfin
+        </div>
+        <div style={{ fontSize: 14, color: t.textDim, marginTop: 6, lineHeight: 1.5 }}>
+          무한히 연결되는 팬덤 경험.<br/>아티스트와 당신 사이, 단 한 번의 탭.
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <input placeholder="이메일" style={{
+          padding: '14px 16px', borderRadius: 14, border: `1px solid ${t.lineStrong}`,
+          background: t.surface, color: t.text, fontSize: 14, fontFamily: t.font,
+        }}/>
+        <input placeholder="비밀번호" type="password" style={{
+          padding: '14px 16px', borderRadius: 14, border: `1px solid ${t.lineStrong}`,
+          background: t.surface, color: t.text, fontSize: 14, fontFamily: t.font,
+        }}/>
+        <button onClick={onLogin} style={{
+          padding: '14px', borderRadius: 14, border: 'none',
+          background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 15, cursor: 'pointer',
+          fontFamily: t.font, marginTop: 8,
+        }}>로그인 →</button>
+      </div>
+      <div style={{ marginTop: 20, display: 'flex', gap: 12, alignItems: 'center' }}>
+        <div style={{ flex: 1, height: 1, background: t.line }}/>
+        <span style={{ fontSize: 11, color: t.textMuted, fontFamily: t.fontMono }}>OR</span>
+        <div style={{ flex: 1, height: 1, background: t.line }}/>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 16 }}>
+        {['카카오로 시작','Apple로 시작','Google로 시작'].map(l => (
+          <button key={l} style={{
+            padding: '12px', borderRadius: 14, border: `1px solid ${t.line}`,
+            background: t.surface, color: t.text, fontWeight: 600, fontSize: 13, cursor: 'pointer',
+            fontFamily: t.font,
+          }}>{l}</button>
+        ))}
+      </div>
+      <div style={{ marginTop: 'auto', textAlign: 'center', fontSize: 11, color: t.textMuted, fontFamily: t.fontMono }}>
+        아직 계정이 없나요? <span style={{ color: t.accent, fontWeight: 700 }}>회원가입</span>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { HomeScreen, ArtistScreen, MediaScreen, MembershipScreen, LoginScreen });

--- a/src/main/resources/static/components/screens-raffle.jsx
+++ b/src/main/resources/static/components/screens-raffle.jsx
@@ -1,0 +1,411 @@
+// Connectfin — Raffle: list + detail + entry flow
+
+const RAFFLES = [
+  {
+    id: 1, artistId: 1, title: 'LUMEN8 DM 30일권', category: 'DM_PASS',
+    prize: 'YUNA의 1:1 DM 30일 무제한', winners: 5,
+    cost: 3, endsAt: '2h 14m',
+    entries: 12_482, maxWeight: 6, hot: true,
+    desc: 'LUMEN8 멤버 YUNA와의 DM 구독권을 30일간 무료로 사용하세요. 당첨자에게는 YUNA의 음성 인사말이 포함됩니다.',
+    rules: ['Fan Membership 가입 필요', 'Jelly 3개 차감 (미당첨 시 전액 환불)', '당첨자 발표 후 48시간 내 지급', '양도 불가']
+  },
+  {
+    id: 2, artistId: 3, title: 'NOIR7 영상통화 팬미팅', category: 'VIDEO_CALL',
+    prize: '1:1 영상통화 3분 × 30명', winners: 30,
+    cost: 5, endsAt: '1d 6h',
+    entries: 48_291, maxWeight: 6, hot: true,
+    desc: 'NOIR7 전 멤버와 랜덤으로 매칭되는 영상통화. 사전 예약된 시간에 진행되며 녹화/캡처는 불가능합니다.',
+    rules: ['DM Subscription 가입자 우선', 'Jelly 5개 차감', '국내/해외 IP 구분 후 추첨', '실명 인증 필수']
+  },
+  {
+    id: 3, artistId: 1, title: '싸인 폴라로이드 세트', category: 'GOODS',
+    prize: 'LUMEN8 멤버 5종 싸인 폴라로이드', winners: 50,
+    cost: 2, endsAt: '3d 2h',
+    entries: 24_112, maxWeight: 4,
+    desc: '공식 앨범 "PRISM" 발매 기념 한정 폴라로이드. 당첨자 주소로 배송됩니다.',
+    rules: ['배송지 국내 한정', '중복 응모 불가', '양도 불가']
+  },
+  {
+    id: 4, artistId: 4, title: 'hanabi* 사운드체크 초대', category: 'EVENT',
+    prize: '8/17 쇼케이스 사운드체크 참관 + 미니 MD', winners: 20,
+    cost: 4, endsAt: '5d 18h',
+    entries: 8_402, maxWeight: 3,
+    desc: '쇼케이스 당일 오후 5시, 사운드체크를 참관하고 hanabi*와 짧게 인사할 수 있는 기회입니다.',
+    rules: ['공연 티켓 별도 구매 필요', '신분증 지참', '동반인 불가']
+  },
+  {
+    id: 5, artistId: 2, title: 'Kagerō 친필 엽서', category: 'GOODS',
+    prize: '멤버 4인 친필 엽서 (랜덤)', winners: 100,
+    cost: 1, endsAt: '6d',
+    entries: 3_241, maxWeight: 2,
+    desc: '투어 파이널 기념. 멤버별 친필 엽서가 랜덤으로 한 장씩 발송됩니다.',
+    rules: ['국제 배송 가능 (배송비 팬 부담)', '중복 응모 불가']
+  },
+  {
+    id: 6, artistId: 6, title: 'ORBITAL 스튜디오 라이브 초대', category: 'EVENT',
+    prize: '비공개 스튜디오 라이브 + 애프터 토크', winners: 10,
+    cost: 6, endsAt: '종료됨', ended: true,
+    entries: 52_012, maxWeight: 6,
+    desc: '10/5 비공개 스튜디오 라이브. (종료)',
+    rules: []
+  },
+];
+
+function RaffleListScreen({ t, onBack, onOpenRaffle }) {
+  const [filter, setFilter] = React.useState('all');
+  const filtered = filter === 'all' ? RAFFLES.filter(r => !r.ended)
+    : filter === 'ended' ? RAFFLES.filter(r => r.ended)
+    : RAFFLES.filter(r => r.category === filter);
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
+      <div style={{ padding: '0 20px 8px', display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <div>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.8 }}>Raffle</div>
+          <div style={{ fontSize: 12, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+            🍮 142 Jelly · 당첨 가중치 × 2
+          </div>
+        </div>
+        <div style={{
+          padding: '5px 10px', borderRadius: 8, background: t.chip,
+          color: t.accent, fontSize: 10, fontFamily: t.fontMono, fontWeight: 700, letterSpacing: 0.5,
+        }}>DM+ TIER</div>
+      </div>
+
+      {/* Hero featured */}
+      {(() => {
+        const hero = RAFFLES.find(r => r.hot);
+        const ha = ARTISTS.find(x => x.id === hero.artistId);
+        return (
+          <div onClick={() => onOpenRaffle(hero.id)} style={{
+            margin: '0 16px 16px', borderRadius: 20, overflow: 'hidden',
+            cursor: 'pointer', position: 'relative', height: 200,
+            background: `repeating-linear-gradient(120deg, ${ha.color1} 0 28px, ${ha.color2} 28px 56px)`,
+          }}>
+            <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.85) 100%)' }}/>
+            <div style={{
+              position: 'absolute', top: 14, left: 14,
+              padding: '4px 9px', borderRadius: 6, background: t.liveGradient, color: '#fff',
+              fontSize: 10, fontWeight: 800, letterSpacing: 0.5, display: 'flex', gap: 5, alignItems: 'center',
+            }}>
+              <span style={{ width: 5, height: 5, borderRadius: '50%', background: '#fff', animation: 'connectfin-pulse 1.2s ease-in-out infinite' }}/>
+              HOT · ENDS IN {hero.endsAt}
+            </div>
+            <div style={{ position: 'absolute', bottom: 14, left: 16, right: 16, color: '#fff' }}>
+              <div style={{ fontSize: 11, fontFamily: t.fontMono, opacity: 0.85, letterSpacing: 0.5 }}>
+                {ha.name} · RAFFLE
+              </div>
+              <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginTop: 2, lineHeight: 1.2 }}>
+                {hero.title}
+              </div>
+              <div style={{ display: 'flex', gap: 14, marginTop: 8, fontSize: 11, fontFamily: t.fontMono, opacity: 0.9 }}>
+                <span>👥 {hero.entries.toLocaleString()} 응모</span>
+                <span>🏆 {hero.winners}명 당첨</span>
+                <span>🍮 {hero.cost} Jelly</span>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* Filter chips */}
+      <div style={{ display: 'flex', gap: 6, padding: '0 16px 12px', overflowX: 'auto' }}>
+        {[
+          { k: 'all', label: 'ALL' },
+          { k: 'DM_PASS', label: 'DM PASS' },
+          { k: 'VIDEO_CALL', label: '영상통화' },
+          { k: 'EVENT', label: '오프라인' },
+          { k: 'GOODS', label: '굿즈' },
+          { k: 'ended', label: '종료됨' },
+        ].map(f => (
+          <button key={f.k} onClick={() => setFilter(f.k)} style={{
+            flexShrink: 0, padding: '6px 12px', borderRadius: 20,
+            background: filter === f.k ? t.gradient : 'transparent',
+            color: filter === f.k ? '#fff' : t.textDim,
+            border: filter === f.k ? 'none' : `1px solid ${t.line}`,
+            fontSize: 11, fontWeight: 700, cursor: 'pointer', fontFamily: t.fontMono, letterSpacing: 0.5,
+          }}>{f.label}</button>
+        ))}
+      </div>
+
+      {/* List */}
+      <div style={{ padding: '0 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {filtered.map(r => {
+          const a = ARTISTS.find(x => x.id === r.artistId);
+          const pct = Math.min(100, (r.entries / 60000) * 100);
+          return (
+            <button key={r.id} onClick={() => onOpenRaffle(r.id)} style={{
+              textAlign: 'left', cursor: 'pointer', padding: 12,
+              borderRadius: 16, background: t.surface, border: `1px solid ${t.line}`,
+              display: 'flex', gap: 12, alignItems: 'center',
+              opacity: r.ended ? 0.55 : 1,
+              fontFamily: t.font, color: t.text,
+            }}>
+              <div style={{
+                width: 72, height: 72, borderRadius: 12, flexShrink: 0,
+                background: `repeating-linear-gradient(45deg, ${a.color1} 0 14px, ${a.color2} 14px 28px)`,
+                position: 'relative', overflow: 'hidden',
+              }}>
+                <div style={{
+                  position: 'absolute', bottom: 0, left: 0, right: 0,
+                  padding: '3px 6px', background: 'rgba(0,0,0,0.55)',
+                  fontSize: 9, fontFamily: t.fontMono, color: '#fff', letterSpacing: 0.5,
+                }}>{r.category.replace('_', ' ')}</div>
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                  <span style={{ fontSize: 11, color: t.textDim, fontWeight: 600 }}>{a.name}</span>
+                  {r.hot && !r.ended && <span style={{ fontSize: 9, fontWeight: 800, padding: '1px 5px', borderRadius: 3, background: t.hot, color: '#fff' }}>HOT</span>}
+                </div>
+                <div style={{ fontWeight: 700, fontSize: 14, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {r.title}
+                </div>
+                <div style={{ marginTop: 6, height: 4, background: t.surface2, borderRadius: 2, overflow: 'hidden' }}>
+                  <div style={{ height: '100%', width: `${pct}%`, background: t.gradient }}/>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4, fontSize: 10, color: t.textMuted, fontFamily: t.fontMono }}>
+                  <span>{r.entries.toLocaleString()} 응모 · {r.winners}명 당첨</span>
+                  <span style={{ color: r.ended ? t.textMuted : t.accent, fontWeight: 700 }}>
+                    {r.ended ? '종료' : `⏳ ${r.endsAt}`}
+                  </span>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ padding: '20px 20px 0', fontSize: 10, color: t.textMuted, fontFamily: t.fontMono, textAlign: 'center', lineHeight: 1.6 }}>
+        GET /raffles?cursor=...&status=active<br/>
+        가중치 계산: base × membership_tier × jelly_spent
+      </div>
+    </div>
+  );
+}
+
+function RaffleDetailScreen({ t, theme, raffleId, onBack, onEnter }) {
+  const r = RAFFLES.find(x => x.id === raffleId) || RAFFLES[0];
+  const a = ARTISTS.find(x => x.id === r.artistId);
+  const [weight, setWeight] = React.useState(1);
+  const [agreed, setAgreed] = React.useState(false);
+  const [entering, setEntering] = React.useState(false);
+  const [result, setResult] = React.useState(null); // 'submitted'
+  const totalCost = r.cost * weight;
+  const myBalance = 142;
+
+  const submit = () => {
+    if (r.ended || !agreed || totalCost > myBalance || entering) return;
+    setEntering(true);
+    setTimeout(() => {
+      setEntering(false);
+      setResult('submitted');
+    }, 1400);
+  };
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingBottom: 120, background: t.bg }}>
+      {/* Cover */}
+      <div style={{ position: 'relative', height: 240 }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `repeating-linear-gradient(30deg, ${a.color1} 0 28px, ${a.color2} 28px 56px)`,
+        }}/>
+        <div style={{ position: 'absolute', inset: 0, background: `linear-gradient(180deg, rgba(0,0,0,0.2) 0%, ${t.bg} 100%)` }}/>
+        <button onClick={onBack} style={{
+          position: 'absolute', top: 60, left: 16, width: 36, height: 36, borderRadius: '50%',
+          background: 'rgba(0,0,0,0.5)', color: '#fff', border: 'none', fontSize: 18, cursor: 'pointer',
+          backdropFilter: 'blur(10px)',
+        }}>←</button>
+        {!r.ended && (
+          <div style={{
+            position: 'absolute', top: 60, right: 16,
+            padding: '6px 12px', borderRadius: 8, background: t.liveGradient, color: '#fff',
+            fontSize: 11, fontWeight: 800, letterSpacing: 0.5, display: 'flex', gap: 6, alignItems: 'center',
+            backdropFilter: 'blur(10px)',
+          }}>
+            <span style={{ width: 5, height: 5, borderRadius: '50%', background: '#fff', animation: 'connectfin-pulse 1.2s ease-in-out infinite' }}/>
+            ENDS IN {r.endsAt}
+          </div>
+        )}
+        <div style={{ position: 'absolute', bottom: 14, left: 18, right: 18, color: '#fff' }}>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+            <ArtistAvatar artist={a} size={36} t={t}/>
+            <div>
+              <div style={{ fontWeight: 700, fontSize: 14 }}>{a.name}</div>
+              <div style={{ fontSize: 10, fontFamily: t.fontMono, opacity: 0.8, letterSpacing: 0.5 }}>{r.category.replace('_', ' ')} · RAFFLE</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 26, fontWeight: 800, letterSpacing: -0.7, lineHeight: 1.2 }}>
+          {r.title}
+        </div>
+        <div style={{
+          marginTop: 10, padding: 14, borderRadius: 14,
+          background: t.surface, border: `1px solid ${t.line}`,
+        }}>
+          <div style={{ fontSize: 10, color: t.accent, fontFamily: t.fontMono, fontWeight: 700, letterSpacing: 0.5 }}>🏆 PRIZE</div>
+          <div style={{ fontSize: 14, fontWeight: 700, marginTop: 4, color: t.text }}>{r.prize}</div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10, marginTop: 12 }}>
+            {[
+              { k: '당첨', v: `${r.winners}명` },
+              { k: '응모', v: r.entries.toLocaleString() },
+              { k: '비용', v: `🍮 ${r.cost}` },
+            ].map(s => (
+              <div key={s.k}>
+                <div style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono, letterSpacing: 0.5 }}>{s.k}</div>
+                <div style={{ fontWeight: 800, fontSize: 15, color: t.text, marginTop: 1 }}>{s.v}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 16, fontSize: 13, lineHeight: 1.6, color: t.textDim }}>
+          {r.desc}
+        </div>
+
+        {/* Rules */}
+        {r.rules.length > 0 && (
+          <div style={{ marginTop: 16 }}>
+            <div style={{ fontSize: 11, fontFamily: t.fontMono, fontWeight: 700, letterSpacing: 0.5, color: t.textDim, marginBottom: 8 }}>
+              RULES
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {r.rules.map((rule, i) => (
+                <div key={i} style={{ display: 'flex', gap: 8, fontSize: 12.5, color: t.text, lineHeight: 1.5 }}>
+                  <span style={{ color: t.accent, fontWeight: 800, flexShrink: 0 }}>{String(i+1).padStart(2,'0')}</span>
+                  <span>{rule}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Weight picker */}
+        {!r.ended && (
+          <div style={{ marginTop: 20, padding: 14, borderRadius: 14, background: t.surface, border: `1px solid ${t.line}` }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: t.text }}>당첨 확률 × <span style={{ color: t.accent, fontSize: 16, fontFamily: t.fontDisplay }}>{weight}</span></div>
+              <div style={{ fontSize: 10, fontFamily: t.fontMono, color: t.textMuted }}>MAX {r.maxWeight}</div>
+            </div>
+            <input type="range" min="1" max={r.maxWeight} step="1" value={weight}
+              onChange={e => setWeight(+e.target.value)}
+              style={{ width: '100%', accentColor: t.accent }}/>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 10, fontFamily: t.fontMono, color: t.textMuted }}>
+              <span>× 1 (기본)</span>
+              <span>× {r.maxWeight} (최대)</span>
+            </div>
+            <div style={{
+              marginTop: 12, padding: '10px 12px', borderRadius: 10, background: t.surface2,
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            }}>
+              <span style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+                {r.cost} × {weight} = <b style={{ color: t.text }}>{totalCost}</b> Jelly 차감
+              </span>
+              <span style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono }}>
+                잔액 {myBalance} 🍮
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Agreement */}
+        {!r.ended && (
+          <label style={{
+            marginTop: 14, display: 'flex', gap: 10, padding: 12,
+            borderRadius: 12, background: t.surface2, cursor: 'pointer',
+            alignItems: 'center',
+          }}>
+            <div style={{
+              width: 18, height: 18, borderRadius: 5,
+              border: `2px solid ${agreed ? t.accent : t.lineStrong}`,
+              background: agreed ? t.accent : 'transparent',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#fff', fontSize: 11, fontWeight: 800, flexShrink: 0,
+            }}>{agreed ? '✓' : ''}</div>
+            <input type="checkbox" checked={agreed} onChange={e => setAgreed(e.target.checked)} style={{ display: 'none' }}/>
+            <span style={{ fontSize: 12, color: t.text, lineHeight: 1.5 }}>
+              응모 규정 및 개인정보 수집에 동의합니다. (미당첨 시 Jelly 전액 자동 환불)
+            </span>
+          </label>
+        )}
+      </div>
+
+      {/* Sticky CTA */}
+      {!r.ended && (
+        <div style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          padding: '14px 18px 34px',
+          background: `linear-gradient(180deg, transparent, ${t.bg} 40%)`,
+        }}>
+          <button onClick={submit} disabled={!agreed || totalCost > myBalance || entering} style={{
+            width: '100%', padding: '16px', borderRadius: 14, border: 'none',
+            background: (!agreed || totalCost > myBalance) ? t.surface2 : t.gradient,
+            color: (!agreed || totalCost > myBalance) ? t.textMuted : '#fff',
+            fontWeight: 800, fontSize: 15, cursor: (!agreed || totalCost > myBalance) ? 'not-allowed' : 'pointer',
+            fontFamily: t.font, letterSpacing: -0.2,
+            boxShadow: agreed && totalCost <= myBalance ? `0 10px 30px ${t.accent}33` : 'none',
+            transition: 'all 0.2s',
+          }}>
+            {entering ? '응모 중…' :
+             totalCost > myBalance ? `잔액 부족 · ${totalCost - myBalance} Jelly 더 필요` :
+             `🎰 ${totalCost} Jelly로 응모 · 확률 × ${weight}`}
+          </button>
+        </div>
+      )}
+
+      {r.ended && (
+        <div style={{
+          margin: '20px 20px 0', padding: 14, borderRadius: 12, background: t.surface2,
+          textAlign: 'center', fontSize: 12, color: t.textDim, fontFamily: t.fontMono,
+        }}>
+          이 래플은 종료되었습니다 · 당첨자 개별 통보 완료
+        </div>
+      )}
+
+      {/* Success modal */}
+      {result === 'submitted' && (
+        <div style={{
+          position: 'absolute', inset: 0, zIndex: 90,
+          background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(6px)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: 24,
+        }} onClick={() => { setResult(null); onEnter && onEnter(); }}>
+          <div onClick={e => e.stopPropagation()} style={{
+            width: '100%', maxWidth: 320, padding: 24, borderRadius: 22,
+            background: t.surface, border: `1px solid ${t.lineStrong}`,
+            textAlign: 'center',
+          }}>
+            <div style={{
+              width: 72, height: 72, borderRadius: '50%', margin: '0 auto',
+              background: t.gradient, display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 36, boxShadow: `0 10px 40px ${t.accent}55`,
+            }}>🎉</div>
+            <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 20, marginTop: 14, color: t.text }}>
+              응모 완료!
+            </div>
+            <div style={{ fontSize: 13, color: t.textDim, lineHeight: 1.55, marginTop: 8 }}>
+              <b style={{ color: t.text }}>{r.title}</b> 응모가 접수되었어요.<br/>
+              당첨자는 <b style={{ color: t.accent }}>{r.endsAt}</b> 후 발표돼요.
+            </div>
+            <div style={{
+              marginTop: 14, padding: '8px 12px', borderRadius: 10, background: t.surface2,
+              fontSize: 11, color: t.textMuted, fontFamily: t.fontMono, letterSpacing: 0.3,
+            }}>
+              entry_id · rf_{r.id}_{Math.random().toString(36).slice(2,10)}<br/>
+              weight × {weight} · {totalCost} Jelly escrow
+            </div>
+            <button onClick={() => { setResult(null); onBack(); }} style={{
+              marginTop: 16, width: '100%', padding: 12, borderRadius: 12, border: 'none',
+              background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+            }}>목록으로 돌아가기</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { RAFFLES, RaffleListScreen, RaffleDetailScreen });

--- a/src/main/resources/static/components/screens-realtime.jsx
+++ b/src/main/resources/static/components/screens-realtime.jsx
@@ -1,0 +1,469 @@
+// Live streaming + realtime chat, DM list + thread, Community feed
+
+function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
+  const a = ARTISTS.find(x => x.id === artistId) || ARTISTS.find(x => x.live) || ARTISTS[0];
+  const [messages, setMessages] = React.useState(() =>
+    LIVE_SEEDS.slice(0, 6).map((s, i) => ({ ...s, id: i, t: s.t || 'fan' }))
+  );
+  const [viewers, setViewers] = React.useState(a.viewers || 58_000);
+  const [hearts, setHearts] = React.useState([]);
+  const [input, setInput] = React.useState('');
+  const listRef = React.useRef(null);
+  const nextId = React.useRef(100);
+
+  React.useEffect(() => {
+    if (!liveOn) return;
+    const id = setInterval(() => {
+      const seed = LIVE_SEEDS[Math.floor(Math.random() * LIVE_SEEDS.length)];
+      setMessages(m => [...m.slice(-40), { ...seed, id: nextId.current++, t: seed.t || 'fan' }]);
+      setViewers(v => Math.max(1000, v + Math.round((Math.random() - 0.4) * 300 * speed)));
+      if (Math.random() < 0.5) {
+        setHearts(h => [...h.slice(-8), { id: nextId.current++, x: 20 + Math.random() * 60, d: 1500 + Math.random() * 1500 }]);
+      }
+    }, 700 / speed);
+    return () => clearInterval(id);
+  }, [speed, liveOn]);
+
+  React.useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+  }, [messages]);
+
+  const send = () => {
+    if (!input.trim()) return;
+    setMessages(m => [...m, { id: nextId.current++, u: 'me', m: input, t: 'me' }]);
+    setInput('');
+  };
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: '#000', position: 'relative' }}>
+      {/* Video area */}
+      <div style={{ position: 'relative', height: '48%', overflow: 'hidden' }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `repeating-linear-gradient(30deg, ${a.color1} 0 24px, ${a.color2} 24px 48px)`,
+          animation: liveOn ? 'connectfin-shimmer 8s linear infinite' : 'none',
+        }}/>
+        <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0) 30%, rgba(0,0,0,0) 60%, rgba(0,0,0,0.6) 100%)' }}/>
+        <div style={{
+          position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+          fontFamily: t.fontMono, color: 'rgba(255,255,255,0.7)', fontSize: 11, letterSpacing: 1,
+        }}>LIVE VIDEO STREAM · {a.name}</div>
+
+        {/* Back */}
+        <button onClick={onBack} style={{
+          position: 'absolute', top: 62, left: 14, zIndex: 3,
+          width: 34, height: 34, borderRadius: '50%',
+          background: 'rgba(0,0,0,0.55)', color: '#fff', border: 'none', fontSize: 16, cursor: 'pointer',
+          backdropFilter: 'blur(10px)',
+        }}>←</button>
+
+        {/* Live badge + viewers */}
+        <div style={{ position: 'absolute', top: 62, right: 14, display: 'flex', gap: 6, zIndex: 3 }}>
+          <div style={{
+            padding: '5px 10px', borderRadius: 6, background: t.liveGradient, color: '#fff',
+            fontSize: 11, fontWeight: 800, letterSpacing: 0.5, display: 'flex', alignItems: 'center', gap: 5,
+          }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: '#fff', animation: 'connectfin-pulse 1.2s ease-in-out infinite' }}/>
+            LIVE
+          </div>
+          <div style={{
+            padding: '5px 10px', borderRadius: 6, background: 'rgba(0,0,0,0.6)',
+            color: '#fff', fontSize: 11, fontFamily: t.fontMono, backdropFilter: 'blur(10px)',
+          }}>👁 {viewers.toLocaleString()}</div>
+        </div>
+
+        {/* Title */}
+        <div style={{ position: 'absolute', bottom: 20, left: 16, right: 16, color: '#fff', zIndex: 3 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+            <ArtistAvatar artist={a} size={40} t={t}/>
+            <div>
+              <div style={{ fontWeight: 800, fontSize: 15 }}>{a.stage}</div>
+              <div style={{ fontSize: 11, opacity: 0.8, fontFamily: t.fontMono }}>@{a.name.toLowerCase()} · {a.genre}</div>
+            </div>
+            <button style={{
+              marginLeft: 'auto', padding: '6px 14px', borderRadius: 20, border: '1px solid rgba(255,255,255,0.4)',
+              background: 'rgba(255,255,255,0.12)', color: '#fff', fontSize: 12, fontWeight: 700, cursor: 'pointer',
+              backdropFilter: 'blur(10px)',
+            }}>+ Follow</button>
+          </div>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 18, fontWeight: 800, lineHeight: 1.2 }}>
+            {a.name === 'hanabi*' ? '🎙️ 늦밤 잡담 · 새 커버곡 첫 공개' : '🌙 퇴근길 LIVE · 오늘도 고생했어'}
+          </div>
+        </div>
+
+        {/* Floating hearts */}
+        <div style={{ position: 'absolute', bottom: 0, right: 0, width: '40%', height: '100%', pointerEvents: 'none' }}>
+          {hearts.map(h => (
+            <div key={h.id} style={{
+              position: 'absolute', bottom: 0, right: `${h.x}%`,
+              fontSize: 20, animation: `connectfin-float ${h.d}ms ease-out forwards`,
+            }}>💜</div>
+          ))}
+        </div>
+      </div>
+
+      {/* Chat */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: t.bg, position: 'relative' }}>
+        <div style={{
+          padding: '10px 16px 6px', borderBottom: `1px solid ${t.line}`,
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        }}>
+          <span style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 14 }}>Live Chat</span>
+          <span style={{ fontFamily: t.fontMono, fontSize: 10, color: t.textDim }}>
+            batch · 200~500ms · ws/sub/live/{a.id}
+          </span>
+        </div>
+        <div ref={listRef} style={{
+          flex: 1, overflowY: 'auto', padding: '10px 14px',
+          display: 'flex', flexDirection: 'column', gap: 6,
+        }}>
+          {messages.map(msg => {
+            const isArtist = msg.t === 'artist';
+            const isMe = msg.t === 'me';
+            return (
+              <div key={msg.id} style={{
+                display: 'flex', gap: 8, alignItems: 'flex-start',
+                fontSize: 13, lineHeight: 1.4,
+                animation: 'connectfin-chatin 240ms ease-out',
+              }}>
+                <span style={{
+                  fontWeight: isArtist ? 800 : 700, fontSize: 12,
+                  color: isArtist ? t.accent : isMe ? t.accent2 : t.textDim,
+                  flexShrink: 0, maxWidth: 100, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {isArtist && '⭐ '}{msg.u}
+                </span>
+                <span style={{ color: t.text, wordBreak: 'break-word', flex: 1 }}>{msg.m}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div style={{
+          padding: '8px 12px', borderTop: `1px solid ${t.line}`,
+          display: 'flex', gap: 8, alignItems: 'center',
+        }}>
+          <input
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && send()}
+            placeholder="메시지 보내기 · 금칙어 필터링됨"
+            style={{
+              flex: 1, padding: '10px 14px', borderRadius: 20,
+              border: `1px solid ${t.line}`, background: t.surface, color: t.text,
+              fontSize: 13, fontFamily: t.font,
+            }}
+          />
+          <button onClick={send} style={{
+            width: 38, height: 38, borderRadius: '50%', border: 'none',
+            background: t.gradient, color: '#fff', fontSize: 16, cursor: 'pointer',
+          }}>→</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DMListScreen({ t, onOpenDM }) {
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
+      <div style={{ padding: '0 20px 12px', display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <div>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.8 }}>Messages</div>
+          <div style={{ fontSize: 12, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+            4 rooms · 3 active subs
+          </div>
+        </div>
+        <div style={{
+          padding: '4px 10px', borderRadius: 20, background: t.chip,
+          fontSize: 11, fontWeight: 700, color: t.accent, fontFamily: t.fontMono,
+        }}>+ 구독권</div>
+      </div>
+
+      <div style={{ padding: '0 12px' }}>
+        {DM_THREADS.map(th => {
+          const a = ARTISTS.find(x => x.id === th.artistId);
+          return (
+            <button key={th.id} onClick={() => onOpenDM(th.id)} style={{
+              width: '100%', display: 'flex', gap: 12, alignItems: 'center',
+              padding: '12px 12px', background: 'transparent', border: 'none',
+              cursor: 'pointer', textAlign: 'left', borderRadius: 14,
+              opacity: th.subscribed ? 1 : 0.6,
+            }}>
+              <div style={{ position: 'relative' }}>
+                <ArtistAvatar artist={a} size={52} t={t}/>
+                {th.online && <div style={{
+                  position: 'absolute', bottom: 2, right: 2, width: 12, height: 12,
+                  borderRadius: '50%', background: t.ok, border: `2px solid ${t.bg}`,
+                }}/>}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    <span style={{ fontWeight: 800, fontSize: 15, color: t.text }}>{th.name}</span>
+                    <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 6px', borderRadius: 4, background: t.chip, color: t.accent, fontFamily: t.fontMono }}>
+                      {th.group}
+                    </span>
+                  </div>
+                  <span style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono }}>{th.time}</span>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 2 }}>
+                  <span style={{
+                    fontSize: 13, color: th.subscribed ? t.textDim : t.textMuted,
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200,
+                    fontStyle: !th.subscribed ? 'italic' : 'normal',
+                  }}>
+                    {th.last}
+                  </span>
+                  {th.unread > 0 && (
+                    <div style={{
+                      minWidth: 20, height: 20, padding: '0 6px', borderRadius: 10,
+                      background: t.hot, color: '#fff', fontSize: 11, fontWeight: 800,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    }}>{th.unread}</div>
+                  )}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{
+        margin: '20px 20px 0', padding: 16, borderRadius: 18,
+        background: t.gradient, color: '#fff',
+      }}>
+        <div style={{ fontSize: 11, fontFamily: t.fontMono, letterSpacing: 0.5, opacity: 0.9 }}>DM SUBSCRIPTION</div>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 18, fontWeight: 800, marginTop: 2 }}>
+          NOIR7의 DM을 잠금해제하세요
+        </div>
+        <div style={{ fontSize: 12, marginTop: 4, opacity: 0.9 }}>월 15 Jelly · 답장 전 최대 3개 메시지</div>
+      </div>
+    </div>
+  );
+}
+
+function DMThreadScreen({ t, theme, threadId, onBack }) {
+  const th = DM_THREADS.find(x => x.id === threadId) || DM_THREADS[0];
+  const a = ARTISTS.find(x => x.id === th.artistId);
+  const [messages, setMessages] = React.useState([
+    { id: 1, from: 'artist', m: '안녕! 오늘 하루도 수고 많았지 🫶', time: '20:14' },
+    { id: 2, from: 'artist', m: '[[name]]아 요즘 어떻게 지내?', time: '20:14' },
+    { id: 3, from: 'me', m: '언니 저 오늘 시험 끝났어요!!! 진짜 살 거 같아요 😭', time: '20:16' },
+    { id: 4, from: 'artist', m: '오~ 수고했어!! 이제 좀 쉬어', time: '20:17' },
+    { id: 5, from: 'me', m: '라이브 매일 챙겨볼게요 🙌', time: '20:17' },
+    { id: 6, from: 'artist', m: '오늘도 고마워 ⭐️', time: '방금' },
+  ]);
+  const [input, setInput] = React.useState('');
+  const [remaining, setRemaining] = React.useState(2); // 3 - already sent 1
+  const nextId = React.useRef(100);
+  const listRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+  }, [messages]);
+
+  const send = () => {
+    if (!input.trim() || remaining <= 0) return;
+    setMessages(m => [...m, { id: nextId.current++, from: 'me', m: input, time: '방금' }]);
+    setInput('');
+    setRemaining(r => r - 1);
+  };
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', background: t.bg }}>
+      {/* Header */}
+      <div style={{
+        paddingTop: 54, padding: '54px 14px 12px', display: 'flex', alignItems: 'center', gap: 10,
+        borderBottom: `1px solid ${t.line}`, background: t.bg,
+      }}>
+        <button onClick={onBack} style={{
+          background: 'transparent', border: 'none', color: t.text, fontSize: 20, cursor: 'pointer', padding: 4,
+        }}>←</button>
+        <ArtistAvatar artist={a} size={36} t={t}/>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontWeight: 800, fontSize: 15 }}>{th.name}</span>
+            <span style={{ fontSize: 9, fontWeight: 800, padding: '2px 5px', borderRadius: 3, background: t.gradient, color: '#fff' }}>ARTIST ✓</span>
+          </div>
+          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+            {th.online ? '● 온라인' : '오프라인'} · 구독 {remaining === 3 ? '~15일' : '만료 12일'}
+          </div>
+        </div>
+        <div style={{ color: t.textDim, fontSize: 18 }}>⋯</div>
+      </div>
+
+      {/* Messages */}
+      <div ref={listRef} style={{
+        flex: 1, overflowY: 'auto', padding: '16px 14px',
+        display: 'flex', flexDirection: 'column', gap: 8,
+      }}>
+        <div style={{
+          alignSelf: 'center', padding: '4px 10px', borderRadius: 10,
+          background: t.surface2, fontSize: 10, color: t.textMuted, fontFamily: t.fontMono,
+        }}>DM · 암호화된 1:1 채널</div>
+        {messages.map(msg => {
+          const isMe = msg.from === 'me';
+          return (
+            <div key={msg.id} style={{
+              display: 'flex', flexDirection: isMe ? 'row-reverse' : 'row',
+              alignItems: 'flex-end', gap: 6,
+            }}>
+              {!isMe && <ArtistAvatar artist={a} size={26} t={t}/>}
+              <div style={{
+                maxWidth: '72%', padding: '10px 13px',
+                borderRadius: isMe ? '18px 18px 4px 18px' : '18px 18px 18px 4px',
+                background: isMe ? t.gradient : t.surface,
+                color: isMe ? '#fff' : t.text,
+                fontSize: 13.5, lineHeight: 1.45,
+                border: !isMe ? `1px solid ${t.line}` : 'none',
+              }}>
+                {msg.m}
+              </div>
+              <span style={{ fontSize: 9, color: t.textMuted, fontFamily: t.fontMono, marginBottom: 2 }}>{msg.time}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Rate-limit hint */}
+      {remaining <= 1 && (
+        <div style={{
+          padding: '6px 14px', fontSize: 11, color: t.textMuted, textAlign: 'center',
+          fontFamily: t.fontMono, background: t.surface2,
+        }}>
+          ⓘ 아티스트 답장 전 최대 3개까지 · 남음 {remaining}개
+        </div>
+      )}
+
+      {/* Input */}
+      <div style={{
+        padding: '10px 12px 28px', borderTop: `1px solid ${t.line}`,
+        display: 'flex', gap: 8, alignItems: 'center',
+      }}>
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && send()}
+          disabled={remaining <= 0}
+          placeholder={remaining <= 0 ? '메시지 제한에 도달했어요' : '메시지를 입력하세요'}
+          style={{
+            flex: 1, padding: '12px 16px', borderRadius: 22,
+            border: `1px solid ${t.line}`, background: t.surface, color: t.text,
+            fontSize: 14, fontFamily: t.font,
+          }}
+        />
+        <button onClick={send} disabled={remaining <= 0} style={{
+          width: 42, height: 42, borderRadius: '50%', border: 'none',
+          background: remaining > 0 ? t.gradient : t.surface2,
+          color: '#fff', fontSize: 18, cursor: remaining > 0 ? 'pointer' : 'not-allowed',
+        }}>↑</button>
+      </div>
+    </div>
+  );
+}
+
+function CommunityScreen({ t, artistId, onBack }) {
+  const a = ARTISTS.find(x => x.id === artistId) || ARTISTS[0];
+  const [tab, setTab] = React.useState('fan');
+  const posts = FEED_POSTS.filter(p => p.artistId === a.id);
+
+  return (
+    <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
+      <div style={{ padding: '0 20px 14px' }}>
+        <button onClick={onBack} style={{
+          background: 'transparent', border: 'none', color: t.text, fontSize: 20, cursor: 'pointer',
+          padding: 0, marginBottom: 8,
+        }}>←</button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <ArtistAvatar artist={a} size={44} t={t}/>
+          <div>
+            <div style={{ fontFamily: t.fontDisplay, fontSize: 24, fontWeight: 800, letterSpacing: -0.6 }}>{a.name}</div>
+            <div style={{ fontSize: 12, color: t.textDim, fontFamily: t.fontMono }}>Fan Community</div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{
+        display: 'flex', gap: 4, padding: '0 16px', borderBottom: `1px solid ${t.line}`,
+      }}>
+        {['fan','artist','media','notice'].map(k => (
+          <button key={k} onClick={() => setTab(k)} style={{
+            flex: 1, padding: '10px 0', background: 'transparent', border: 'none',
+            color: tab === k ? t.text : t.textDim,
+            fontWeight: tab === k ? 800 : 600, fontSize: 13, cursor: 'pointer',
+            borderBottom: tab === k ? `2px solid ${t.accent}` : '2px solid transparent',
+            fontFamily: t.font, textTransform: 'uppercase', letterSpacing: 0.5,
+          }}>{k}</button>
+        ))}
+      </div>
+
+      <div style={{ padding: '12px 16px' }}>
+        {/* Composer */}
+        <div style={{
+          display: 'flex', gap: 10, padding: 12, borderRadius: 16,
+          background: t.surface, border: `1px solid ${t.line}`, marginBottom: 12,
+        }}>
+          <div style={{ width: 36, height: 36, borderRadius: '50%', background: t.chip,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 800, color: t.accent, fontSize: 14 }}>나</div>
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', color: t.textMuted, fontSize: 13 }}>
+            {tab === 'fan' ? '팬 포스트를 작성해 보세요…' : tab === 'artist' ? 'Fan Letter 작성 (Membership 필요)' : '#해시태그로 공유'}
+          </div>
+          <button style={{
+            padding: '6px 12px', borderRadius: 10, border: 'none',
+            background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 11, cursor: 'pointer',
+          }}>POST</button>
+        </div>
+
+        {/* Posts */}
+        {(tab === 'fan' ? [
+          { author: '별빛모아', role: 'FAN', body: '오늘 데뷔 2주년 축하해요! 2년 동안 함께해서 정말 행복했어요 💜', likes: 4812, comments: 428, img: true },
+          { author: 'luminous', role: 'FAN', body: '@YUNA 언니 헤어 진짜 대박이에요... 오늘 라이브 꼭 챙겨볼게요!!', likes: 892, comments: 67 },
+          { author: 'starling', role: 'FAN', body: '#lumen8_prism 해시태그 트렌딩 중 🔥', likes: 1_204, comments: 88, tag: true },
+        ] : tab === 'artist' ? posts.filter(p => p.type === 'artist').map(p => ({ author: p.author, role: 'ARTIST', body: p.body, likes: p.likes, comments: p.comments, artist: true })) : [
+          { author: '루멘기록', role: 'FAN', body: '어제 앵콜 무대 팬캠 공유합니다 🎬', likes: 2110, comments: 190, media: true },
+        ]).map((p, i) => (
+          <div key={i} style={{
+            padding: 14, borderRadius: 16, background: t.surface,
+            border: p.artist ? `1px solid ${t.accent}44` : `1px solid ${t.line}`,
+            marginBottom: 10,
+          }}>
+            <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 8 }}>
+              <div style={{ width: 32, height: 32, borderRadius: '50%',
+                background: p.artist ? t.gradient : t.chip,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: p.artist ? '#fff' : t.accent, fontWeight: 800, fontSize: 12,
+              }}>{p.author.slice(0,2)}</div>
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                  <span style={{ fontWeight: 700, fontSize: 13 }}>{p.author}</span>
+                  {p.artist && <span style={{ fontSize: 9, fontWeight: 800, padding: '2px 5px', borderRadius: 3, background: t.gradient, color: '#fff' }}>✓</span>}
+                </div>
+                <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono }}>{p.role} · 방금 전</div>
+              </div>
+            </div>
+            <div style={{ fontSize: 13.5, lineHeight: 1.5, color: t.text }}>{p.body}</div>
+            {p.img && <div style={{ marginTop: 10 }}><MediaPlaceholder artist={a} kind="IMAGE" label="Anniversary cake 🎂" aspect="4/3" t={t} radius={12}/></div>}
+            {p.media && <div style={{ marginTop: 10 }}><MediaPlaceholder artist={a} kind="VIDEO" label="Encore fancam" aspect="16/9" t={t} radius={12}/></div>}
+            {p.tag && (
+              <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+                {['#lumen8_prism','#yuna','#comeback'].map(tg => (
+                  <span key={tg} style={{
+                    fontSize: 11, padding: '3px 10px', borderRadius: 12, background: t.chip, color: t.accent, fontWeight: 700,
+                    fontFamily: t.fontMono,
+                  }}>{tg}</span>
+                ))}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 18, marginTop: 10, fontSize: 12, color: t.textDim }}>
+              <span>♡ {p.likes?.toLocaleString()}</span>
+              <span>💬 {p.comments?.toLocaleString()}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { LiveScreen, DMListScreen, DMThreadScreen, CommunityScreen });

--- a/src/main/resources/static/components/tokens.jsx
+++ b/src/main/resources/static/components/tokens.jsx
@@ -1,0 +1,331 @@
+// Connectfin — design tokens, shared placeholder components, data fixtures
+// Two themes: "dark" (neon) and "y2k" (pop).
+
+const THEMES = {
+  dark: {
+    name: 'Dark Neon',
+    bg: '#0A0B10',
+    bg2: '#12141C',
+    surface: '#181A24',
+    surface2: '#1F2230',
+    line: 'rgba(255,255,255,0.08)',
+    lineStrong: 'rgba(255,255,255,0.14)',
+    text: '#F5F6FA',
+    textDim: 'rgba(245,246,250,0.62)',
+    textMuted: 'rgba(245,246,250,0.38)',
+    accent: '#8B5CFF',     // violet
+    accent2: '#22D3EE',    // cyan
+    hot: '#FF3D7A',
+    ok: '#34E4A8',
+    chip: 'rgba(139,92,255,0.16)',
+    gradient: 'linear-gradient(135deg, #8B5CFF 0%, #22D3EE 100%)',
+    liveGradient: 'linear-gradient(135deg, #FF3D7A 0%, #FF8A3D 100%)',
+    navBg: 'rgba(10,11,16,0.82)',
+    font: '"Pretendard Variable", Pretendard, -apple-system, system-ui, sans-serif',
+    fontDisplay: '"Space Grotesk", "Pretendard Variable", system-ui, sans-serif',
+    fontMono: '"JetBrains Mono", ui-monospace, monospace',
+  },
+  y2k: {
+    name: 'Y2K Pop',
+    bg: '#FFE9F3',
+    bg2: '#F3DEFF',
+    surface: '#FFFFFF',
+    surface2: '#FFF4FA',
+    line: 'rgba(90,20,120,0.10)',
+    lineStrong: 'rgba(90,20,120,0.22)',
+    text: '#2A0E48',
+    textDim: 'rgba(42,14,72,0.62)',
+    textMuted: 'rgba(42,14,72,0.42)',
+    accent: '#FF3DA1',     // hot pink
+    accent2: '#7B2CFF',    // violet
+    hot: '#FF5B2E',
+    ok: '#2EEBC2',
+    chip: 'rgba(255,61,161,0.14)',
+    gradient: 'linear-gradient(135deg, #FF3DA1 0%, #7B2CFF 50%, #2EEBC2 100%)',
+    liveGradient: 'linear-gradient(135deg, #FF3DA1 0%, #FF8A3D 100%)',
+    navBg: 'rgba(255,233,243,0.85)',
+    font: '"Space Grotesk", "Pretendard Variable", system-ui, sans-serif',
+    fontDisplay: '"Space Grotesk", system-ui, sans-serif',
+    fontMono: '"JetBrains Mono", ui-monospace, monospace',
+  },
+};
+
+// Artists — multi-genre (K-pop, J-pop, rock, utaite, hip-hop, VTuber-adjacent)
+const ARTISTS = [
+  { id: 1, name: 'LUMEN8', stage: '루멘에잇', genre: 'K-POP · 걸그룹', color1: '#FF3DA1', color2: '#7B2CFF', members: 5, live: true, viewers: 142_839, followers: '2.4M' },
+  { id: 2, name: 'Kagerō', stage: 'カゲロウ', genre: 'J-ROCK · 밴드', color1: '#0F4C81', color2: '#E63946', members: 4, live: false, viewers: 0, followers: '890K' },
+  { id: 3, name: 'NOIR7', stage: '누아르세븐', genre: 'K-POP · 보이그룹', color1: '#111111', color2: '#D4AF37', members: 7, live: false, viewers: 0, followers: '3.1M' },
+  { id: 4, name: 'hanabi*', stage: '하나비', genre: '우타이테 · 솔로', color1: '#FF8A3D', color2: '#FFD23D', members: 1, live: true, viewers: 58_241, followers: '412K' },
+  { id: 5, name: 'Velvet Static', stage: '벨벳 스태틱', genre: 'INDIE ROCK · 밴드', color1: '#5B1D4E', color2: '#C41E3A', members: 4, live: false, viewers: 0, followers: '124K' },
+  { id: 6, name: 'ORBITAL', stage: '오비탈', genre: 'HIPHOP · 크루', color1: '#1E1E1E', color2: '#22D3EE', members: 3, live: false, viewers: 0, followers: '678K' },
+];
+
+// Home feed posts
+const FEED_POSTS = [
+  { id: 101, artistId: 1, type: 'artist', author: 'YUNA', authorRole: 'LUMEN8', time: '방금 전', body: '오늘 라이브 올게🌙 궁금한 거 댓글로 남겨주면 답해줄게~!', likes: 48_291, comments: 3124, pinned: true },
+  { id: 102, artistId: 4, type: 'artist', author: 'hanabi*', authorRole: 'hanabi*', time: '2분 전', body: '새 커버곡 녹음 중... 힌트 한 조각 📼', likes: 11_204, comments: 892 },
+  { id: 103, artistId: 1, type: 'fan', author: '별빛모아', authorRole: 'FAN', time: '5분 전', body: '어제 팬미팅 영상 돌려보는 중... 진짜 잊을 수 없을 거 같아 🥹', likes: 1_842, comments: 214 },
+  { id: 104, artistId: 3, type: 'artist', author: 'KAI', authorRole: 'NOIR7', time: '12분 전', body: '연습실. 오늘도 수고했다 세븐츠.', likes: 62_114, comments: 4891 },
+  { id: 105, artistId: 2, type: 'fan', author: '螢火', authorRole: 'FAN', time: '18분 전', body: '어제 라이브 셋리스트 진짜 미쳤음... Encore에서 운 사람 나뿐?', likes: 488, comments: 93 },
+];
+
+// DM threads
+const DM_THREADS = [
+  { id: 1, artistId: 1, name: 'YUNA', group: 'LUMEN8', last: '오늘도 고마워 ⭐️', time: '방금', unread: 2, online: true, subscribed: true },
+  { id: 2, artistId: 4, name: 'hanabi*', group: 'hanabi*', last: '[[name]]아 들어봤어?!', time: '3분', unread: 1, online: true, subscribed: true },
+  { id: 3, artistId: 1, name: 'RIN', group: 'LUMEN8', last: '연습 끝났다~', time: '1시간', unread: 0, online: false, subscribed: true },
+  { id: 4, artistId: 3, name: 'KAI', group: 'NOIR7', time: '어제', last: '구독 필요 · 15 젤리/월', unread: 0, online: false, subscribed: false },
+];
+
+// sample seed chat lines for live
+const LIVE_SEEDS = [
+  { u: '루미에르', m: '언니 목소리 오늘 진짜 좋다🫶', t: 'fan' },
+  { u: 'starseed_02', m: '카메라 좀 더 가까이!!' },
+  { u: '별빛모아', m: 'YUNAAAAAA' },
+  { u: 'moonlit', m: '다음곡 "Prism" 해줘요 제발' },
+  { u: 'YUNA', m: '다들 저녁 먹었어?', t: 'artist' },
+  { u: 'cometkid', m: 'ㅠㅠㅠㅠㅠㅠ 사랑해요' },
+  { u: 'drift_ko', m: '지금 들어옴 놓친거 많음??' },
+  { u: '푸른새벽', m: 'bgm 볼륨 ↑' },
+  { u: 'velvetfan', m: '오늘 의상 역대급' },
+  { u: 'utanoko', m: 'ハナビちゃん 応援してる〜' },
+  { u: 'mika_j', m: '오빠 생일 축하해!!' },
+  { u: 'neonpop', m: '🩵🩵🩵🩵' },
+  { u: 'LUMINARY', m: '실화냐;; 머리 너무 예뻐' },
+  { u: 'rainpeach', m: '첫 라이브인데 이게 뭐람... 너무 좋음' },
+];
+
+// Media gallery
+const MEDIA = [
+  { id: 1, artistId: 1, kind: 'video', title: '[MV] LUMEN8 — Prism (Official)', duration: '3:42', views: '14M', daysAgo: 7 },
+  { id: 2, artistId: 1, kind: 'photo', title: '백스테이지 컷 #42', daysAgo: 1 },
+  { id: 3, artistId: 4, kind: 'video', title: 'hanabi* covers「アイドル」', duration: '4:18', views: '2.1M', daysAgo: 3 },
+  { id: 4, artistId: 3, kind: 'video', title: 'NOIR7 Dance Practice — MIRROR', duration: '5:02', views: '8.4M', daysAgo: 14 },
+  { id: 5, artistId: 2, kind: 'photo', title: 'Tour Final — Osaka', daysAgo: 21 },
+  { id: 6, artistId: 5, kind: 'video', title: 'Velvet Static — Live at CLUB FF', duration: '3:12', views: '48K', daysAgo: 30 },
+];
+
+// ————————————— Shared UI primitives —————————————
+
+// Artist avatar — no SVG portraits, just layered gradient placeholders
+function ArtistAvatar({ artist, size = 44, live = false, ring = false, t }) {
+  const s = size;
+  const stripe = `repeating-linear-gradient(135deg, ${artist.color1} 0 10px, ${artist.color2} 10px 20px)`;
+  return (
+    <div style={{ position: 'relative', width: s, height: s, flexShrink: 0 }}>
+      {ring && (
+        <div style={{
+          position: 'absolute', inset: -3, borderRadius: '50%',
+          background: live ? t.liveGradient : t.gradient,
+          padding: 2,
+        }}>
+          <div style={{ width: '100%', height: '100%', borderRadius: '50%', background: t.bg }} />
+        </div>
+      )}
+      <div style={{
+        position: 'absolute', inset: ring ? 1 : 0,
+        borderRadius: '50%', overflow: 'hidden',
+        background: stripe,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontFamily: t.fontDisplay, fontWeight: 800,
+        color: '#fff', fontSize: s * 0.32,
+        letterSpacing: -0.5,
+        boxShadow: ring ? 'none' : `0 0 0 1px ${t.line} inset`,
+      }}>
+        {artist.name.slice(0, 2).toUpperCase()}
+      </div>
+      {live && !ring && (
+        <div style={{
+          position: 'absolute', bottom: -2, right: -2,
+          width: 14, height: 14, borderRadius: '50%',
+          background: t.hot, border: `2px solid ${t.bg}`,
+          boxShadow: `0 0 10px ${t.hot}`,
+        }} />
+      )}
+    </div>
+  );
+}
+
+// Media placeholder — striped block with mono label
+function MediaPlaceholder({ artist, label, aspect = '16/9', t, kind = 'video', radius = 18 }) {
+  return (
+    <div style={{
+      aspectRatio: aspect, width: '100%',
+      borderRadius: radius, overflow: 'hidden', position: 'relative',
+      background: `repeating-linear-gradient(45deg, ${artist.color1} 0 14px, ${artist.color2} 14px 28px)`,
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: `linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,0.55) 100%)`,
+      }} />
+      <div style={{
+        position: 'absolute', top: 10, left: 10,
+        fontFamily: t.fontMono, fontSize: 10, letterSpacing: 0.5,
+        padding: '4px 8px', borderRadius: 6,
+        background: 'rgba(0,0,0,0.45)', color: '#fff',
+        textTransform: 'uppercase',
+      }}>{kind} · {artist.name}</div>
+      <div style={{
+        position: 'absolute', bottom: 10, left: 12, right: 12,
+        color: '#fff', fontFamily: t.fontDisplay, fontWeight: 700,
+        fontSize: 14, textShadow: '0 1px 4px rgba(0,0,0,0.5)',
+      }}>{label}</div>
+      {kind === 'video' && (
+        <div style={{
+          position: 'absolute', top: '50%', left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: 48, height: 48, borderRadius: '50%',
+          background: 'rgba(255,255,255,0.92)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div style={{
+            width: 0, height: 0, marginLeft: 3,
+            borderTop: '9px solid transparent',
+            borderBottom: '9px solid transparent',
+            borderLeft: '14px solid #111',
+          }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Tab bar (5 icons, bottom)
+function TabBar({ current, onNav, t, theme }) {
+  const tabs = [
+    { k: 'home', label: '홈', icon: '⌂' },
+    { k: 'live', label: '라이브', icon: '●' },
+    { k: 'media', label: '미디어', icon: '▤' },
+    { k: 'dm', label: 'DM', icon: '✉' },
+    { k: 'me', label: '마이', icon: '◐' },
+  ];
+  return (
+    <div style={{
+      position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 40,
+      paddingBottom: 28, paddingTop: 8, paddingLeft: 8, paddingRight: 8,
+      background: t.navBg,
+      backdropFilter: 'blur(24px) saturate(180%)',
+      WebkitBackdropFilter: 'blur(24px) saturate(180%)',
+      borderTop: `1px solid ${t.line}`,
+      display: 'flex', justifyContent: 'space-around',
+    }}>
+      {tabs.map(tab => {
+        const active = current === tab.k;
+        return (
+          <button key={tab.k} onClick={() => onNav(tab.k)} style={{
+            flex: 1, background: 'transparent', border: 'none',
+            padding: '6px 0', cursor: 'pointer',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3,
+            fontFamily: t.font,
+          }}>
+            <div style={{
+              fontSize: tab.k === 'live' ? 10 : 22,
+              color: active ? t.text : t.textMuted,
+              lineHeight: 1,
+              display: 'flex', alignItems: 'center', gap: 4,
+            }}>
+              {tab.k === 'live' ? (
+                <span style={{
+                  width: 8, height: 8, borderRadius: '50%',
+                  background: active ? t.hot : t.textMuted,
+                  boxShadow: active ? `0 0 8px ${t.hot}` : 'none',
+                }} />
+              ) : tab.icon}
+              {tab.k === 'live' && <span style={{ fontSize: 10, fontWeight: 700 }}>LIVE</span>}
+            </div>
+            <span style={{
+              fontSize: 10, fontWeight: active ? 700 : 500,
+              color: active ? t.text : t.textMuted,
+              letterSpacing: -0.2,
+            }}>{tab.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Status bar (light/dark aware)
+function StatusBar({ dark, t }) {
+  const c = dark ? '#fff' : t.text;
+  return (
+    <div style={{
+      position: 'absolute', top: 0, left: 0, right: 0, zIndex: 50,
+      height: 54, display: 'flex', alignItems: 'center',
+      padding: '12px 28px 0', justifyContent: 'space-between',
+      pointerEvents: 'none',
+    }}>
+      <span style={{
+        fontFamily: '-apple-system, system-ui', fontWeight: 700,
+        fontSize: 16, color: c,
+      }}>9:41</span>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+        <svg width="17" height="11" viewBox="0 0 17 11"><rect x="0" y="6" width="3" height="4" rx="0.7" fill={c}/><rect x="4.5" y="4" width="3" height="6" rx="0.7" fill={c}/><rect x="9" y="2" width="3" height="8" rx="0.7" fill={c}/><rect x="13.5" y="0" width="3" height="10" rx="0.7" fill={c}/></svg>
+        <svg width="15" height="11" viewBox="0 0 15 11"><path d="M7.5 3C9.5 3 11.3 3.8 12.6 5.1L13.6 4.1C12 2.5 9.9 1.5 7.5 1.5C5.1 1.5 3 2.5 1.4 4.1L2.4 5.1C3.7 3.8 5.5 3 7.5 3Z" fill={c}/><circle cx="7.5" cy="9" r="1.3" fill={c}/></svg>
+        <div style={{
+          width: 24, height: 11, border: `1px solid ${c}`, borderRadius: 3, position: 'relative',
+          opacity: 0.85,
+        }}>
+          <div style={{ position: 'absolute', inset: 1, width: '72%', background: c, borderRadius: 1 }}/>
+          <div style={{ position: 'absolute', right: -3, top: 3, width: 2, height: 4, background: c, borderRadius: 1 }}/>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Dynamic-island-style top for dark phone
+function DynamicIsland() {
+  return (
+    <div style={{
+      position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+      width: 118, height: 34, borderRadius: 22, background: '#000', zIndex: 60,
+    }}/>
+  );
+}
+
+// Phone shell
+function Phone({ children, theme, t, width = 390, height = 844 }) {
+  return (
+    <div style={{
+      width, height, borderRadius: 54, overflow: 'hidden',
+      position: 'relative', background: t.bg,
+      boxShadow: '0 50px 120px rgba(0,0,0,0.45), 0 0 0 10px #111, 0 0 0 11px #333',
+      color: t.text, fontFamily: t.font,
+    }}>
+      <DynamicIsland/>
+      <StatusBar dark={theme === 'dark'} t={t}/>
+      {children}
+      <div style={{
+        position: 'absolute', bottom: 8, left: 0, right: 0,
+        display: 'flex', justifyContent: 'center', zIndex: 80, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 134, height: 5, borderRadius: 100,
+          background: theme === 'dark' ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.3)',
+        }}/>
+      </div>
+    </div>
+  );
+}
+
+// Infinite logo mark (stylised ∞)
+function Infinity8({ size = 28, color, color2, stroke = 6 }) {
+  return (
+    <svg width={size} height={size * 0.55} viewBox="0 0 100 56" fill="none">
+      <defs>
+        <linearGradient id={`infg-${color.replace('#','')}`} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor={color}/>
+          <stop offset="100%" stopColor={color2 || color}/>
+        </linearGradient>
+      </defs>
+      <path d="M 28 28 C 28 10, 8 10, 8 28 S 28 46, 28 28 C 28 10, 72 46, 72 28 S 92 10, 92 28 S 72 46, 72 28 C 72 10, 28 46, 28 28 Z"
+        stroke={`url(#infg-${color.replace('#','')})`} strokeWidth={stroke} strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
+Object.assign(window, {
+  THEMES, ARTISTS, FEED_POSTS, DM_THREADS, LIVE_SEEDS, MEDIA,
+  ArtistAvatar, MediaPlaceholder, TabBar, StatusBar, DynamicIsland, Phone, Infinity8,
+});

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,784 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Connectfin — Fan Platform Prototype</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.css">
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; min-height: 100vh; background: #0A0B10; font-family: 'Pretendard Variable', system-ui, sans-serif; }
+  body { overflow-x: hidden; }
+  button { font-family: inherit; }
+  input, textarea { font-family: inherit; outline: none; }
+  input::placeholder { color: rgba(128,128,128,0.6); }
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  @keyframes connectfin-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.55; transform: scale(0.85); } }
+  @keyframes connectfin-shimmer { 0% { transform: translateX(0) translateY(0); } 100% { transform: translateX(-48px) translateY(-48px); } }
+  @keyframes connectfin-float { 0% { transform: translateY(0) scale(0.8); opacity: 0; } 15% { opacity: 1; } 100% { transform: translateY(-220px) scale(1.1); opacity: 0; } }
+  @keyframes connectfin-chatin { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes connectfin-fadein { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes tweak-hint-pulse { 0%, 100% { opacity: 0.2; } 50% { opacity: 0.55; } }
+</style>
+</head>
+<body>
+
+<div id="root"></div>
+
+<template id="__bundler_thumbnail">
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7B2CFF"/>
+      <stop offset="100%" stop-color="#FF3DA1"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="36" fill="url(#bg)"/>
+  <g transform="translate(100 100)" stroke="#fff" stroke-width="9" fill="none" stroke-linecap="round">
+    <path d="M-32 0 C-32 -18 -14 -18 -14 0 C-14 18 14 18 14 0 C14 -18 32 -18 32 0 C32 18 14 18 14 0 C14 -18 -14 -18 -14 0 C-14 18 -32 18 -32 0 Z"/>
+  </g>
+  <text x="100" y="170" font-family="system-ui, sans-serif" font-size="16" font-weight="800" fill="#fff" text-anchor="middle" letter-spacing="2">CONNECTFIN</text>
+</svg>
+</template>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7/bundles/stomp.umd.min.js"></script>
+
+<script type="text/babel" src="components/tokens.jsx"></script>
+<script type="text/babel" src="components/api-client.jsx"></script>
+<script type="text/babel" src="components/desktop-data.jsx"></script>
+<script type="text/babel" src="components/screens-main.jsx"></script>
+<script type="text/babel" src="components/screens-realtime.jsx"></script>
+<script type="text/babel" src="components/screens-raffle.jsx"></script>
+<script type="text/babel" src="components/desktop-shell.jsx"></script>
+<script type="text/babel" src="components/desktop-profile.jsx"></script>
+<script type="text/babel" src="components/desktop-global.jsx"></script>
+<script type="text/babel" src="components/desktop-dm.jsx"></script>
+
+<script type="text/babel" data-presets="react">
+const TWEAKS = /*EDITMODE-BEGIN*/{
+  "theme": "dark",
+  "liveOn": true,
+  "simSpeed": 0.5,
+  "viewMode": "mobile",
+  "accentHue": 150,
+  "desktopView": false
+}/*EDITMODE-END*/;
+
+function App() {
+  const [tweaks, setTweaks] = React.useState(() => {
+    try { return { ...TWEAKS, ...(JSON.parse(localStorage.getItem('connectfin_tweaks') || '{}')) }; }
+    catch { return TWEAKS; }
+  });
+  const [showTweaks, setShowTweaks] = React.useState(false);
+
+  // Global view (for desktop)
+  const [globalView, setGlobalView] = React.useState('home'); // home | artist | jelly | shop | live | dm
+  const [artistId, setArtistId] = React.useState(1);
+  const [profileTab, setProfileTab] = React.useState('highlight');
+  // Mobile screen
+  const [mobileScreen, setMobileScreen] = React.useState('home');
+  const [threadId, setThreadId] = React.useState(1);
+  const [raffleId, setRaffleId] = React.useState(1);
+
+  // Auth state
+  const [authUser, setAuthUser] = React.useState(() => {
+    const token = window.ConnectfinAPI?.getToken();
+    return token ? { token } : null;
+  });
+  const [showLogin, setShowLogin] = React.useState(false);
+
+  const handleLogin = async (email, password) => {
+    try {
+      const res = await window.ConnectfinAPI.api('/api/auth/v1/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password }),
+      });
+      window.ConnectfinAPI.setToken(res.accessToken);
+      setAuthUser({ token: res.accessToken, email });
+      setShowLogin(false);
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  const handleLogout = () => {
+    window.ConnectfinAPI.clearToken();
+    setAuthUser(null);
+  };
+
+  React.useEffect(() => {
+    localStorage.setItem('connectfin_tweaks', JSON.stringify(tweaks));
+    try { window.parent.postMessage({ type: '__edit_mode_set_keys', edits: tweaks }, '*'); } catch {}
+  }, [tweaks]);
+
+  // Tweaks host protocol + keyboard shortcut
+  React.useEffect(() => {
+    const msgHandler = (e) => {
+      if (e.data?.type === '__activate_edit_mode') setShowTweaks(true);
+      if (e.data?.type === '__deactivate_edit_mode') setShowTweaks(false);
+    };
+    const keyHandler = (e) => {
+      if (e.shiftKey && (e.key === 'T' || e.key === 't')) {
+        const tag = (document.activeElement?.tagName || '').toLowerCase();
+        if (tag === 'input' || tag === 'textarea') return;
+        e.preventDefault();
+        setShowTweaks(v => !v);
+      }
+      if (e.key === 'Escape') setShowTweaks(false);
+    };
+    window.addEventListener('message', msgHandler);
+    window.addEventListener('keydown', keyHandler);
+    try { window.parent.postMessage({ type: '__edit_mode_available' }, '*'); } catch {}
+    return () => {
+      window.removeEventListener('message', msgHandler);
+      window.removeEventListener('keydown', keyHandler);
+    };
+  }, []);
+
+  const baseTheme = THEMES[tweaks.theme] || THEMES.dark;
+  const t = React.useMemo(() => {
+    if (tweaks.theme !== 'dark') return baseTheme;
+    const h = tweaks.accentHue;
+    const accent = `oklch(0.72 0.22 ${h})`;
+    const accent2 = `oklch(0.78 0.18 ${(h + 140) % 360})`;
+    return {
+      ...baseTheme,
+      accent, accent2,
+      chip: `oklch(0.72 0.22 ${h} / 0.18)`,
+      gradient: `linear-gradient(135deg, ${accent} 0%, ${accent2} 100%)`,
+    };
+  }, [baseTheme, tweaks.accentHue, tweaks.theme]);
+
+  // ── Desktop mode ──
+  if (tweaks.viewMode === 'desktop') {
+    const artist = ARTISTS.find(a => a.id === artistId) || ARTISTS[0];
+
+    const openArtist = (id) => { setArtistId(id); setGlobalView('artist'); setProfileTab('highlight'); };
+    const goLive = (id) => { setArtistId(id); setMobileScreen('live'); setGlobalView('live'); };
+    const openDM = () => { setGlobalView('dm'); };
+    const openMembership = () => { setTweaks(tw => ({ ...tw, viewMode: 'mobile' })); setMobileScreen('membership'); };
+
+    let body;
+    if (globalView === 'home') body = <DesktopHome t={t} theme={tweaks.theme} onArtistOpen={openArtist} onOpenLive={goLive} onNavGlobal={setGlobalView}/>;
+    else if (globalView === 'artist') body = <DesktopArtistProfile t={t} theme={tweaks.theme} artist={artist} tab={profileTab} onNavProfile={setProfileTab} onOpenLive={goLive} onOpenDM={openDM} onOpenMembership={openMembership}/>;
+    else if (globalView === 'jelly') body = <DesktopJellyShop t={t} theme={tweaks.theme}/>;
+    else if (globalView === 'shop') body = <DesktopShop t={t} theme={tweaks.theme}/>;
+    else if (globalView === 'live') body = <DesktopLiveViewer t={t} theme={tweaks.theme} artistId={artistId} speed={tweaks.simSpeed} liveOn={tweaks.liveOn} onExit={() => setGlobalView('artist')}/>;
+    else if (globalView === 'dm') body = <DesktopDMScreen t={t} theme={tweaks.theme} onExit={() => setGlobalView('home')}/>;
+
+    return (
+      <>
+        {showLogin && <LoginModal t={t} theme={tweaks.theme} onLogin={handleLogin} onClose={() => setShowLogin(false)}/>}
+        <DesktopShell t={t} theme={tweaks.theme}
+          activeArtist={globalView === 'artist' ? artist : null}
+          globalView={globalView}
+          profileTab={profileTab}
+          onNavGlobal={(v) => { setGlobalView(v); }}
+          onNavProfile={setProfileTab}
+          onArtistOpen={openArtist}
+          authUser={authUser}
+          onShowLogin={() => setShowLogin(true)}
+          onLogout={handleLogout}
+        >
+          {body}
+        </DesktopShell>
+        {globalView !== 'dm' && <DMFloatingShortcut t={t} theme={tweaks.theme} onOpenDM={openDM}/>}
+        <HiddenTweaksTrigger show={showTweaks} onShow={() => setShowTweaks(true)} t={t}/>
+        {showTweaks && <TweaksPanel tweaks={tweaks} setTweaks={setTweaks} t={t} theme={tweaks.theme} onClose={() => setShowTweaks(false)}/>}
+      </>
+    );
+  }
+
+  // ── Mobile mode ──
+  return <MobileApp
+    tweaks={tweaks} setTweaks={setTweaks} t={t} showTweaks={showTweaks} setShowTweaks={setShowTweaks}
+    screen={mobileScreen} setScreen={setMobileScreen}
+    artistId={artistId} setArtistId={setArtistId}
+    threadId={threadId} setThreadId={setThreadId}
+    raffleId={raffleId} setRaffleId={setRaffleId}
+    authUser={authUser}
+    onShowLogin={() => setShowLogin(true)}
+    onLogout={handleLogout}
+  />;
+}
+
+// ───────── DM Floating Shortcut (desktop) ─────────
+function DMFloatingShortcut({ t, theme, onOpenDM }) {
+  const [open, setOpen] = React.useState(false);
+  const threads = (typeof DM_THREADS !== 'undefined' ? DM_THREADS : []).slice(0, 4);
+  const unread = threads.reduce((sum, x) => sum + (x.unread || 0), 0);
+
+  return (
+    <>
+      {/* Backdrop for panel */}
+      {open && (
+        <div onClick={() => setOpen(false)} style={{
+          position: 'fixed', inset: 0, zIndex: 79,
+          background: 'transparent',
+        }}/>
+      )}
+
+      {/* Preview panel */}
+      {open && (
+        <div style={{
+          position: 'fixed', right: 24, bottom: 94, zIndex: 81,
+          width: 340,
+          background: theme === 'dark' ? 'rgba(18,20,28,0.97)' : 'rgba(255,255,255,0.98)',
+          color: t.text,
+          border: `1px solid ${t.lineStrong}`,
+          borderRadius: 16,
+          boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
+          backdropFilter: 'blur(24px)',
+          overflow: 'hidden',
+          animation: 'connectfin-fadein 160ms ease-out',
+        }}>
+          <div style={{
+            padding: '14px 18px',
+            borderBottom: `1px solid ${t.line}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          }}>
+            <div>
+              <div style={{ fontFamily: t.fontMono, fontSize: 10, letterSpacing: 1, color: t.textDim }}>DIRECT MESSAGE</div>
+              <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 16 }}>
+                아티스트와의 대화
+              </div>
+            </div>
+            <button onClick={() => setOpen(false)} style={{
+              background: 'transparent', border: 'none', color: t.textDim,
+              fontSize: 20, cursor: 'pointer', lineHeight: 1,
+            }}>×</button>
+          </div>
+
+          <div style={{ maxHeight: 340, overflowY: 'auto' }}>
+            {threads.length === 0 ? (
+              <div style={{ padding: '32px 20px', textAlign: 'center', color: t.textDim, fontSize: 13 }}>
+                아직 대화가 없어요
+              </div>
+            ) : threads.map(th => {
+              const artist = (typeof ARTISTS !== 'undefined' ? ARTISTS : []).find(a => a.id === th.artistId) || {};
+              return (
+                <div key={th.id} onClick={() => { setOpen(false); onOpenDM(); }} style={{
+                  display: 'flex', alignItems: 'center', gap: 12,
+                  padding: '12px 18px', cursor: 'pointer',
+                  borderBottom: `1px solid ${t.line}`,
+                }}
+                  onMouseEnter={e => e.currentTarget.style.background = theme === 'dark' ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)'}
+                  onMouseLeave={e => e.currentTarget.style.background = 'transparent'}
+                >
+                  <div style={{
+                    width: 42, height: 42, borderRadius: '50%', flexShrink: 0,
+                    background: artist.color1 && artist.color2
+                      ? `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`
+                      : t.gradient,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#fff', fontWeight: 800, fontSize: 13,
+                    position: 'relative',
+                  }}>
+                    {artist.name?.slice(0, 2) || '??'}
+                    {(th.unread || 0) > 0 && (
+                      <div style={{
+                        position: 'absolute', top: -2, right: -2,
+                        minWidth: 18, height: 18, borderRadius: 9,
+                        background: t.hot, color: '#fff',
+                        fontSize: 10, fontWeight: 800,
+                        display: 'flex', alignItems: 'center', justifyContent: 'center',
+                        padding: '0 5px',
+                        border: `2px solid ${theme === 'dark' ? '#121420' : '#fff'}`,
+                      }}>{th.unread}</div>
+                    )}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
+                      <div style={{ fontWeight: 700, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {artist.name}
+                        {th.subscribed && <span style={{ color: t.accent2, marginLeft: 4 }}>✓</span>}
+                      </div>
+                      <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono, flexShrink: 0 }}>
+                        {th.time || ''}
+                      </div>
+                    </div>
+                    <div style={{
+                      fontSize: 12, color: (th.unread || 0) > 0 ? t.text : t.textDim,
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      marginTop: 2, fontWeight: (th.unread || 0) > 0 ? 600 : 400,
+                    }}>
+                      {th.last || '대화 시작하기'}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <button onClick={() => { setOpen(false); onOpenDM(); }} style={{
+            width: '100%', padding: '14px 18px',
+            border: 'none', background: t.gradient, color: '#fff',
+            fontWeight: 800, fontSize: 13, cursor: 'pointer',
+            fontFamily: t.fontMono, letterSpacing: 0.5,
+          }}>
+            전체 DM 보기 →
+          </button>
+        </div>
+      )}
+
+      {/* Floating button */}
+      <button
+        onClick={() => setOpen(v => !v)}
+        aria-label="DM 바로가기"
+        style={{
+          position: 'fixed', right: 24, bottom: 24, zIndex: 82,
+          width: 58, height: 58, borderRadius: '50%',
+          border: 'none', cursor: 'pointer',
+          background: t.gradient,
+          boxShadow: open
+            ? `0 0 0 4px ${t.chip}, 0 16px 40px rgba(0,0,0,0.4)`
+            : '0 10px 30px rgba(0,0,0,0.35)',
+          color: '#fff',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          transition: 'all 200ms ease',
+          transform: open ? 'scale(0.94)' : 'scale(1)',
+        }}
+        onMouseEnter={e => { if (!open) e.currentTarget.style.transform = 'scale(1.06)'; }}
+        onMouseLeave={e => { if (!open) e.currentTarget.style.transform = 'scale(1)'; }}
+      >
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
+        </svg>
+        {unread > 0 && !open && (
+          <div style={{
+            position: 'absolute', top: -2, right: -2,
+            minWidth: 22, height: 22, borderRadius: 11,
+            background: t.hot, color: '#fff',
+            fontSize: 11, fontWeight: 800,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: '0 6px',
+            border: `2px solid ${theme === 'dark' ? '#0A0B10' : '#fff'}`,
+            fontFamily: t.fontMono,
+          }}>{unread > 99 ? '99+' : unread}</div>
+        )}
+      </button>
+    </>
+  );
+}
+
+// ───────── Hidden tweaks trigger ─────────
+function HiddenTweaksTrigger({ show, onShow, t }) {
+  const [hovered, setHovered] = React.useState(false);
+  if (show) return null;
+  return (
+    <div style={{
+      position: 'fixed', bottom: 10, left: 10, zIndex: 90,
+      padding: 8, cursor: 'pointer',
+    }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={onShow}
+      title="Shift+T to toggle Tweaks"
+    >
+      <div style={{
+        width: hovered ? 'auto' : 8, height: 8,
+        padding: hovered ? '4px 10px' : 0, borderRadius: 20,
+        background: hovered ? t.accent : t.textMuted,
+        opacity: hovered ? 1 : 0.35,
+        animation: hovered ? 'none' : 'tweak-hint-pulse 2.4s ease-in-out infinite',
+        display: 'flex', alignItems: 'center', gap: 6,
+        color: '#fff', fontSize: 10, fontWeight: 700, letterSpacing: 0.5,
+        fontFamily: t.fontMono, transition: 'all 160ms',
+        boxShadow: hovered ? '0 6px 20px rgba(0,0,0,0.3)' : 'none',
+      }}>
+        {hovered && <span>⚙ TWEAKS · ⇧T</span>}
+      </div>
+    </div>
+  );
+}
+
+// ───────── Desktop Live Viewer (uses same layout as artist) ─────────
+function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
+  const a = ARTISTS.find(x => x.id === artistId) || ARTISTS[0];
+  const [messages, setMessages] = React.useState(() => LIVE_SEEDS.map((s, i) => ({ ...s, id: i, t: s.t || 'fan' })));
+  const [viewers, setViewers] = React.useState(a.viewers || 58_000);
+  const [input, setInput] = React.useState('');
+  const [hearts, setHearts] = React.useState([]);
+  const nextId = React.useRef(100);
+  const listRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!liveOn) return;
+    const id = setInterval(() => {
+      const seed = LIVE_SEEDS[Math.floor(Math.random() * LIVE_SEEDS.length)];
+      setMessages(m => [...m.slice(-80), { ...seed, id: nextId.current++, t: seed.t || 'fan' }]);
+      setViewers(v => Math.max(1000, v + Math.round((Math.random() - 0.4) * 300 * speed)));
+      if (Math.random() < 0.6) {
+        setHearts(h => [...h.slice(-15), { id: nextId.current++, x: 10 + Math.random() * 80, d: 1600 + Math.random() * 2200 }]);
+      }
+    }, 550 / speed);
+    return () => clearInterval(id);
+  }, [speed, liveOn]);
+
+  React.useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
+  }, [messages]);
+
+  const send = () => {
+    if (!input.trim()) return;
+    setMessages(m => [...m, { id: nextId.current++, u: 'me', m: input, t: 'me' }]);
+    setInput('');
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', height: 'calc(100vh - 56px)' }}>
+      <div style={{ position: 'relative', overflow: 'hidden', background: '#000' }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `repeating-linear-gradient(30deg, ${a.color1} 0 28px, ${a.color2} 28px 56px)`,
+          animation: liveOn ? 'connectfin-shimmer 10s linear infinite' : 'none',
+        }}/>
+        <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(0,0,0,0.55) 0%, transparent 25%, transparent 65%, rgba(0,0,0,0.75) 100%)' }}/>
+        <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', fontFamily: t.fontMono, color: 'rgba(255,255,255,0.6)', fontSize: 13, letterSpacing: 2 }}>[ LIVE VIDEO · {a.name} · 1080p ]</div>
+
+        <div style={{ position: 'absolute', top: 16, left: 18, display: 'flex', gap: 8 }}>
+          <div style={{ padding: '6px 12px', borderRadius: 6, background: t.liveGradient, fontSize: 12, fontWeight: 800, color: '#fff', display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: '#fff', animation: 'connectfin-pulse 1.2s ease-in-out infinite' }}/> LIVE
+          </div>
+          <div style={{ padding: '6px 12px', borderRadius: 6, background: 'rgba(0,0,0,0.55)', fontSize: 12, fontFamily: t.fontMono, backdropFilter: 'blur(10px)', color: '#fff' }}>
+            👁 {viewers.toLocaleString()}
+          </div>
+        </div>
+
+        <div style={{ position: 'absolute', bottom: 28, left: 28, right: 28, color: '#fff' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 10 }}>
+            <ArtistAvatar artist={a} size={56} t={t} ring/>
+            <div>
+              <div style={{ fontFamily: t.fontDisplay, fontSize: 24, fontWeight: 800, letterSpacing: -0.5 }}>{a.stage}</div>
+              <div style={{ fontSize: 12, opacity: 0.75, fontFamily: t.fontMono }}>@{a.name.toLowerCase()} · {a.genre} · {a.followers} followers</div>
+            </div>
+          </div>
+          <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, maxWidth: 600, lineHeight: 1.25 }}>
+            🌙 퇴근길 LIVE · 오늘도 고생했어
+          </div>
+        </div>
+
+        <div style={{ position: 'absolute', bottom: 0, right: 0, width: 100, height: '60%', pointerEvents: 'none' }}>
+          {hearts.map(h => (
+            <div key={h.id} style={{ position: 'absolute', bottom: 0, left: `${h.x}%`, fontSize: 22, animation: `connectfin-float ${h.d}ms ease-out forwards` }}>💜</div>
+          ))}
+        </div>
+
+        <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, padding: '14px 20px 12px', display: 'flex', alignItems: 'center', gap: 14, background: 'linear-gradient(0deg, rgba(0,0,0,0.6), transparent)', color: '#fff' }}>
+          <span style={{ fontSize: 18 }}>⏸</span>
+          <span style={{ fontSize: 16 }}>🔊</span>
+          <div style={{ flex: 1, height: 3, background: 'rgba(255,255,255,0.2)', borderRadius: 2, position: 'relative' }}>
+            <div style={{ position: 'absolute', inset: 0, width: '100%', background: t.liveGradient, borderRadius: 2 }}/>
+          </div>
+          <span style={{ fontFamily: t.fontMono, fontSize: 11 }}>LIVE</span>
+          <button onClick={onExit} style={{ padding: '4px 10px', borderRadius: 6, border: `1px solid rgba(255,255,255,0.3)`, background: 'transparent', color: '#fff', fontSize: 11, cursor: 'pointer', fontFamily: t.fontMono }}>← 프로필</button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', borderLeft: `1px solid ${t.line}`, background: theme === 'dark' ? '#0B0D15' : t.surface, color: t.text }}>
+        <div style={{ padding: '14px 18px 12px', borderBottom: `1px solid ${t.line}` }}>
+          <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 15 }}>실시간 채팅</div>
+          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+            ws · /live/{a.id} · {messages.length} msgs buffered
+          </div>
+          <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+            {['전체','팬클럽','아티스트만'].map((tab, i) => (
+              <button key={tab} style={{
+                padding: '4px 10px', borderRadius: 12,
+                background: i === 0 ? t.chip : 'transparent',
+                color: i === 0 ? t.accent : t.textDim, border: 'none', fontSize: 11, fontWeight: 700, cursor: 'pointer', fontFamily: t.fontMono,
+              }}>{tab}</button>
+            ))}
+          </div>
+        </div>
+
+        <div ref={listRef} style={{ flex: 1, overflowY: 'auto', padding: '10px 16px', display: 'flex', flexDirection: 'column', gap: 6, fontSize: 13 }}>
+          {messages.map(msg => {
+            const isArtist = msg.t === 'artist';
+            const isMe = msg.t === 'me';
+            return (
+              <div key={msg.id} style={{
+                display: 'flex', gap: 8, alignItems: 'flex-start',
+                padding: isArtist ? '6px 10px' : '2px 0',
+                borderRadius: isArtist ? 8 : 0,
+                background: isArtist ? t.chip : 'transparent',
+                lineHeight: 1.45, animation: 'connectfin-chatin 240ms ease-out',
+              }}>
+                <span style={{
+                  fontWeight: isArtist ? 800 : 700,
+                  color: isArtist ? t.accent : isMe ? t.accent2 : t.textDim,
+                  flexShrink: 0, maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12,
+                }}>
+                  {isArtist && '⭐ '}{msg.u}
+                </span>
+                <span style={{ flex: 1, wordBreak: 'break-word' }}>{msg.m}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ padding: '10px 14px 14px', display: 'flex', gap: 8, borderTop: `1px solid ${t.line}` }}>
+          <input value={input} onChange={e => setInput(e.target.value)} onKeyDown={e => e.key === 'Enter' && send()} placeholder="채팅 · Enter로 전송"
+            style={{ flex: 1, padding: '10px 14px', borderRadius: 20, border: `1px solid ${t.line}`, background: theme === 'dark' ? '#12141C' : '#fff', color: t.text, fontSize: 13 }}/>
+          <button onClick={send} style={{ padding: '0 16px', borderRadius: 20, border: 'none', background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 13, cursor: 'pointer' }}>SEND</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ───────── Mobile app (phone view) ─────────
+function MobileApp({ tweaks, setTweaks, t, showTweaks, setShowTweaks, screen, setScreen, artistId, setArtistId, threadId, setThreadId, raffleId, setRaffleId }) {
+  const nav = (k) => {
+    if (k === 'me') { setScreen('membership'); return; }
+    if (k === 'live') {
+      const la = ARTISTS.find(a => a.live);
+      if (la && tweaks.liveOn) { setArtistId(la.id); setScreen('live'); return; }
+    }
+    setScreen(k);
+  };
+
+  let content;
+  if (screen === 'login') content = <LoginScreen t={t} onLogin={() => setScreen('home')}/>;
+  else if (screen === 'home') content = <HomeScreen t={t} theme={tweaks.theme} speed={tweaks.simSpeed} liveOn={tweaks.liveOn} onNav={nav} onOpenLive={(id) => { setArtistId(id); setScreen('live'); }} onOpenArtist={(id) => { setArtistId(id); setScreen('artist'); }}/>;
+  else if (screen === 'artist') content = <ArtistScreen t={t} theme={tweaks.theme} artistId={artistId} onBack={() => setScreen('home')} onOpenLive={(id) => { setArtistId(id); setScreen('live'); }} onOpenDM={(id) => { const th = DM_THREADS.find(x => x.artistId === id); setThreadId(th?.id || 1); setScreen('dm-thread'); }}/>;
+  else if (screen === 'live') content = <LiveScreen t={t} theme={tweaks.theme} artistId={artistId} speed={tweaks.simSpeed} liveOn={tweaks.liveOn} onBack={() => setScreen('home')} onNav={nav}/>;
+  else if (screen === 'dm') content = <DMListScreen t={t} onOpenDM={(id) => { setThreadId(id); setScreen('dm-thread'); }}/>;
+  else if (screen === 'dm-thread') content = <DMThreadScreen t={t} theme={tweaks.theme} threadId={threadId} onBack={() => setScreen('dm')}/>;
+  else if (screen === 'community') content = <CommunityScreen t={t} artistId={artistId} onBack={() => setScreen('artist')}/>;
+  else if (screen === 'media') content = <MediaScreen t={t} onBack={() => setScreen('home')}/>;
+  else if (screen === 'membership') content = <MembershipScreen t={t} onOpenRaffles={() => setScreen('raffle-list')}/>;
+  else if (screen === 'raffle-list') content = <RaffleListScreen t={t} onBack={() => setScreen('membership')} onOpenRaffle={(id) => { setRaffleId(id); setScreen('raffle-detail'); }}/>;
+  else if (screen === 'raffle-detail') content = <RaffleDetailScreen t={t} theme={tweaks.theme} raffleId={raffleId} onBack={() => setScreen('raffle-list')} onEnter={() => {}}/>;
+
+  const showTabBar = !['login','live','dm-thread','raffle-detail'].includes(screen);
+
+  return (
+    <div style={{
+      minHeight: '100vh', width: '100%',
+      background: tweaks.theme === 'dark'
+        ? 'radial-gradient(ellipse at 20% 10%, #1a0f2e 0%, #080814 50%, #000 100%)'
+        : 'radial-gradient(ellipse at 30% 10%, #FFD6EE 0%, #E9D4FF 50%, #FFE9F3 100%)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      padding: '40px 20px', fontFamily: t.font,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 28 }}>
+        <Phone theme={tweaks.theme} t={t}>
+          {content}
+          {showTabBar && <TabBar current={
+            screen === 'home' ? 'home' : screen === 'dm' ? 'dm' : screen === 'media' ? 'media' :
+            screen === 'membership' ? 'me' : screen === 'live' ? 'live' : ''
+          } onNav={nav} t={t} theme={tweaks.theme}/>}
+        </Phone>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, color: t.text }}>
+          <button onClick={() => setTweaks(tw => ({ ...tw, viewMode: 'desktop' }))} style={{
+            padding: '10px 16px', borderRadius: 10, border: `1px solid ${t.line}`,
+            background: t.gradient, color: '#fff', fontWeight: 700, fontSize: 12, cursor: 'pointer',
+            fontFamily: t.fontMono, letterSpacing: 0.5,
+          }}>← DESKTOP 웹으로</button>
+          <div style={{ fontFamily: t.fontMono, fontSize: 10, color: t.textDim, lineHeight: 1.6, maxWidth: 220 }}>
+            모바일 프로토타입<br/>
+            11개 화면 · 라이브 채팅 · DM · 커뮤니티
+          </div>
+        </div>
+      </div>
+      <HiddenTweaksTrigger show={showTweaks} onShow={() => setShowTweaks(true)} t={t}/>
+      {showTweaks && <TweaksPanel tweaks={tweaks} setTweaks={setTweaks} t={t} theme={tweaks.theme} onClose={() => setShowTweaks(false)}/>}
+    </div>
+  );
+}
+
+// ───────── Login modal ─────────
+function LoginModal({ t, theme, onLogin, onClose }) {
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const submit = async () => {
+    if (!email || !password) return;
+    setLoading(true);
+    setError('');
+    try {
+      await onLogin(email, password);
+    } catch (err) {
+      setError(err.message || '로그인 실패');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') submit();
+    if (e.key === 'Escape') onClose();
+  };
+
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 200,
+      background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }} onClick={onClose}>
+      <div onClick={e => e.stopPropagation()} style={{
+        width: 360, padding: 32, borderRadius: 20,
+        background: theme === 'dark' ? 'rgba(18,20,28,0.98)' : 'rgba(255,255,255,0.98)',
+        border: `1px solid ${t.line}`,
+        boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
+      }}>
+        <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginBottom: 6 }}>로그인</div>
+        <div style={{ fontSize: 13, color: t.textDim, marginBottom: 24 }}>Connectfin 계정으로 로그인하세요</div>
+
+        <input
+          type="email" placeholder="이메일" value={email}
+          onChange={e => setEmail(e.target.value)} onKeyDown={handleKeyDown}
+          autoFocus
+          style={{
+            width: '100%', padding: '12px 14px', marginBottom: 10, borderRadius: 10,
+            border: `1px solid ${t.line}`, background: t.surface2 || 'transparent',
+            color: t.text, fontSize: 14, fontFamily: t.font,
+          }}
+        />
+        <input
+          type="password" placeholder="비밀번호 (8자 이상)" value={password}
+          onChange={e => setPassword(e.target.value)} onKeyDown={handleKeyDown}
+          style={{
+            width: '100%', padding: '12px 14px', marginBottom: 16, borderRadius: 10,
+            border: `1px solid ${t.line}`, background: t.surface2 || 'transparent',
+            color: t.text, fontSize: 14, fontFamily: t.font,
+          }}
+        />
+
+        {error && (
+          <div style={{ fontSize: 12, color: '#ff6b6b', marginBottom: 12, lineHeight: 1.4 }}>{error}</div>
+        )}
+
+        <button onClick={submit} disabled={loading || !email || !password} style={{
+          width: '100%', padding: '13px 0', borderRadius: 12, border: 'none',
+          background: (!email || !password) ? (t.line || '#333') : (t.gradient || t.accent),
+          color: '#fff', fontSize: 15, fontWeight: 700, cursor: loading ? 'wait' : 'pointer',
+          fontFamily: t.font, opacity: loading ? 0.6 : 1,
+        }}>
+          {loading ? '로그인 중...' : '로그인'}
+        </button>
+
+        <div style={{ textAlign: 'center', marginTop: 16, fontSize: 11, color: t.textMuted, fontFamily: t.fontMono }}>
+          POST /api/auth/v1/login
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ───────── Tweaks panel ─────────
+function TweaksPanel({ tweaks, setTweaks, t, theme, onClose }) {
+  const upd = (k, v) => setTweaks(tw => ({ ...tw, [k]: v }));
+  return (
+    <div style={{
+      position: 'fixed', right: 20, bottom: 20, width: 320, zIndex: 100,
+      background: theme === 'dark' ? 'rgba(18,20,28,0.96)' : 'rgba(255,255,255,0.98)',
+      color: t.text, borderRadius: 16,
+      border: `1px solid ${t.lineStrong}`,
+      boxShadow: '0 30px 70px rgba(0,0,0,0.45)',
+      backdropFilter: 'blur(24px)',
+      fontFamily: t.font, padding: 18,
+      animation: 'connectfin-fadein 180ms ease-out',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 14 }}>
+        <div>
+          <div style={{ fontFamily: t.fontMono, fontSize: 10, letterSpacing: 1, color: t.textDim }}>CONNECTFIN · ⇧T</div>
+          <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18 }}>Tweaks</div>
+        </div>
+        <button onClick={onClose} style={{ background: 'transparent', border: 'none', color: t.textDim, fontSize: 22, cursor: 'pointer', lineHeight: 1 }}>×</button>
+      </div>
+
+      <TweakRow label="View">
+        <div style={{ display: 'flex', gap: 6 }}>
+          {[['desktop','DESKTOP'], ['mobile','MOBILE']].map(([k, l]) => (
+            <button key={k} onClick={() => upd('viewMode', k)} style={btnStyle(tweaks.viewMode === k, t)}>{l}</button>
+          ))}
+        </div>
+      </TweakRow>
+
+      <TweakRow label="Theme">
+        <div style={{ display: 'flex', gap: 6 }}>
+          {['dark','y2k'].map(k => (
+            <button key={k} onClick={() => upd('theme', k)} style={btnStyle(tweaks.theme === k, t)}>
+              {k === 'dark' ? 'Dark Neon' : 'Y2K Pop'}
+            </button>
+          ))}
+        </div>
+      </TweakRow>
+
+      {tweaks.theme === 'dark' && (
+        <TweakRow label={`Accent hue · ${tweaks.accentHue}°`}>
+          <input type="range" min="0" max="360" step="1" value={tweaks.accentHue}
+            onChange={e => upd('accentHue', +e.target.value)}
+            style={{
+              width: '100%', height: 6, borderRadius: 3, appearance: 'none',
+              background: 'linear-gradient(90deg, oklch(0.72 0.22 0), oklch(0.72 0.22 60), oklch(0.72 0.22 120), oklch(0.72 0.22 180), oklch(0.72 0.22 240), oklch(0.72 0.22 300), oklch(0.72 0.22 360))',
+            }}/>
+        </TweakRow>
+      )}
+
+      <TweakRow label="Live simulation">
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button onClick={() => upd('liveOn', true)} style={btnStyle(tweaks.liveOn, t)}>ON</button>
+          <button onClick={() => upd('liveOn', false)} style={btnStyle(!tweaks.liveOn, t)}>OFF</button>
+        </div>
+      </TweakRow>
+
+      <TweakRow label={`Chat speed · ${tweaks.simSpeed}×`}>
+        <input type="range" min="0.5" max="5" step="0.5" value={tweaks.simSpeed}
+          onChange={e => upd('simSpeed', +e.target.value)}
+          style={{ width: '100%' }}/>
+      </TweakRow>
+
+      <div style={{
+        marginTop: 14, padding: 10, borderRadius: 10, background: t.surface2,
+        fontSize: 11, color: t.textDim, lineHeight: 1.5, fontFamily: t.fontMono,
+      }}>
+        💡 평소에는 우하단 점(·)이 희미하게 깜빡입니다. <b>Shift + T</b> 또는 점 hover로 언제든 열 수 있어요.
+        ESC로 즉시 닫기.
+      </div>
+    </div>
+  );
+}
+
+function TweakRow({ label, children }) {
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={{ fontSize: 11, fontWeight: 600, opacity: 0.7, marginBottom: 6, fontFamily: 'JetBrains Mono, monospace', letterSpacing: 0.3 }}>
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function btnStyle(active, t) {
+  return {
+    flex: 1, padding: '8px 0', borderRadius: 8,
+    border: active ? `1px solid ${t.accent}` : `1px solid ${t.line}`,
+    background: active ? t.chip : 'transparent',
+    color: active ? t.accent : t.text,
+    fontWeight: 700, fontSize: 12, cursor: 'pointer',
+    fontFamily: 'JetBrains Mono, monospace', letterSpacing: 0.5,
+  };
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App/>);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `index.html` — SockJS/STOMP CDN, `api-client.jsx` 로드, `App()` 에 Auth 상태/핸들러와 `LoginModal`, `DesktopShell`/`MobileApp` 에 `authUser`/`onShowLogin`/`onLogout` props 전달
- `components/api-client.jsx` (신규) — `ConnectfinAPI` IIFE 를 `window.ConnectfinAPI` 로 노출. 토큰 관리(localStorage), `api()`/`apiMultipart()`, `formatTime/formatCount` 유틸 포함. Babel standalone 환경 제약으로 ES module 대신 전역 주입 방식 사용
- `SecurityConfig.java` — `"/"`, `"/index.html"`, `"/components/**"` 를 기존 `permitAll()` 블록에 추가. 기존 순서·구조는 그대로
- 수동 배치한 9개 JSX (tokens, desktop-*, screens-*, ios-frame) 최초 커밋 포함

## 범위 외 (이번 PR에서 손대지 않음)
- `DesktopShell` 내부 UI 반영(로그인 버튼 등) — 다음 작업에서 처리. 이번 PR 에서는 props 만 내려준다.
- `Dockerfile`, `application*.yml`, `build.gradle` — 변경 불필요

## Test plan
- [x] `./gradlew compileJava` 성공
- [x] `index.html` 에 SockJS / STOMP CDN `<script>` 존재
- [x] `index.html` 에 `api-client.jsx` 로드 태그 존재 (`tokens.jsx` 다음, 나머지 JSX 보다 앞)
- [x] `App()` 에 `authUser`, `showLogin`, `handleLogin`, `handleLogout` 존재
- [x] `LoginModal` 컴포넌트 함수 존재
- [x] `SecurityConfig` permitAll 에 정적 리소스 3개 경로 추가
- [ ] 로컬에서 `./gradlew bootRun` → `http://localhost:8080/` 접속 시 index.html 응답 (리뷰어 확인용)
- [ ] 브라우저 콘솔에서 `window.ConnectfinAPI` 가 정의됨 (리뷰어 확인용)

## 주의사항
- `apiMultipart()` 는 `Content-Type` 헤더를 의도적으로 설정하지 않음 — 브라우저가 `multipart/form-data; boundary=...` 를 자동 생성해야 서버 `@ModelAttribute` 파싱이 동작한다.
- `LoginModal` 은 `App()` 상태와 직접 연결되므로 별도 JSX 로 분리하지 않고 `index.html` 인라인 스크립트에 둔다.

Closes #106