### PR TITLE
Feat: FanPost API 연동, 아티스트 상세/검색 연동, Auth UI 반영

### DIFF
--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -1,5 +1,27 @@
 // Connectfin — Desktop artist profile (8 tabs)
 
+// ── API 응답 → 기존 카드 컴포넌트 호환 포맷 변환 ──
+function mapFanPost(fp) {
+  return {
+    id: fp.fanPostId,
+    artistId: fp.artistId,
+    author: fp.writerNickname,
+    body: fp.content,
+    likes: window.ConnectfinAPI.formatCount(fp.likeCount),
+    comments: fp.commentCount,
+    timeAgo: window.ConnectfinAPI.formatTime(fp.createdAt),
+    hasGrid: fp.mediaCount > 0,
+    gridCount: Math.min(fp.mediaCount, 6),
+    // API 전용 필드 (카드에서 선택적 사용)
+    mediaCount: fp.mediaCount,
+    media: fp.media || [],
+    hashtags: fp.hashtags || [],
+    fanMembershipSubscribed: fp.fanMembershipSubscribed,
+    dmSubscribed: fp.dmSubscribed,
+    writerProfileImageUrl: fp.writerProfileImageUrl,
+  };
+}
+
 // Artist cover hero (top banner with gradient)
 function ArtistCoverBanner({ artist, t, theme }) {
   return (
@@ -17,7 +39,7 @@ function ArtistCoverBanner({ artist, t, theme }) {
       }}>
         <div style={{ fontFamily: t.fontDisplay, fontSize: 28, fontWeight: 800, letterSpacing: -0.5 }}>{artist.name}.</div>
         <div style={{ fontSize: 12, opacity: 0.85, fontFamily: t.fontMono, letterSpacing: 0.3 }}>
-          가입하고 최신 소식을 받아보세요!
+          {artist.intro || '가입하고 최신 소식을 받아보세요!'}
         </div>
       </div>
       <button style={{
@@ -31,22 +53,39 @@ function ArtistCoverBanner({ artist, t, theme }) {
 
 // Main desktop profile router
 function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive, onOpenDM, onOpenMembership }) {
+  const [artistDetail, setArtistDetail] = React.useState(null);
+
+  React.useEffect(() => {
+    window.ConnectfinAPI.api(`/api/member/v2/artists/${artist.id}`)
+      .then(data => setArtistDetail(data))
+      .catch(() => { /* mock 유지 */ });
+  }, [artist.id]);
+
+  const displayArtist = artistDetail ? {
+    ...artist,
+    name: artistDetail.name,
+    intro: artistDetail.intro,
+    coverImageUrl: artistDetail.coverImageUrl,
+    profileImageUrl: artistDetail.profileImageUrl,
+    artistMembers: artistDetail.artistMembers || [],
+  } : artist;
+
   let body;
-  if (tab === 'highlight') body = <TabHighlight t={t} theme={theme} artist={artist} onNavProfile={onNavProfile}/>;
-  else if (tab === 'fan') body = <TabFan t={t} theme={theme} artist={artist}/>;
-  else if (tab === 'artist') body = <TabArtistPosts t={t} theme={theme} artist={artist}/>;
-  else if (tab === 'fanletter') body = <TabFanLetter t={t} theme={theme} artist={artist}/>;
-  else if (tab === 'media') body = <TabMedia t={t} theme={theme} artist={artist}/>;
-  else if (tab === 'live') body = <TabLive t={t} theme={theme} artist={artist} onOpenLive={onOpenLive}/>;
-  else if (tab === 'notice') body = <TabNotice t={t} theme={theme} artist={artist}/>;
-  else if (tab === 'shop') body = <TabShop t={t} theme={theme} artist={artist}/>;
+  if (tab === 'highlight') body = <TabHighlight t={t} theme={theme} artist={displayArtist} onNavProfile={onNavProfile}/>;
+  else if (tab === 'fan') body = <TabFan t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'artist') body = <TabArtistPosts t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'fanletter') body = <TabFanLetter t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'media') body = <TabMedia t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'live') body = <TabLive t={t} theme={theme} artist={displayArtist} onOpenLive={onOpenLive}/>;
+  else if (tab === 'notice') body = <TabNotice t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'shop') body = <TabShop t={t} theme={theme} artist={displayArtist}/>;
 
   return (
     <div>
-      <ArtistCoverBanner artist={artist} t={t} theme={theme}/>
+      <ArtistCoverBanner artist={displayArtist} t={t} theme={theme}/>
       <div style={{ display: 'flex', maxWidth: 1320, margin: '0 auto', padding: '20px 24px 60px', gap: 24 }}>
         <div style={{ flex: 1, minWidth: 0 }}>{body}</div>
-        <DesktopRightSidebar t={t} theme={theme} artist={artist} onOpenDM={onOpenDM} onOpenMembership={onOpenMembership}/>
+        <DesktopRightSidebar t={t} theme={theme} artist={displayArtist} onOpenDM={onOpenDM} onOpenMembership={onOpenMembership}/>
       </div>
     </div>
   );
@@ -102,7 +141,37 @@ function TabHighlight({ t, theme, artist, onNavProfile }) {
 
 // ────────── FAN (팬 포스트 타임라인) ──────────
 function TabFan({ t, theme, artist }) {
-  const posts = FAN_POSTS.filter(p => p.artistId === artist.id);
+  const mockPosts = FAN_POSTS.filter(p => p.artistId === artist.id);
+  const [posts, setPosts] = React.useState(mockPosts);
+  const [loading, setLoading] = React.useState(false);
+  const [hasNext, setHasNext] = React.useState(false);
+  const [nextCursor, setNextCursor] = React.useState(null);
+
+  React.useEffect(() => {
+    setLoading(true);
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-posts`)
+      .then(data => {
+        setPosts(data.content.map(mapFanPost));
+        setHasNext(data.hasNext);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => { /* mock 유지 */ })
+      .finally(() => setLoading(false));
+  }, [artist.id]);
+
+  const loadMore = () => {
+    if (!hasNext || !nextCursor || loading) return;
+    setLoading(true);
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-posts?cursor=${nextCursor}`)
+      .then(data => {
+        setPosts(prev => [...prev, ...data.content.map(mapFanPost)]);
+        setHasNext(data.hasNext);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
   return (
     <div>
       <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
@@ -112,6 +181,13 @@ function TabFan({ t, theme, artist }) {
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         {posts.map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
       </div>
+      {hasNext && (
+        <button onClick={loadMore} disabled={loading} style={{
+          width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>{loading ? '로딩 중...' : '더 보기'}</button>
+      )}
     </div>
   );
 }
@@ -510,11 +586,23 @@ function FanPostFullCard({ post, artist, t, theme }) {
           color: '#fff', fontWeight: 800, fontSize: 11,
         }}>{post.author.slice(0, 2)}</div>
         <div>
-          <div style={{ fontWeight: 700, fontSize: 13 }}>{post.author} <span style={{ color: t.accent2 }}>✓✓</span></div>
+          <div style={{ fontWeight: 700, fontSize: 13 }}>
+            {post.author}
+            {post.fanMembershipSubscribed && <span style={{ color: t.accent2, marginLeft: 4 }}>✓</span>}
+            {post.dmSubscribed && <span style={{ color: t.accent, marginLeft: 2 }}>✉</span>}
+            {!post.fanMembershipSubscribed && !post.dmSubscribed && <span style={{ color: t.accent2 }}> ✓✓</span>}
+          </div>
           <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{post.timeAgo}</div>
         </div>
       </div>
       {post.tag && <div style={{ color: t.hot, fontSize: 13, fontWeight: 700, marginBottom: 4 }}>{post.tag}</div>}
+      {post.hashtags && post.hashtags.length > 0 && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 4 }}>
+          {post.hashtags.map(tag => (
+            <span key={tag} style={{ color: t.accent, fontSize: 12, fontWeight: 600 }}>#{tag}</span>
+          ))}
+        </div>
+      )}
       <div style={{ fontSize: 13, lineHeight: 1.55, whiteSpace: 'pre-line', color: t.text }}>{post.body}</div>
       {post.hasGrid && (
         <div style={{ display: 'grid', gridTemplateColumns: `repeat(${post.gridCount}, 1fr)`, gap: 4, marginTop: 12 }}>

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -1,6 +1,6 @@
 // Connectfin — Desktop shell: global nav + content column + right sidebar
 
-function DesktopShell({ t, theme, children, activeArtist, onNavGlobal, globalView, onArtistOpen, onNavProfile, profileTab }) {
+function DesktopShell({ t, theme, children, activeArtist, onNavGlobal, globalView, onArtistOpen, onNavProfile, profileTab, authUser, onShowLogin, onLogout }) {
   return (
     <div style={{
       minHeight: '100vh', width: '100%', background: t.bg, color: t.text,
@@ -8,7 +8,7 @@ function DesktopShell({ t, theme, children, activeArtist, onNavGlobal, globalVie
     }}>
       <DesktopLeftNav t={t} theme={theme} globalView={globalView} onNavGlobal={onNavGlobal} onArtistOpen={onArtistOpen}/>
       <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-        <DesktopTopbar t={t} theme={theme} activeArtist={activeArtist} globalView={globalView} profileTab={profileTab} onNavProfile={onNavProfile}/>
+        <DesktopTopbar t={t} theme={theme} activeArtist={activeArtist} globalView={globalView} profileTab={profileTab} onNavProfile={onNavProfile} authUser={authUser} onShowLogin={onShowLogin} onLogout={onLogout}/>
         <div style={{ flex: 1, minWidth: 0 }}>
           {children}
         </div>
@@ -39,7 +39,7 @@ function DesktopLeftNav({ t, theme, globalView, onNavGlobal, onArtistOpen }) {
       {ARTISTS.slice(0, 6).map(a => (
         <NavArtist key={a.id} artist={a} t={t} onClick={() => onArtistOpen(a.id)}/>
       ))}
-      <NavItem t={t} icon="⊕" label="커뮤니티 찾기"/>
+      <ArtistSearchSection t={t} theme={theme} onArtistOpen={onArtistOpen}/>
 
       <NavSection t={t} label="서비스 바로가기"/>
       <NavItem t={t} icon="🛍" label="Shop" onClick={() => onNavGlobal('shop')} active={globalView === 'shop'}/>
@@ -103,7 +103,7 @@ function NavArtist({ artist, t, onClick }) {
 }
 
 // ───────── Top bar (profile tabs live here when on artist page) ─────────
-function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile }) {
+function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile, authUser, onShowLogin, onLogout }) {
   const dark = theme === 'dark';
   return (
     <header style={{
@@ -152,11 +152,19 @@ function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavPr
       <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginLeft: 'auto' }}>
         <span style={{ fontFamily: t.fontMono, fontSize: 11, color: t.textDim }}>142 🍮</span>
         <span style={{ fontSize: 18, cursor: 'pointer' }}>🔔</span>
-        <div style={{
-          width: 30, height: 30, borderRadius: '50%', background: t.gradient,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          color: '#fff', fontWeight: 800, fontSize: 12, cursor: 'pointer',
-        }}>ME</div>
+        {authUser ? (
+          <button onClick={onLogout} style={{
+            padding: '6px 14px', borderRadius: 14, border: `1px solid ${t.line}`,
+            background: 'transparent', color: t.text, fontSize: 12, fontWeight: 600,
+            cursor: 'pointer', fontFamily: t.fontMono,
+          }}>로그아웃</button>
+        ) : (
+          <button onClick={onShowLogin} style={{
+            padding: '6px 14px', borderRadius: 14, border: 'none',
+            background: t.gradient, color: '#fff', fontSize: 12, fontWeight: 700,
+            cursor: 'pointer', fontFamily: t.fontMono,
+          }}>로그인</button>
+        )}
       </div>
     </header>
   );
@@ -267,6 +275,117 @@ function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
         </div>
       )}
     </aside>
+  );
+}
+
+// ───────── Artist search (left nav) ─────────
+function ArtistSearchSection({ t, theme, onArtistOpen }) {
+  const [query, setQuery] = React.useState('');
+  const [results, setResults] = React.useState(null);
+  const [popular, setPopular] = React.useState([]);
+  const [showSearch, setShowSearch] = React.useState(false);
+  const debounceRef = React.useRef(null);
+
+  // 인기 검색어 로드 (최초 1회)
+  React.useEffect(() => {
+    window.ConnectfinAPI.api('/api/member/v1/artists/search/popular?limit=5')
+      .then(data => setPopular(data || []))
+      .catch(() => {});
+  }, []);
+
+  // 검색 (debounce 300ms)
+  React.useEffect(() => {
+    if (!query.trim()) {
+      setResults(null);
+      return;
+    }
+    if (!window.ConnectfinAPI.getToken()) return;
+
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      window.ConnectfinAPI.api(`/api/member/v2/artists/search?keyword=${encodeURIComponent(query)}`)
+        .then(data => setResults(data.content || []))
+        .catch(() => setResults([]));
+    }, 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [query]);
+
+  if (!showSearch) {
+    return (
+      <button onClick={() => setShowSearch(true)} style={{
+        display: 'flex', alignItems: 'center', gap: 12, width: '100%', textAlign: 'left',
+        padding: '9px 10px', borderRadius: 10,
+        background: 'transparent', color: t.text,
+        border: 'none', cursor: 'pointer',
+        fontSize: 14, fontWeight: 500, fontFamily: t.font, marginBottom: 2,
+      }}>
+        <span style={{ fontSize: 16, width: 20, textAlign: 'center' }}>⌕</span>
+        <span>커뮤니티 찾기</span>
+      </button>
+    );
+  }
+
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+        <input
+          type="text" value={query} onChange={e => setQuery(e.target.value)}
+          placeholder="아티스트 검색..." autoFocus
+          style={{
+            flex: 1, padding: '8px 12px', borderRadius: 8,
+            border: `1px solid ${t.line}`,
+            background: theme === 'dark' ? '#12141C' : '#fff',
+            color: t.text, fontSize: 13, fontFamily: t.font,
+          }}
+        />
+        <button onClick={() => { setShowSearch(false); setQuery(''); setResults(null); }} style={{
+          padding: '6px 10px', borderRadius: 8, border: `1px solid ${t.line}`,
+          background: 'transparent', color: t.textDim, fontSize: 12, cursor: 'pointer',
+        }}>✕</button>
+      </div>
+
+      {/* 검색 결과 */}
+      {results !== null && (
+        <div style={{ marginBottom: 8 }}>
+          {results.length === 0 ? (
+            <div style={{ padding: '8px 10px', fontSize: 12, color: t.textDim }}>검색 결과가 없습니다</div>
+          ) : results.map(a => (
+            <button key={a.id} onClick={() => { onArtistOpen(a.id); setShowSearch(false); setQuery(''); setResults(null); }} style={{
+              display: 'flex', alignItems: 'center', gap: 10, width: '100%', textAlign: 'left',
+              padding: '8px 10px', borderRadius: 8,
+              background: 'transparent', border: 'none', cursor: 'pointer', color: t.text,
+            }}>
+              <div style={{
+                width: 28, height: 28, borderRadius: '50%', background: t.gradient,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: '#fff', fontSize: 10, fontWeight: 800,
+              }}>{a.name?.slice(0, 2)}</div>
+              <div>
+                <div style={{ fontSize: 13, fontWeight: 600 }}>{a.name}</div>
+                <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono }}>@{a.slug}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 인기 검색어 (검색 중이 아닐 때만) */}
+      {results === null && popular.length > 0 && (
+        <div style={{ padding: '4px 10px' }}>
+          <div style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono, letterSpacing: 0.5, marginBottom: 6 }}>인기 검색어</div>
+          {popular.map((item, i) => (
+            <button key={item.keyword} onClick={() => setQuery(item.keyword)} style={{
+              display: 'flex', alignItems: 'center', gap: 8, width: '100%', textAlign: 'left',
+              padding: '5px 0', background: 'transparent', border: 'none',
+              cursor: 'pointer', color: t.text, fontSize: 12,
+            }}>
+              <span style={{ fontFamily: t.fontMono, fontSize: 11, color: t.accent, fontWeight: 700, width: 16 }}>{i + 1}</span>
+              <span>{item.keyword}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -538,7 +538,7 @@ function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
 }
 
 // ───────── Mobile app (phone view) ─────────
-function MobileApp({ tweaks, setTweaks, t, showTweaks, setShowTweaks, screen, setScreen, artistId, setArtistId, threadId, setThreadId, raffleId, setRaffleId }) {
+function MobileApp({ tweaks, setTweaks, t, showTweaks, setShowTweaks, screen, setScreen, artistId, setArtistId, threadId, setThreadId, raffleId, setRaffleId, authUser, onShowLogin, onLogout }) {
   const nav = (k) => {
     if (k === 'me') { setScreen('membership'); return; }
     if (k === 'live') {


### PR DESCRIPTION
## Summary
- **index.html** — `MobileApp` 시그니처에 `authUser`/`onShowLogin`/`onLogout` 추가 (F-1 잔여 수정)
- **desktop-shell.jsx**
  - `DesktopShell`/`DesktopTopbar` 시그니처에 auth props 추가, 탑바의 ME 아바타를 `authUser` 유무에 따른 **로그인/로그아웃 버튼** 으로 교체
  - `DesktopLeftNav` 의 "커뮤니티 찾기" `NavItem` 을 신규 `ArtistSearchSection` 으로 교체
  - `ArtistSearchSection` — 인기 검색어(`/api/member/v1/artists/search/popular?limit=5`, 공개) + 검색(`/api/member/v2/artists/search?keyword=...`, 로그인 필수, 300ms debounce)
- **desktop-profile.jsx**
  - `mapFanPost(fp)` — 서버 FanPost DTO 를 기존 카드 컴포넌트 포맷으로 변환 (`likes` 는 `formatCount` 로 문자열화)
  - `TabFan` — `/api/post/v1/artists/{id}/fan-posts` 연동 + 커서 기반 `loadMore`, 실패 시 기존 mock fallback
  - `DesktopArtistProfile` — `/api/member/v2/artists/{id}` 호출, mock 과 병합한 `displayArtist` 를 banner/body 에 전달
  - `ArtistCoverBanner` — 고정 카피를 `artist.intro || fallback` 으로 교체
  - `FanPostFullCard` — `fanMembershipSubscribed`/`dmSubscribed` 배지 조건부 + `hashtags` 칩 렌더

## 범위 외 (이번 PR 에서 손대지 않음)
- `HomeScreen` 혼합 피드 (대시보드 API 미구현)
- `ArtistPost`/`FanLetter`/댓글/Hashtag 전용 뷰
- `screens-raffle`, `screens-realtime`, `desktop-dm` — 별도 작업
- STOMP/DM/래플/라이브

## Test plan
- [x] `./gradlew compileJava` 성공 (자바 변경 없음 — sanity only)
- [x] `index.html` `MobileApp` 시그니처에 `authUser/onShowLogin/onLogout` 포함
- [x] `desktop-shell.jsx` `DesktopShell`/`DesktopTopbar` 시그니처에 auth props 포함
- [x] `DesktopTopbar` 에 로그인/로그아웃 버튼 조건부 렌더
- [x] `desktop-profile.jsx` 에 `mapFanPost` 함수 존재
- [x] `TabFan` 에 `useEffect` + `loadMore` 존재
- [x] `ArtistCoverBanner` 에 `artist.intro` fallback
- [x] `DesktopArtistProfile` 에 `artistDetail` state + API 호출
- [x] `ArtistSearchSection` 존재, `커뮤니티 찾기` `NavItem` 이 교체됨
- [ ] 로컬 `./gradlew bootRun` 후 로그인 플로우 + FanPost 탭 + 아티스트 검색 수동 확인 (리뷰어)

## 주의사항
- `api()` 호출은 반드시 `window.ConnectfinAPI.api()` — Babel 브라우저 트랜스파일 환경 제약상 import 불가.
- 검색 API 는 `PageResponse` 를 `ApiResponse` 래퍼 없이 직접 반환. `api()` 의 `json.success !== undefined` 분기로 처리됨.
- 검색 API 는 로그인 필수 — 토큰 없으면 호출 시도조차 하지 않음 (`getToken()` 가드).
- 인기 검색어와 FanPost 리스트는 공개 GET — 토큰 유무 무관하게 시도.
- `mapFanPost` 에서 `likes` 를 `formatCount(fp.likeCount)` 로 변환하는 이유: 기존 `FanPostFullCard` 가 `post.likes` 를 문자열("4.2K") 로 기대.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)