### PR TITLE
Feat: ArtistPost/FanLetter API 연동, 좋아요 토글 공통 컴포넌트

### DIFF
--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -8,6 +8,7 @@ function mapFanPost(fp) {
     author: fp.writerNickname,
     body: fp.content,
     likes: window.ConnectfinAPI.formatCount(fp.likeCount),
+    likeCount: fp.likeCount,
     comments: fp.commentCount,
     timeAgo: window.ConnectfinAPI.formatTime(fp.createdAt),
     hasGrid: fp.mediaCount > 0,
@@ -20,6 +21,109 @@ function mapFanPost(fp) {
     dmSubscribed: fp.dmSubscribed,
     writerProfileImageUrl: fp.writerProfileImageUrl,
   };
+}
+
+function mapArtistPost(ap) {
+  return {
+    id: ap.artistPostId,
+    artistId: ap.artistId,
+    author: ap.writerNickname,
+    body: ap.content,
+    likes: window.ConnectfinAPI.formatCount(ap.likeCount),
+    comments: ap.commentCount,
+    time: window.ConnectfinAPI.formatTime(ap.createdAt),
+    // API 전용 필드
+    artistPostId: ap.artistPostId,
+    likeCount: ap.likeCount,
+    commentCount: ap.commentCount,
+    mediaCount: ap.mediaCount,
+    media: ap.media || [],
+    hashtags: ap.hashtags || [],
+    artistBadge: ap.artistBadge,
+    writerProfileImageUrl: ap.writerProfileImageUrl,
+  };
+}
+
+function mapFanLetterListItem(fl) {
+  return {
+    id: fl.fanLetterId,
+    artistId: null, // 목록 응답에 없음
+    recipientType: fl.recipientType,
+    recipientDisplayName: fl.recipientDisplayName,
+    recipientProfileImageUrl: fl.recipientProfileImageUrl,
+    imageUrl: fl.image?.imageUrl || null,
+    thumbnailUrl: fl.image?.thumbnailUrl || null,
+    artistLiked: fl.artistLiked,
+    artistLikeDisplayName: fl.artistLikeDisplayName,
+    artistLikeProfileImageUrl: fl.artistLikeProfileImageUrl,
+    createdAt: fl.createdAt,
+    // mock 호환 필드
+    author: fl.recipientDisplayName,
+    body: null, // FanLetter는 텍스트 없음
+    texture: null, // API 응답에는 텍스처 없음 — 이미지 기반
+  };
+}
+
+// ── 공통 좋아요 버튼 ──
+// postType: 'FAN_POST' | 'ARTIST_POST' | 'FAN_LETTER'
+function LikeButton({ t, postType, artistId, postId, initialCount }) {
+  const [liked, setLiked] = React.useState(false);
+  const [count, setCount] = React.useState(initialCount || 0);
+  const [toggling, setToggling] = React.useState(false);
+
+  const toggle = async () => {
+    if (toggling || !window.ConnectfinAPI.getToken()) return;
+    setToggling(true);
+
+    // Optimistic UI: 즉시 반영
+    const nextLiked = !liked;
+    setLiked(nextLiked);
+    setCount(prev => prev + (nextLiked ? 1 : -1));
+
+    try {
+      let path;
+      if (postType === 'FAN_POST') {
+        path = `/api/post/v1/artists/${artistId}/fan-posts/${postId}/likes/toggle`;
+      } else if (postType === 'ARTIST_POST') {
+        path = `/api/post/v3/artists/${artistId}/artist-posts/${postId}/likes/toggle`;
+      } else if (postType === 'FAN_LETTER') {
+        path = `/api/post/v1/artists/${artistId}/fan-letters/${postId}/likes/toggle`;
+      }
+
+      const res = await window.ConnectfinAPI.api(path, { method: 'POST' });
+
+      // 서버 응답으로 보정
+      if (res.reacted !== undefined) {
+        // v1 동기 (InteractionResponse): 서버 확정값
+        setLiked(res.reacted);
+        setCount(res.reactionCount);
+      } else if (res.expectedReacted !== undefined) {
+        // v3 비동기 (ArtistPostLikeQueuedResponse): 의도 상태
+        setLiked(res.expectedReacted);
+        // count는 서버가 안 줌 — optimistic 값 유지
+      }
+    } catch (err) {
+      // 실패 시 롤백
+      setLiked(!nextLiked);
+      setCount(prev => prev + (nextLiked ? -1 : 1));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  return (
+    <button onClick={toggle} disabled={toggling} style={{
+      padding: '10px 16px', borderRadius: 10,
+      border: liked ? 'none' : `1px solid ${t.line}`,
+      background: liked ? t.chip : 'transparent',
+      color: liked ? t.accent : t.text,
+      cursor: 'pointer', fontWeight: 700, fontSize: 12,
+      display: 'flex', alignItems: 'center', gap: 6,
+      opacity: toggling ? 0.6 : 1,
+    }}>
+      {liked ? '♥' : '♡'} {window.ConnectfinAPI.formatCount(count)}
+    </button>
+  );
 }
 
 // Artist cover hero (top banner with gradient)
@@ -194,7 +298,37 @@ function TabFan({ t, theme, artist }) {
 
 // ────────── ARTIST (아티스트 포스트 타임라인) ──────────
 function TabArtistPosts({ t, theme, artist }) {
-  const posts = ARTIST_POSTS.filter(p => p.artistId === artist.id);
+  const mockPosts = ARTIST_POSTS.filter(p => p.artistId === artist.id);
+  const [posts, setPosts] = React.useState(mockPosts);
+  const [loading, setLoading] = React.useState(false);
+  const [hasNext, setHasNext] = React.useState(false);
+  const [nextCursor, setNextCursor] = React.useState(null);
+
+  React.useEffect(() => {
+    setLoading(true);
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/artist-posts`)
+      .then(data => {
+        setPosts(data.content.map(mapArtistPost));
+        setHasNext(data.hasNext);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => { /* mock 유지 */ })
+      .finally(() => setLoading(false));
+  }, [artist.id]);
+
+  const loadMore = () => {
+    if (!hasNext || !nextCursor || loading) return;
+    setLoading(true);
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/artist-posts?cursor=${nextCursor}`)
+      .then(data => {
+        setPosts(prev => [...prev, ...data.content.map(mapArtistPost)]);
+        setHasNext(data.hasNext);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
   return (
     <div>
       {/* Moments (hero horizontal) */}
@@ -218,14 +352,54 @@ function TabArtistPosts({ t, theme, artist }) {
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         {posts.map(p => <ArtistPostCard key={p.id} post={p} artist={artist} t={t}/>)}
       </div>
+      {hasNext && (
+        <button onClick={loadMore} disabled={loading} style={{
+          width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>{loading ? '로딩 중...' : '더 보기'}</button>
+      )}
     </div>
   );
 }
 
 // ────────── FAN LETTER (텍스처 카드 그리드) ──────────
 function TabFanLetter({ t, theme, artist }) {
-  const letters = FAN_LETTERS.filter(l => l.artistId === artist.id);
+  const mockLetters = FAN_LETTERS.filter(l => l.artistId === artist.id);
+  const [letters, setLetters] = React.useState(mockLetters);
   const [selected, setSelected] = React.useState(null);
+  const [selectedDetail, setSelectedDetail] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+  const [hasNext, setHasNext] = React.useState(false);
+  const [nextCursor, setNextCursor] = React.useState(null);
+
+  React.useEffect(() => {
+    if (!window.ConnectfinAPI.getToken()) return; // FanLetter 목록은 로그인 필수
+    setLoading(true);
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters`)
+      .then(data => {
+        setLetters(data.content.map(mapFanLetterListItem));
+        setHasNext(data.hasNext);
+        setNextCursor(data.nextCursor);
+      })
+      .catch(() => { /* mock 유지 */ })
+      .finally(() => setLoading(false));
+  }, [artist.id]);
+
+  const openDetail = (letter) => {
+    setSelected(letter);
+    // 상세 API 호출 (목록과 필드가 다름)
+    if (window.ConnectfinAPI.getToken() && letter.id) {
+      window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters/${letter.id}`)
+        .then(data => setSelectedDetail(data))
+        .catch(() => setSelectedDetail(null));
+    }
+  };
+
+  const closeDetail = () => {
+    setSelected(null);
+    setSelectedDetail(null);
+  };
 
   return (
     <div>
@@ -236,10 +410,28 @@ function TabFanLetter({ t, theme, artist }) {
         <Chip t={t}>🌐 한국어</Chip>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-        {letters.map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => setSelected(l)}/>)}
+        {letters.map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => openDetail(l)}/>)}
       </div>
+      {hasNext && (
+        <button onClick={() => {
+          if (!hasNext || !nextCursor || loading) return;
+          setLoading(true);
+          window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters?cursor=${nextCursor}`)
+            .then(data => {
+              setLetters(prev => [...prev, ...data.content.map(mapFanLetterListItem)]);
+              setHasNext(data.hasNext);
+              setNextCursor(data.nextCursor);
+            })
+            .catch(() => {})
+            .finally(() => setLoading(false));
+        }} disabled={loading} style={{
+          width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>{loading ? '로딩 중...' : '더 보기'}</button>
+      )}
 
-      {selected && <FanLetterModal letter={selected} artist={artist} t={t} theme={theme} onClose={() => setSelected(null)}/>}
+      {selected && <FanLetterModal letter={selected} detail={selectedDetail} artist={artist} t={t} theme={theme} onClose={closeDetail}/>}
     </div>
   );
 }
@@ -294,23 +486,35 @@ function FanLetterCard({ letter, artist, t, theme, onClick }) {
       border: `1px solid ${t.line}`, background: dark ? '#141624' : t.surface,
     }}>
       <div style={{
-        aspectRatio: '3/4', padding: '20px 18px', position: 'relative',
-        ...texture,
-        fontSize: 11, lineHeight: 1.6, whiteSpace: 'pre-line',
+        aspectRatio: '3/4', position: 'relative',
         overflow: 'hidden',
+        ...(letter.imageUrl ? {} : { padding: '20px 18px', ...texture, fontSize: 11, lineHeight: 1.6, whiteSpace: 'pre-line' }),
       }}>
-        {letter.body}
+        {letter.imageUrl ? (
+          <img src={letter.imageUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }}/>
+        ) : letter.body}
+        {letter.artistLiked && (
+          <div style={{
+            position: 'absolute', bottom: 8, right: 8,
+            width: 28, height: 28, borderRadius: '50%',
+            background: 'rgba(255,255,255,0.9)', display: 'flex',
+            alignItems: 'center', justifyContent: 'center', fontSize: 14,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+          }}>💜</div>
+        )}
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', fontSize: 12 }}>
         <ArtistAvatar artist={artist} size={20} t={t}/>
-        <span style={{ color: t.textDim }}>To. {artist.name}</span>
-        <span style={{ marginLeft: 'auto', color: t.textDim, fontFamily: t.fontMono, fontSize: 10 }}>· {letter.author}</span>
+        <span style={{ color: t.textDim }}>To. {letter.recipientDisplayName || artist.name}</span>
+        <span style={{ marginLeft: 'auto', color: t.textDim, fontFamily: t.fontMono, fontSize: 10 }}>
+          {window.ConnectfinAPI.formatTime(letter.createdAt) || `· ${letter.author || ''}`}
+        </span>
       </div>
     </div>
   );
 }
 
-function FanLetterModal({ letter, artist, t, theme, onClose }) {
+function FanLetterModal({ letter, detail, artist, t, theme, onClose }) {
   return (
     <div onClick={onClose} style={{
       position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)', zIndex: 200,
@@ -326,18 +530,39 @@ function FanLetterModal({ letter, artist, t, theme, onClose }) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <ArtistAvatar artist={artist} size={32} t={t}/>
             <div>
-              <div style={{ fontWeight: 800, fontSize: 14 }}>To. {artist.name}</div>
-              <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>From. {letter.author}</div>
+              <div style={{ fontWeight: 800, fontSize: 14 }}>To. {detail?.recipientDisplayName || letter.recipientDisplayName || artist.name}</div>
+              <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+                From. {detail?.writerNickname || letter.author || ''}
+                {detail?.fanMembershipSubscribed && <span style={{ color: t.accent2, marginLeft: 4 }}>✓</span>}
+              </div>
             </div>
           </div>
           <button onClick={onClose} style={{ background: 'transparent', border: 'none', color: t.text, fontSize: 22, cursor: 'pointer' }}>×</button>
         </div>
-        <div style={{ whiteSpace: 'pre-line', lineHeight: 1.7, fontSize: 14 }}>
-          {letter.body}
-        </div>
-        <div style={{ display: 'flex', gap: 10, marginTop: 18 }}>
-          <button style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: `1px solid ${t.line}`, background: 'transparent', color: t.text, cursor: 'pointer', fontWeight: 700, fontSize: 12 }}>♡ 공감하기</button>
-          <button style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: 'none', background: t.gradient, color: '#fff', cursor: 'pointer', fontWeight: 800, fontSize: 12 }}>🌐 번역 보기</button>
+        {(letter.imageUrl || detail?.image?.imageUrl) ? (
+          <div style={{ borderRadius: 12, overflow: 'hidden', margin: '10px 0' }}>
+            <img src={detail?.image?.imageUrl || letter.imageUrl} alt="" style={{ width: '100%', borderRadius: 12 }}/>
+          </div>
+        ) : letter.body ? (
+          <div style={{ whiteSpace: 'pre-line', lineHeight: 1.7, fontSize: 14 }}>
+            {letter.body}
+          </div>
+        ) : null}
+        <div style={{ display: 'flex', gap: 10, marginTop: 18, alignItems: 'center' }}>
+          <LikeButton
+            t={t}
+            postType="FAN_LETTER"
+            artistId={artist.id}
+            postId={letter.id}
+            initialCount={detail?.likeCount ?? 0}
+          />
+          {(detail?.artistLiked || letter.artistLiked) && (
+            <span style={{ fontSize: 12, color: t.accent2, fontWeight: 600 }}>
+              💜 {detail?.artistLikeDisplayName || letter.artistLikeDisplayName || artist.name}
+            </span>
+          )}
+          <div style={{ flex: 1 }}/>
+          <button style={{ padding: '10px 16px', borderRadius: 10, border: 'none', background: t.gradient, color: '#fff', cursor: 'pointer', fontWeight: 800, fontSize: 12 }}>🌐 번역 보기</button>
         </div>
       </div>
     </div>
@@ -556,7 +781,11 @@ function ArtistPostCard({ post, artist, t, inline }) {
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
         <ArtistAvatar artist={artist} size={36} t={t}/>
         <div>
-          <div style={{ fontWeight: 800, fontSize: 14 }}>{artist.name}.</div>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>
+            {post.author || artist.name}
+            {post.artistBadge && <span style={{ marginLeft: 6, fontSize: 9, fontWeight: 800, padding: '2px 6px', borderRadius: 4, background: t.gradient, color: '#fff', letterSpacing: 0.4 }}>ARTIST ✓</span>}
+            {post.artistBadge === undefined && <span style={{ marginLeft: 4, color: t.accent2 }}>.</span>}
+          </div>
           <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{post.time}</div>
         </div>
       </div>
@@ -564,8 +793,19 @@ function ArtistPostCard({ post, artist, t, inline }) {
       <div style={{ display: 'flex', gap: 4, marginTop: 10, fontSize: 11, color: t.textDim }}>
         <span style={{ cursor: 'pointer', fontFamily: t.fontMono }}>번역 보기</span>
       </div>
-      <div style={{ display: 'flex', gap: 16, marginTop: 12, fontSize: 12, color: t.textDim }}>
-        <span>♡ {post.likes}</span>
+      {post.hashtags && post.hashtags.length > 0 && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+          {post.hashtags.map(tag => (
+            <span key={tag} style={{ color: t.accent, fontSize: 12, fontWeight: 600 }}>#{tag}</span>
+          ))}
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: 16, marginTop: 12, fontSize: 12, color: t.textDim, alignItems: 'center' }}>
+        {post.artistPostId ? (
+          <LikeButton t={t} postType="ARTIST_POST" artistId={post.artistId || artist.id} postId={post.artistPostId} initialCount={post.likeCount ?? 0}/>
+        ) : (
+          <span>♡ {post.likes}</span>
+        )}
         <span>💬 {post.comments}</span>
       </div>
     </div>
@@ -620,8 +860,12 @@ function FanPostFullCard({ post, artist, t, theme }) {
         </div>
       )}
       <div style={{ fontSize: 11, color: t.textDim, marginTop: 8, fontFamily: t.fontMono }}>번역 보기</div>
-      <div style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: 12, color: t.textDim }}>
-        <span>♡ {post.likes}</span>
+      <div style={{ display: 'flex', gap: 16, marginTop: 10, fontSize: 12, color: t.textDim, alignItems: 'center' }}>
+        {post.artistId && post.id ? (
+          <LikeButton t={t} postType="FAN_POST" artistId={post.artistId} postId={post.id} initialCount={post.likeCount ?? 0}/>
+        ) : (
+          <span>♡ {post.likes}</span>
+        )}
         {post.comments !== null && <span>💬 {post.comments}</span>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **유틸 추가** — `mapArtistPost`, `mapFanLetterListItem` 신규. `mapFanPost` 에 `likeCount` 필드 노출 (LikeButton `initialCount` 연결).
- **`LikeButton` 공통 컴포넌트** — `postType` 에 따라 세 도메인 처리:
  - `FAN_POST` → `POST /api/post/v1/.../fan-posts/{id}/likes/toggle` (동기, `reacted`/`reactionCount` 반환)
  - `ARTIST_POST` → `POST /api/post/v3/.../artist-posts/{id}/likes/toggle` (비동기 `202`, `expectedReacted` 만 반환. count 는 optimistic 유지)
  - `FAN_LETTER` → `POST /api/post/v1/.../fan-letters/{id}/likes/toggle` (동기)
  - Optimistic UI + 실패 시 롤백. 비로그인 시 API 호출 스킵.
- **ArtistPost**
  - `TabArtistPosts` — `/api/post/v1/artists/{id}/artist-posts` 연동 + 커서 기반 `loadMore`, 실패 시 mock fallback
  - `ArtistPostCard` — `post.author` / `post.artistBadge` 조건부, `hashtags` 칩, `LikeButton` 적용 (mock 데이터는 기존 span fallback)
- **FanLetter**
  - `TabFanLetter` — 목록 API (로그인 필수) + 카드 클릭 시 상세 API 별도 호출, `loadMore`, 비로그인/실패 시 mock 유지
  - `FanLetterCard` — `imageUrl` 있으면 이미지, 없으면 기존 텍스처+텍스트 fallback. `artistLiked` 시 💜 오버레이. 하단 `To.` / 타임스탬프 API 필드로 교체
  - `FanLetterModal` — `detail` prop, `recipientDisplayName`/`writerNickname`/`fanMembershipSubscribed` 사용, 이미지/텍스트 조건부 본문, `LikeButton` + `artistLiked` 뱃지
- **FanPostFullCard** — 하단 좋아요 영역을 `LikeButton` 으로 교체 (API 데이터일 때만; mock 은 기존 span)

## 범위 외 (이번 PR 에서 손대지 않음)
- 댓글/대댓글 컴포넌트, Hashtag 자동완성, 게시글 작성/수정/삭제 UI
- `screens-main.jsx`, `screens-realtime.jsx`, `screens-raffle.jsx`, `desktop-dm.jsx` — 별도 작업

## Test plan
- [x] `./gradlew compileJava` 성공 (자바 변경 없음 — sanity only)
- [x] `mapArtistPost`, `mapFanLetterListItem`, `LikeButton` 존재
- [x] `TabArtistPosts` 에 `useEffect` API 호출 + `loadMore`
- [x] `TabFanLetter` 에 `useEffect` + `openDetail` / `closeDetail`
- [x] `ArtistPostCard` 에 `artistBadge` 조건부 + 해시태그
- [x] `FanLetterCard` 에 `imageUrl` 조건부 이미지 + `artistLiked` 오버레이
- [x] `FanLetterModal` 에 `detail` prop + API 상세 필드 + `LikeButton`
- [x] `FanPostFullCard` / `ArtistPostCard` 하단 `LikeButton` 적용
- [ ] 로컬 `./gradlew bootRun` 후 로그인 → FanPost/ArtistPost 좋아요 토글, FanLetter 카드/모달 수동 확인 (리뷰어)

## 주의사항
- ArtistPost v3 좋아요는 `202 Accepted` + `expectedReacted` 만 반환. `reactionCount` 없음 → optimistic count 유지. `api()` 가 이미 202 를 정상 처리함.
- FanLetter 목록 API 는 **로그인 필수**. 토큰 없으면 mock 유지.
- FanLetter 는 목록/상세 DTO 필드가 다름. 카드 클릭 시 상세 API 를 별도 호출해 `detail` 로 주입.
- `mapFanPost` 의 `likeCount` 는 이번에 추가. 기존 `likes` (문자열 "4.2K") 는 유지되어 mock fallback 경로에서 계속 사용된다.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)