### PR TITLE
fix/ 리뷰 피드백 수정

### DIFF
--- a/FRONTEND_TEAM_VIBE_HANDOFF.md
+++ b/FRONTEND_TEAM_VIBE_HANDOFF.md
@@ -1,6 +1,6 @@
 # Frontend Team Vibe Handoff
 
-작성일: 2026-04-23
+작성일: 2026-04-24
 
 이 문서는 같은 팀 프론트엔드 담당자가 AI 바이브 코딩에 바로 넣을 수 있게, 현재 백엔드 코드와 `HANDOFF_revised.md`를 기준으로 내 담당 범위의 구현 상태와 앞으로 구현할 것을 꼼꼼하게 정리한 문서다.
 
@@ -423,6 +423,7 @@ YouTube 카드 응답 필드:
 - 작성자 정보는 로그인 사용자와 `artistId` 소속 `ArtistMember`를 서버가 확인해 추론한다
 - 서버가 YouTube Data API로 메타데이터를 읽어 저장한다
 - 목록은 `CursorSliceResponse` 기반 `id DESC`
+- YouTube 카드 엔티티는 현재 hard delete 전제로 관리한다
 
 중요한 운영 주의:
 
@@ -630,6 +631,10 @@ VOD 카드 응답 필드:
 - 비로그인 메인 홈은 아직 별도 API가 없으므로, 지금은 랜딩 화면 + 검색/인기검색어 중심으로 잡는 것이 안전하다
 - 검색 입력 자체는 기존 search API를 그대로 쓰고, 대시보드는 홈 진입 시 한 번 더 호출해 섹션을 채우면 된다
 - 공식글 카드(`ArtistPostResponse`)는 기존 ArtistPost 카드 컴포넌트를 재사용할 수 있다
+- 구독 아티스트 섹션은 현재 artist별 최신 2건을 전용 batch query로 조립하는 구조라, artist 수만큼 개별 API를 다시 호출하는 방식은 아니다
+- `followedArtistMembersLatestPosts`에서 카드 작성자 이름은 `stageName`이 아니라 `post.writerNickname`을 우선 노출하는 것이 맞다
+- `stageName`은 현재 팔로우 중인 ArtistMember 메타데이터로만 보고, 필요하면 보조 라벨/서브텍스트로만 쓰는 편이 안전하다
+- 즉 메인 홈 팔로우 섹션도 작성자 표기 기준은 `writerNickname + artistBadge` 쪽에 맞추는 것이 맞다
 
 ## 5. 앞으로 내가 구현할 것
 
@@ -687,6 +692,8 @@ VOD 카드 응답 필드:
 
 - 실호출에는 `YOUTUBE_DATA_API_KEY`가 필요하다
 - UI는 `썸네일 + 제목 + 길이 + 업로드일 + 외부 링크` 기준으로 잡는 것이 맞다
+- 최근 보강으로 중복 등록 경쟁은 500이 아니라 `MEDIA_YOUTUBE_VIDEO_DUPLICATED` 도메인 에러로 내려오게 맞췄다
+- `www.youtube.com/...`, `youtu.be/...`처럼 스킴 없이 붙여 넣은 링크도 현재는 허용 방향으로 보강됐다
 
 ## 5-4. 후순위 기능: 종료된 스트리밍 영상 조회
 
@@ -915,6 +922,7 @@ FanLetter HOT은 아래 응답을 사용한다.
 - replies는 상세 응답에 전부 들어오는 구조가 아니다
 - FanPost/댓글/FanLetter 상세의 subscription badge 필드는 지금 실제 값 기준으로 처리해도 된다
 - ArtistPost는 FanPost와 비슷하지만 작성자 표기는 `writerNickname + artistBadge` 기준이다
+- 메인 홈 대시보드의 `followedArtistMembersLatestPosts`도 작성자 이름은 `stageName` 대신 `post.writerNickname`을 우선 사용해야 한다
 - FanPost / ArtistPost / FanLetter multipart 검증 실패는 이제 공통 400 에러 포맷으로 내려온다
 - FanLetter는 텍스트 피드처럼 만들면 정책과 어긋난다
 - FanLetter 목록은 작성자 프로필/배지가 기본 노출 대상이 아니다

--- a/src/main/java/com/example/infinite/domain/artistcontent/follow/service/FollowService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/follow/service/FollowService.java
@@ -48,11 +48,29 @@ public class FollowService {
                 })
                 .orElseGet(() -> {
                     try {
-                        // 같은 사용자가 같은 대상을 거의 동시에 follow 하면 둘 다 "미존재"를 보고 insert를 시도할 수 있다.
-                        // 이 경우 unique 제약이 최종 방어선이 되므로, saveAndFlush로 여기서 바로 감지하고 현재 상태를 다시 해석한다.
+                        /*
+                         * 여기서도 "조회 후 insert" 사이의 경쟁 조건을 의식해야 한다.
+                         *
+                         * 두 요청이 거의 동시에 들어오면 둘 다 기존 row 가 없다고 판단하고
+                         * insert 를 시도할 수 있다.
+                         * 애플리케이션 코드만으로는 이 틈을 완전히 없애기 어렵기 때문에
+                         * 최종 정합성은 DB unique 제약에 맡긴다.
+                         *
+                         * saveAndFlush 를 쓰는 이유는
+                         * commit 시점까지 예외를 미루지 않고 지금 여기서 충돌을 감지해
+                         * "결과적으로는 follow 상태가 true 인가?"를 바로 다시 해석하기 위해서다.
+                         */
                         followRepository.saveAndFlush(Follow.create(follower, targetArtistMember));
                         return FollowResponse.of(artistMemberId, true);
                     } catch (DataIntegrityViolationException exception) {
+                        /*
+                         * unique 충돌이 났다는 것은 대개 "다른 동시 요청이 먼저 insert 했다"는 뜻이다.
+                         * 이 경우 사용자 입장에서는 이미 follow 된 상태가 최종 결과이므로
+                         * 예외를 그대로 500 으로 올리기보다 현재 상태를 다시 읽어 true 로 돌려준다.
+                         *
+                         * 반대로 재조회해도 row 가 없다면 예상한 경쟁 상황이 아니므로
+                         * 다른 무결성 오류로 보고 원래 예외를 다시 던진다.
+                         */
                         boolean followed = followRepository.findByFollowerMemberIdAndTargetArtistMemberId(
                                 follower.getId(),
                                 artistMemberId
@@ -66,7 +84,12 @@ public class FollowService {
     }
 
     public List<ArtistMember> getFollowedArtistMembers(Long followerMemberId) {
-        // 홈 대시보드는 follow 엔티티를 직접 다루지 않고 아티스트 멤버 목록만 받는다.
+        /*
+         * 홈 대시보드가 필요한 것은 "follow row 자체"가 아니라
+         * 그 row 가 가리키는 ArtistMember 들이다.
+         * 그래서 서비스 경계에서 Follow 엔티티를 한 번 벗겨
+         * 상위 계층은 ArtistMember 목록만 다루게 만든다.
+         */
         return followRepository.findAllByFollowerMemberIdOrderByIdDesc(followerMemberId).stream()
                 .map(Follow::getTargetArtistMember)
                 .toList();

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/service/ArtistYoutubeVideoService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/service/ArtistYoutubeVideoService.java
@@ -15,6 +15,7 @@ import com.example.infinite.domain.member.member.support.MemberReader;
 import com.example.infinite.global.auth.MemberDetailsImpl;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,18 +62,56 @@ public class ArtistYoutubeVideoService {
         YoutubeVideoMetadata metadata = youtubeMetadataClient.fetchVideoMetadata(youtubeVideoId);
         // 작성자 활동명/프로필을 스냅샷으로 저장해 이후 ArtistMember 프로필이 바뀌어도
         // 과거에 등록한 영상 카드 표시가 흔들리지 않게 한다.
-        ArtistYoutubeVideo saved = artistYoutubeVideoRepository.save(ArtistYoutubeVideo.create(
-                artistId,
-                member.getId(),
-                artistMember.getStageName(),
-                artistMember.getProfileImageUrl(),
-                metadata.youtubeVideoId(),
-                metadata.youtubeUrl(),
-                metadata.title(),
-                metadata.thumbnailUrl(),
-                metadata.durationSeconds(),
-                metadata.publishedAt()
-        ));
+        ArtistYoutubeVideo saved;
+        try {
+            /*
+             * 왜 save 가 아니라 saveAndFlush 인가?
+             *
+             * 이 메서드는 위에서 "이미 같은 영상이 있는지"를 한 번 먼저 확인한다.
+             * 하지만 그 확인과 insert 사이에는 아주 짧은 틈이 있고,
+             * 동시에 두 요청이 들어오면 둘 다 "없음"을 보고 save 를 시도할 수 있다.
+             *
+             * 이 경쟁 상황의 최종 방어선은 DB unique 제약이다.
+             * 그래서 flush 시점을 뒤로 미루지 않고 여기서 바로 강제해,
+             * 중복이면 지금 이 메서드 안에서 감지하고 우리가 의도한 도메인 예외로 바꾼다.
+             */
+            saved = artistYoutubeVideoRepository.saveAndFlush(ArtistYoutubeVideo.create(
+                    artistId,
+                    member.getId(),
+                    artistMember.getStageName(),
+                    artistMember.getProfileImageUrl(),
+                    metadata.youtubeVideoId(),
+                    metadata.youtubeUrl(),
+                    metadata.title(),
+                    metadata.thumbnailUrl(),
+                    metadata.durationSeconds(),
+                    metadata.publishedAt()
+            ));
+        } catch (DataIntegrityViolationException exception) {
+            /*
+             * 왜 예외 메시지 문자열을 바로 믿지 않고 다시 exists 조회를 하는가?
+             *
+             * DataIntegrityViolationException 은 "DB 무결성 오류"라는 큰 범주 예외라서
+             * 실행 환경/DB 벤더/드라이버에 따라 메시지 형식이 달라질 수 있다.
+             * 예를 들어 로컬 MySQL, 테스트 DB, 운영 DB 의 메시지가 완전히 같다고 보장할 수 없다.
+             *
+             * 여기서 우리가 정말 알고 싶은 것은
+             * "지금 실패 원인이 artist + youtubeVideoId 중복인가?" 이다.
+             *
+             * 그래서 문자열 파싱 대신, 실패 직후 같은 키가 실제로 존재하는지 다시 확인한다.
+             * 존재한다면 우리가 기대한 중복 경쟁으로 보고
+             * 클라이언트가 이해할 수 있는 MEDIA_YOUTUBE_VIDEO_DUPLICATED 로 변환한다.
+             * 반대로 존재하지 않는다면 다른 무결성 오류일 수 있으므로 원래 예외를 다시 던진다.
+             */
+            boolean duplicated = artistYoutubeVideoRepository.existsByArtistIdAndYoutubeVideoId(
+                    artistId,
+                    metadata.youtubeVideoId()
+            );
+            if (duplicated) {
+                throw new ArtistContentException(ArtistContentErrorCode.MEDIA_YOUTUBE_VIDEO_DUPLICATED);
+            }
+            throw exception;
+        }
 
         return ArtistYoutubeVideoResponse.from(saved);
     }

--- a/src/main/java/com/example/infinite/domain/artistcontent/media/service/YoutubeUrlParser.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/media/service/YoutubeUrlParser.java
@@ -70,16 +70,48 @@ public final class YoutubeUrlParser {
     }
 
     private static URI parseUri(String rawUrl) {
+        URI parsed = tryParse(rawUrl);
+        if (hasSchemeAndHost(parsed)) {
+            return parsed;
+        }
+
+        /*
+         * 여기서 한 번 더 https:// 를 붙여 재시도하는 이유:
+         *
+         * 사용자는 종종 아래처럼 스킴 없이 링크를 붙여 넣는다.
+         * - www.youtube.com/watch?v=...
+         * - youtube.com/shorts/...
+         * - youtu.be/...
+         *
+         * 이런 값은 "문법적으로 완전히 틀린 문자열"은 아니라서
+         * new URI(rawUrl) 자체는 예외 없이 성공할 수 있다.
+         * 문제는 이 경우 host 가 비어 있는 상대 URI 로 해석될 수 있다는 점이다.
+         *
+         * 즉 "파싱은 성공했는데 host 가 null" 인 상태가 생기고,
+         * 그대로 아래 검증으로 내려가면 정상 유튜브 링크를 잘못 invalid 로 거절하게 된다.
+         *
+         * 그래서 1차 파싱 결과에 scheme/host 가 없으면
+         * "사용자가 스킴만 생략했나?"를 의심하고 https:// 를 붙여 한 번 더 해석한다.
+         * 이 보정 후에도 host 가 없으면 그때 진짜 invalid 로 본다.
+         */
+        URI withHttps = tryParse("https://" + rawUrl);
+        if (hasSchemeAndHost(withHttps)) {
+            return withHttps;
+        }
+
+        throw new ArtistContentException(ArtistContentErrorCode.MEDIA_YOUTUBE_URL_INVALID);
+    }
+
+    private static URI tryParse(String rawUrl) {
         try {
             return new URI(rawUrl);
-        } catch (URISyntaxException firstException) {
-            try {
-                // 사용자가 스킴 없이 붙여 넣는 경우를 허용해 프론트 입력 부담을 줄인다.
-                return new URI("https://" + rawUrl);
-            } catch (URISyntaxException ignored) {
-                throw new ArtistContentException(ArtistContentErrorCode.MEDIA_YOUTUBE_URL_INVALID);
-            }
+        } catch (URISyntaxException exception) {
+            return null;
         }
+    }
+
+    private static boolean hasSchemeAndHost(URI uri) {
+        return uri != null && StringUtils.hasText(uri.getScheme()) && StringUtils.hasText(uri.getHost());
     }
 
     private static String extractWatchVideoId(String query) {

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepositoryImpl.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepositoryImpl.java
@@ -116,6 +116,17 @@ public class ArtistPostRepositoryImpl implements ArtistPostRepositoryCustom {
             return List.of();
         }
 
+        /*
+         * 이 쿼리는 메인 홈 follow 섹션용 "전역 최신 목록"이다.
+         *
+         * 중요 포인트:
+         * - writerIds 중 누가 썼는지만 본다
+         * - 결과는 artist별로 자르지 않고 한 줄의 최신순 피드처럼 정렬한다
+         * - 따라서 정렬 기준은 단순 id DESC + limit 이다
+         *
+         * 반대로 "artist별 최신 n건" 같은 요구에는 이 쿼리를 쓰면 안 되고,
+         * 아래 findLatestRowsByArtistIds 처럼 artist 단위 top-N 쿼리가 필요하다.
+         */
         return queryFactory
                 .select(Projections.constructor(
                         ArtistPostReadRow.class,
@@ -147,6 +158,21 @@ public class ArtistPostRepositoryImpl implements ArtistPostRepositoryCustom {
             return List.of();
         }
 
+        /*
+         * 이 쿼리는 "artist 여러 개에 대해 각 artist의 최신 n건"을 한 번에 읽기 위한 패턴이다.
+         *
+         * 어떻게 동작하나?
+         * - 바깥 row 를 artistPost 라고 두고
+         * - 같은 artist 안에서 자기보다 id 가 더 큰 newerArtistPost 개수를 센다
+         * - 그 개수가 perArtistLimit 미만인 row 만 남긴다
+         *
+         * 예를 들어 perArtistLimit = 2 이면
+         * 같은 artist 안에서 "나보다 최신 글이 0개 또는 1개뿐인 row"만 통과한다.
+         * 결과적으로 각 artist마다 최신 2건이 남는다.
+         *
+         * 즉 SQL window function 없이도 Querydsl/JPA 안에서
+         * per-group top N 을 표현한 쿼리라고 이해하면 된다.
+         */
         return queryFactory
                 .select(Projections.constructor(
                         ArtistPostReadRow.class,

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostBaseCacheService.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/service/ArtistPostBaseCacheService.java
@@ -129,6 +129,14 @@ public class ArtistPostBaseCacheService {
     }
 
     public List<ArtistPostBaseResponse> loadLatestArtistPostBasesByWriterIds(Collection<Long> writerIds, int limit) {
+        /*
+         * 메인 홈 follow 섹션은 "artist별 묶음"이 아니라
+         * "여러 writer의 글을 하나의 최신순 흐름으로 합친 목록" 이 필요하다.
+         *
+         * 그래서 여기서는 artistId 별 캐시 slice 를 재사용하지 않고
+         * writer 집합을 기준으로 최신 row 를 한 번에 읽은 뒤
+         * 공통 조립기(buildBaseResponses)로 base 응답을 만든다.
+         */
         return buildBaseResponses(artistPostRepository.findLatestRowsByWriterIds(writerIds, limit));
     }
 
@@ -136,6 +144,16 @@ public class ArtistPostBaseCacheService {
             Collection<Long> artistIds,
             int perArtistLimit
     ) {
+        /*
+         * 이 메서드의 반환 타입이 List 가 아니라 Map 인 이유:
+         *
+         * 구독 섹션은 최종 응답이 "artist 하나 + 그 artist의 글들" 구조라서
+         * 서비스 상위 계층에서 artistId 로 바로 꺼내 쓸 수 있는 모양이 더 편하다.
+         *
+         * 저장소는 artist 여러 개를 한 번에 읽어 오지만,
+         * 여기서 다시 artistId 기준으로 묶어 Map 으로 바꿔 주면
+         * MemberHomeDashboardService 쪽 조립 코드가 단순해진다.
+         */
         if (artistIds == null || artistIds.isEmpty() || perArtistLimit < 1) {
             return Map.of();
         }
@@ -160,6 +178,8 @@ public class ArtistPostBaseCacheService {
             return List.of();
         }
 
+        // row 조회와 media/hashtag 조회를 분리해 둔 구조라서
+        // 여기서 postId 배치 수집 -> 부가 데이터 일괄 조회 -> 최종 DTO 조립 순서가 반복된다.
         List<Long> postIds = rows.stream()
                 .map(ArtistPostReadRow::artistPostId)
                 .toList();

--- a/src/main/java/com/example/infinite/domain/member/home/service/MemberHomeDashboardService.java
+++ b/src/main/java/com/example/infinite/domain/member/home/service/MemberHomeDashboardService.java
@@ -46,6 +46,17 @@ public class MemberHomeDashboardService {
     private final ArtistPostService artistPostService;
 
     public MemberHomeDashboardResponse getDashboard(MemberDetailsImpl memberDetails) {
+        /*
+         * 메인 홈 대시보드는 "하나의 큰 피드"를 그대로 내려주는 API가 아니다.
+         * 아래 3개 섹션을 각기 다른 규칙으로 조립해 한 응답에 묶어 주는 성격에 가깝다.
+         *
+         * 1) 인기 검색어
+         * 2) 내가 구독한 아티스트별 최신 글 묶음
+         * 3) 내가 follow 한 아티스트 멤버들의 최신 글 묶음
+         *
+         * 그래서 이 메서드는 단순 repository 1회 조회가 아니라
+         * "섹션별 정책에 맞는 서비스 호출"을 오케스트레이션하는 진입점으로 읽는 것이 맞다.
+         */
         Member member = memberReader.findByEmailOrThrow(MemberInputSupport.extractEmail(memberDetails));
 
         return new MemberHomeDashboardResponse(
@@ -56,6 +67,14 @@ public class MemberHomeDashboardService {
     }
 
     private List<SubscribedArtistLatestPostsResponse> buildSubscribedArtistsLatestPosts(Long memberId) {
+        /*
+         * 구독 섹션은 "글 최신순 전역 2건"이 아니라
+         * "구독한 각 artist마다 최신 n건" 이 필요하다.
+         *
+         * 즉 기준 축이 writer 가 아니라 artist 다.
+         * 그래서 먼저 활성 구독 목록에서 artistId 들을 뽑고,
+         * 그 뒤 artist 단위 batch query 로 각 artist의 최신 글 묶음을 조립한다.
+         */
         List<FanMembership> activeMemberships = fanMembershipRepository.findByUserIdAndStatusAndExpiredAtAfterOrderByIdDesc(
                 memberId,
                 SubscriptionStatus.ACTIVE,
@@ -98,12 +117,28 @@ public class MemberHomeDashboardService {
     }
 
     private List<FollowedArtistMemberLatestPostResponse> buildFollowedArtistMembersLatestPosts(Long memberId) {
+        /*
+         * follow 섹션은 구독 섹션과 반대로 "artist별 묶음"이 아니라
+         * "내가 관심 있는 멤버들이 최근에 쓴 글을 한데 모은 전역 최신 목록" 이다.
+         *
+         * 그래서 여기서는 artistId 기준 그룹핑을 먼저 하지 않고,
+         * follow 중인 ArtistMember -> writerId 집합으로 바꾼 뒤
+         * writer 기준 최신 ArtistPost 를 모아 온다.
+         */
         List<ArtistMember> followedArtistMembers = followService.getFollowedArtistMembers(memberId);
         if (followedArtistMembers.isEmpty()) {
             return List.of();
         }
 
-        // 한 회원은 현재 정책상 한 ArtistMember에만 연결되므로 writerId -> ArtistMember 매핑이 단순하다.
+        /*
+         * 홈 카드 바깥쪽 메타데이터는 Follow 대상인 ArtistMember 에서 가져오고,
+         * 실제 글 본문/좋아요 수/작성 시각 등은 ArtistPostResponse 에서 가져온다.
+         *
+         * 현재 정책상 한 Member 가 동시에 여러 ArtistMember 로 존재하지 않는다고 보고 있으므로
+         * writerId -> ArtistMember 매핑을 단순 Map 으로 둘 수 있다.
+         * 만약 미래에 한 member 가 여러 artist 소속을 동시에 가질 수 있게 되면
+         * 이 매핑 정책은 다시 검토해야 한다.
+         */
         Map<Long, ArtistMember> artistMemberByWriterId = new LinkedHashMap<>();
         for (ArtistMember followedArtistMember : followedArtistMembers) {
             artistMemberByWriterId.putIfAbsent(followedArtistMember.getMember().getId(), followedArtistMember);
@@ -117,6 +152,8 @@ public class MemberHomeDashboardService {
             return List.of();
         }
 
+        // 여기서는 "글 1건"을 바로 반환하지 않고,
+        // 프론트가 카드에 바로 쓸 수 있게 ArtistMember 메타데이터를 한 번 더 감싸서 내려준다.
         return posts.stream()
                 .map(post -> {
                     ArtistMember artistMember = artistMemberByWriterId.get(post.writerId());


### PR DESCRIPTION
#117 
## 작업 배경
YouTube 미디어 import와 메인 홈 연동 문서를 실제 코드 기준으로 다시 맞췄습니다.

이번 수정의 핵심은
- YouTube 중복 등록 경쟁 상황에서 500이 아니라 도메인 에러로 응답하도록 보강
- 스킴 없이 입력된 YouTube 링크도 정상적으로 허용
- 메인 홈/팔로우 섹션의 조회 정책과 작성자 표기 기준을 문서와 주석에 명확히 정리
입니다.

## 주요 변경 사항

### 1. YouTube 중복 등록 경쟁 처리 보강
- `ArtistYoutubeVideoService#importYoutubeVideo`
- 기존 중복 사전 조회만으로는
  동시에 같은 영상을 등록할 때 조회 후 insert 사이 경쟁 구간이 남아 있었음
- `save` 대신 `saveAndFlush`로 변경해서 무결성 충돌을 메서드 내부에서 즉시 감지
- `DataIntegrityViolationException` 발생 시
  `artistId + youtubeVideoId` 재조회 후
  실제 중복이면 `MEDIA_YOUTUBE_VIDEO_DUPLICATED` 도메인 에러로 변환
- 기대 효과
  - 중복 경쟁 상황에서 500 대신 프론트가 처리 가능한 명시적 에러 응답 제공

### 2. YouTube URL 파싱 보강
- `YoutubeUrlParser`
- 사용자가 아래처럼 스킴 없이 입력한 경우를 허용하도록 처리 보강
  - `www.youtube.com/watch?v=...`
  - `youtube.com/shorts/...`
  - `youtu.be/...`
- 1차 URI 파싱 후 `scheme/host`가 비어 있으면
  `https://`를 붙여 한 번 더 재해석
- 그래도 host가 없거나 유효한 YouTube 링크가 아니면
  `MEDIA_YOUTUBE_URL_INVALID` 유지

### 3. 메인 홈 Follow/구독 섹션 정책 정리
- 메인 홈 대시보드 관련 주석과 핸드오프 문서 보강
- 구독 아티스트 섹션
  - artist별 최신 2건을 전용 batch query로 조립
  - artist 수만큼 개별 API를 다시 호출하는 구조가 아님
- Follow 섹션
  - artist별 묶음이 아니라
    follow 중인 ArtistMember 작성 글을 하나의 전역 최신 목록으로 조립
  - 카드 작성자 이름은 `stageName`보다 `post.writerNickname` 우선
  - `stageName`은 필요 시 보조 메타데이터로만 사용

### 4. Follow 서비스 / 배치 조회 의도 설명 보강
- `FollowService`
  - follow 토글 시 unique 제약 기반 동시성 처리 의도 주석 보강
  - 홈 대시보드에는 Follow 엔티티 자체가 아니라 `ArtistMember` 목록을 넘긴다는 경계 정리
- `ArtistPostRepositoryImpl`
  - `findLatestRowsByWriterIds`: writer 기준 전역 최신 목록 쿼리임을 명시
  - `findLatestRowsByArtistIds`: artist별 최신 N건 batch query 패턴 설명 추가
- `ArtistPostBaseCacheService`, `MemberHomeDashboardService`
  - 메인 홈 각 섹션이 어떤 기준(writer / artist)으로 조립되는지 주석 보강

### 5. 프론트 핸드오프 문서 최신화
- `FRONTEND_TEAM_VIBE_HANDOFF.md` 작성일 갱신
- YouTube 카드 운영 주의사항에
  - hard delete 전제
  - `MEDIA_YOUTUBE_VIDEO_DUPLICATED`
  - 스킴 없는 URL 허용
  반영
- 메인 홈 follow 섹션 작성자 표기 기준을
  `writerNickname + artistBadge` 쪽으로 명확히 수정

## 리뷰 포인트
- 같은 YouTube 영상을 거의 동시에 등록할 때
  500이 아니라 `MEDIA_YOUTUBE_VIDEO_DUPLICATED`로 내려오는지
- 스킴 없는 YouTube 링크는 허용하되
  비정상 URL은 여전히 `MEDIA_YOUTUBE_URL_INVALID`로 잘 차단되는지
- 메인 홈 대시보드에서
  - 구독 섹션은 artist별 최신 2건 batch query
  - follow 섹션은 writer 기준 전역 최신 목록
  이라는 정책이 문서/코드/프론트 기대값과 일치하는지
- `followedArtistMembersLatestPosts` 작성자 표기가
  `stageName`이 아니라 `post.writerNickname` 기준으로 맞는지

