### PR TITLE
[FIX] SubscriptionMembershipController X-User-Id 헤더 제거 및 AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/example/infinite/domain/subscriptionmembership/controller/SubscriptionMembershipController.java
+++ b/src/main/java/com/example/infinite/domain/subscriptionmembership/controller/SubscriptionMembershipController.java
@@ -3,11 +3,13 @@ package com.example.infinite.domain.subscriptionmembership.controller;
 import com.example.infinite.domain.subscriptionmembership.dto.response.SubscriptionHistoryResponse;
 import com.example.infinite.domain.subscriptionmembership.dto.response.SubscriptionStatusResponse;
 import com.example.infinite.domain.subscriptionmembership.service.SubscriptionMembershipService;
+import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.ApiResponse;
 import com.example.infinite.global.common.dto.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,45 +21,45 @@ public class SubscriptionMembershipController {
 
     @PostMapping("/dm/{artistId}")
     public ApiResponse<Void> purchaseDmSubscription(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PathVariable Long artistId) {
-        subscriptionMembershipService.purchaseDmSubscription(userId, artistId);
+        subscriptionMembershipService.purchaseDmSubscription(memberDetails.getMemberId(), artistId);
         return ApiResponse.success(null);
     }
 
     @PostMapping("/membership/{artistId}")
     public ApiResponse<Void> purchaseFanMembership(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PathVariable Long artistId) {
-        subscriptionMembershipService.purchaseFanMembership(userId, artistId);
+        subscriptionMembershipService.purchaseFanMembership(memberDetails.getMemberId(), artistId);
         return ApiResponse.success(null);
     }
 
     @GetMapping("/dm/{artistId}/status")
     public ApiResponse<SubscriptionStatusResponse> getDmSubscriptionStatus(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PathVariable Long artistId) {
-        return ApiResponse.success(subscriptionMembershipService.getDmSubscriptionStatus(userId, artistId));
+        return ApiResponse.success(subscriptionMembershipService.getDmSubscriptionStatus(memberDetails.getMemberId(), artistId));
     }
 
     @GetMapping("/membership/{artistId}/status")
     public ApiResponse<SubscriptionStatusResponse> getFanMembershipStatus(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PathVariable Long artistId) {
-        return ApiResponse.success(subscriptionMembershipService.getFanMembershipStatus(userId, artistId));
+        return ApiResponse.success(subscriptionMembershipService.getFanMembershipStatus(memberDetails.getMemberId(), artistId));
     }
 
     @GetMapping("/dm/history")
     public ApiResponse<PageResponse<SubscriptionHistoryResponse>> getDmSubscriptionHistory(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PageableDefault(size = 10) Pageable pageable) {
-        return ApiResponse.success(subscriptionMembershipService.getDmSubscriptionHistory(userId, pageable));
+        return ApiResponse.success(subscriptionMembershipService.getDmSubscriptionHistory(memberDetails.getMemberId(), pageable));
     }
 
     @GetMapping("/membership/history")
     public ApiResponse<PageResponse<SubscriptionHistoryResponse>> getFanMembershipHistory(
-            @RequestHeader("X-User-Id") Long userId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails,
             @PageableDefault(size = 10) Pageable pageable) {
-        return ApiResponse.success(subscriptionMembershipService.getFanMembershipHistory(userId, pageable));
+        return ApiResponse.success(subscriptionMembershipService.getFanMembershipHistory(memberDetails.getMemberId(), pageable));
     }
 }


### PR DESCRIPTION
## 💡 기능 상세 내용
  - [x] SubscriptionMembershipController의 모든 엔드포인트에서 `@RequestHeader("X-User-Id")` 제거
  - [x] `@AuthenticationPrincipal MemberDetailsImpl`로 교체하여 JWT 토큰 기반으로 userId 추출

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [x] X-User-Id 헤더를 직접 받는 파라미터가 컨트롤러에 존재하지 않는다
  - [x] 모든 엔드포인트가 JWT 인증 객체에서 userId를 추출한다

  ## 🔗 기타 참고 사항
  - 대상 파일: `SubscriptionMembershipController.java`
  - Closes #113