### PR TITLE
Feat: 프론트엔드 REST/STOMP API 연동 (라이브·DM·래플·대시보드)

### DIFF
--- a/src/main/resources/static/components/api-client.jsx
+++ b/src/main/resources/static/components/api-client.jsx
@@ -152,6 +152,118 @@ const ConnectfinAPI = (() => {
     return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
   }
 
+  // ── STOMP ──
+  let stompClient = null;
+  let stompSubscriptions = {};
+
+  function connectStomp(onConnected, onError) {
+    // 이미 연결돼 있으면 바로 콜백 (중복 연결 방지)
+    if (stompClient && stompClient.connected) {
+      if (onConnected) onConnected();
+      return stompClient;
+    }
+
+    const token = getToken();
+    if (!token) {
+      if (onError) onError(new Error('No token'));
+      return;
+    }
+
+    // @stomp/stompjs 7.x UMD → 전역 StompJs 객체
+    const client = new StompJs.Client({
+      webSocketFactory: () => new SockJS('/ws-stomp'),
+      connectHeaders: {
+        'Authorization': 'Bearer ' + token,
+      },
+      reconnectDelay: 5000,
+      heartbeatIncoming: 10000,
+      heartbeatOutgoing: 10000,
+    });
+
+    client.onConnect = () => {
+      stompClient = client;
+      if (onConnected) onConnected();
+    };
+
+    client.onStompError = (frame) => {
+      console.error('STOMP error:', frame.headers?.message);
+      if (onError) onError(new Error(frame.headers?.message || 'STOMP error'));
+    };
+
+    client.onWebSocketClose = () => {
+      // reconnectDelay가 설정돼 있으므로 자동 재연결 시도
+    };
+
+    client.activate();
+    return client;
+  }
+
+  // 라이브 채팅 구독 — 서버가 300ms마다 배치(List) 전송
+  function subscribeLive(liveId, onBatch) {
+    if (!stompClient || !stompClient.connected) return null;
+    const sub = stompClient.subscribe(`/sub/live/${liveId}`, (message) => {
+      try {
+        const batch = JSON.parse(message.body);
+        if (onBatch) onBatch(Array.isArray(batch) ? batch : [batch]);
+      } catch (e) {
+        console.error('Live chat parse error:', e);
+      }
+    });
+    stompSubscriptions[`live:${liveId}`] = sub;
+    return sub;
+  }
+
+  // 라이브 채팅 전송 — payload는 String (메시지 텍스트만)
+  function sendLiveChat(liveId, message) {
+    if (!stompClient || !stompClient.connected) return;
+    stompClient.publish({
+      destination: `/pub/live/${liveId}/chat`,
+      body: message,
+    });
+  }
+
+  // DM 구독 — 단건 메시지 수신
+  function subscribeDm(roomId, onMessage) {
+    if (!stompClient || !stompClient.connected) return null;
+    const sub = stompClient.subscribe(`/sub/dm/${roomId}`, (message) => {
+      try {
+        const msg = JSON.parse(message.body);
+        if (onMessage) onMessage(msg);
+      } catch (e) {
+        console.error('DM parse error:', e);
+      }
+    });
+    stompSubscriptions[`dm:${roomId}`] = sub;
+    return sub;
+  }
+
+  // DM 전송 — payload는 String (메시지 텍스트만)
+  function sendDm(roomId, message) {
+    if (!stompClient || !stompClient.connected) return;
+    stompClient.publish({
+      destination: `/pub/dm/${roomId}`,
+      body: message,
+    });
+  }
+
+  function unsubscribe(key) {
+    if (stompSubscriptions[key]) {
+      stompSubscriptions[key].unsubscribe();
+      delete stompSubscriptions[key];
+    }
+  }
+
+  function disconnectStomp() {
+    Object.keys(stompSubscriptions).forEach(key => {
+      stompSubscriptions[key].unsubscribe();
+    });
+    stompSubscriptions = {};
+    if (stompClient) {
+      stompClient.deactivate();
+      stompClient = null;
+    }
+  }
+
   // ── Public API ──
   return {
     getToken,
@@ -161,6 +273,14 @@ const ConnectfinAPI = (() => {
     apiMultipart,
     formatTime,
     formatCount,
+    // STOMP
+    connectStomp,
+    subscribeLive,
+    sendLiveChat,
+    subscribeDm,
+    sendDm,
+    unsubscribe,
+    disconnectStomp,
   };
 })();
 

--- a/src/main/resources/static/components/desktop-dm.jsx
+++ b/src/main/resources/static/components/desktop-dm.jsx
@@ -2,13 +2,34 @@
 // Layout: Thread list (left) · Active conversation (right)
 
 function DesktopDMScreen({ t, theme, onExit }) {
+  const [rooms, setRooms] = React.useState(DM_THREADS);
   const [activeId, setActiveId] = React.useState(DM_THREADS[0]?.id || 1);
   const [filter, setFilter] = React.useState('all'); // all | unread | subscribed
 
-  const activeThread = DM_THREADS.find(x => x.id === activeId) || DM_THREADS[0];
-  const activeArtist = ARTISTS.find(a => a.id === activeThread.artistId);
+  React.useEffect(() => {
+    if (!window.ConnectfinAPI.getToken()) return;
+    window.ConnectfinAPI.api('/api/v1/dm/rooms')
+      .then(data => {
+        if (data && data.length > 0) {
+          const mapped = data.map(room => ({
+            id: room.id,
+            artistId: room.artistId,
+            name: ARTISTS.find(a => a.id === room.artistId)?.name || `Artist ${room.artistId}`,
+            last: '',
+            unread: 0,
+            subscribed: true,
+          }));
+          setRooms(mapped);
+          setActiveId(mapped[0].id);
+        }
+      })
+      .catch(() => { /* mock 유지 */ });
+  }, []);
 
-  const filtered = DM_THREADS.filter(th => {
+  const activeThread = rooms.find(x => x.id === activeId) || rooms[0];
+  const activeArtist = ARTISTS.find(a => a.id === activeThread?.artistId);
+
+  const filtered = rooms.filter(th => {
     if (filter === 'unread') return (th.unread || 0) > 0;
     if (filter === 'subscribed') return th.subscribed;
     return true;
@@ -143,7 +164,7 @@ function DesktopDMScreen({ t, theme, onExit }) {
           padding: '12px 18px', borderTop: `1px solid ${t.line}`,
           fontSize: 10, color: t.textDim, fontFamily: t.fontMono, letterSpacing: 0.3,
         }}>
-          GET /dm/threads?cursor= · {DM_THREADS.length} threads cached
+          GET /dm/threads?cursor= · {rooms.length} threads cached
         </div>
       </div>
 
@@ -165,6 +186,22 @@ function DMConversationPanel({ thread, artist, t, theme }) {
   const [showInfo, setShowInfo] = React.useState(false);
   const nextId = React.useRef(100);
   const listRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!window.ConnectfinAPI.getToken() || !thread?.id) return;
+    window.ConnectfinAPI.api(`/api/v1/dm/rooms/${thread.id}/messages`)
+      .then(data => {
+        if (data.content && data.content.length > 0) {
+          setMessages(data.content.map(msg => ({
+            from: msg.senderType === 'USER' ? 'me' : (artist?.name || 'Artist'),
+            m: msg.content,
+            time: window.ConnectfinAPI.formatTime(msg.sentAt),
+            mine: msg.senderType === 'USER',
+          })));
+        }
+      })
+      .catch(() => { /* mock 유지 */ });
+  }, [thread?.id]);
 
   React.useEffect(() => {
     if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;

--- a/src/main/resources/static/components/desktop-dm.jsx
+++ b/src/main/resources/static/components/desktop-dm.jsx
@@ -203,13 +203,42 @@ function DMConversationPanel({ thread, artist, t, theme }) {
       .catch(() => { /* mock 유지 */ });
   }, [thread?.id]);
 
+  // STOMP DM 실시간 수신
+  React.useEffect(() => {
+    if (!window.ConnectfinAPI.getToken() || !thread?.id) return;
+
+    window.ConnectfinAPI.connectStomp(
+      () => {
+        window.ConnectfinAPI.subscribeDm(thread.id, (msg) => {
+          setMessages(prev => [...prev, {
+            from: msg.senderType === 'USER' ? 'me' : (artist?.name || 'Artist'),
+            m: msg.content,
+            time: window.ConnectfinAPI.formatTime(msg.sentAt),
+            mine: msg.senderType === 'USER',
+            id: msg.id,
+          }]);
+        });
+      },
+      () => {} // 연결 실패 시 무시 — REST fallback으로 이미 히스토리 로드됨
+    );
+
+    return () => {
+      window.ConnectfinAPI.unsubscribe(`dm:${thread.id}`);
+    };
+  }, [thread?.id]);
+
   React.useEffect(() => {
     if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
   }, [messages]);
 
   const send = () => {
     if (!input.trim() || remaining <= 0) return;
-    setMessages(m => [...m, { id: nextId.current++, from: 'me', m: input, time: '방금' }]);
+    // STOMP로 전송 (연결돼 있을 때만)
+    if (window.ConnectfinAPI.getToken() && thread?.id) {
+      window.ConnectfinAPI.sendDm(thread.id, input);
+    }
+    // 로컬에도 즉시 추가 (optimistic)
+    setMessages(m => [...m, { id: nextId.current++, from: 'me', m: input, time: '방금', mine: true }]);
     setInput('');
     setRemaining(r => r - 1);
   };

--- a/src/main/resources/static/components/desktop-global.jsx
+++ b/src/main/resources/static/components/desktop-global.jsx
@@ -3,9 +3,34 @@
 // ──────────────── Home ────────────────
 function DesktopHome({ t, theme, onArtistOpen, onOpenLive, onNavGlobal }) {
   const [slideIdx, setSlideIdx] = React.useState(0);
+  const [liveNow, setLiveNow] = React.useState(ON_LIVE_NOW);
   React.useEffect(() => {
     const id = setInterval(() => setSlideIdx(i => (i + 1) % HERO_SLIDES.length), 4500);
     return () => clearInterval(id);
+  }, []);
+
+  React.useEffect(() => {
+    // 모든 아티스트의 라이브 목록에서 LIVE 상태만 필터
+    Promise.all(
+      ARTISTS.map(a =>
+        window.ConnectfinAPI.api(`/api/v1/artists/${a.id}/lives`)
+          .then(data => (data || []).filter(l => l.liveStatus === 'LIVE').map(l => ({
+            ...l, artistId: a.id, artistName: a.name, artistColor1: a.color1, artistColor2: a.color2,
+          })))
+          .catch(() => [])
+      )
+    ).then(results => {
+      const allLive = results.flat();
+      if (allLive.length > 0) {
+        setLiveNow(allLive.map(l => ({
+          id: l.id, artistId: l.artistId, title: l.title,
+          host: l.hostDisplayName || l.artistName,
+          viewers: 0, // API에 viewerCount 없음
+          artistName: l.artistName, color1: l.artistColor1, color2: l.artistColor2,
+          status: 'LIVE',
+        })));
+      }
+    });
   }, []);
 
   return (
@@ -50,10 +75,10 @@ function DesktopHome({ t, theme, onArtistOpen, onOpenLive, onNavGlobal }) {
           <div style={{
             padding: '1px 8px', borderRadius: 10, background: t.hot,
             color: '#fff', fontSize: 11, fontWeight: 800,
-          }}>{ON_LIVE_NOW.length}</div>
+          }}>{liveNow.length}</div>
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 14 }}>
-          {ON_LIVE_NOW.map(live => {
+          {liveNow.map(live => {
             const a = ARTISTS.find(x => x.id === live.artistId);
             return <OnLiveCard key={live.id} live={live} artist={a} t={t} onOpen={() => onOpenLive(live.artistId)}/>;
           })}

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -154,6 +154,51 @@ function formatDuration(seconds) {
   return `${m}:${String(s).padStart(2, '0')}`;
 }
 
+function ArtistMemberChip({ member, artist, t }) {
+  const [followed, setFollowed] = React.useState(false);
+  const [toggling, setToggling] = React.useState(false);
+
+  const toggleFollow = async (e) => {
+    e.stopPropagation();
+    if (toggling || !window.ConnectfinAPI.getToken()) return;
+    setToggling(true);
+    try {
+      const res = await window.ConnectfinAPI.api(
+        `/api/member/v1/follows/artist-members/${member.artistMemberId}/toggle`,
+        { method: 'POST' }
+      );
+      setFollowed(res.followed);
+    } catch (err) {
+      // 무시
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  return (
+    <div style={{
+      flexShrink: 0, display: 'flex', alignItems: 'center', gap: 6,
+      padding: '4px 10px 4px 4px', borderRadius: 20,
+      background: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(8px)',
+      color: '#fff', fontSize: 11, fontWeight: 600,
+    }}>
+      <div style={{
+        width: 24, height: 24, borderRadius: '50%',
+        background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 9, fontWeight: 800, color: '#fff',
+      }}>{member.stageName?.slice(0, 1)}</div>
+      <span>{member.stageName}</span>
+      <button onClick={toggleFollow} disabled={toggling} style={{
+        marginLeft: 2, padding: '2px 8px', borderRadius: 10, border: 'none',
+        background: followed ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.15)',
+        color: '#fff', fontSize: 10, fontWeight: 700, cursor: 'pointer',
+        opacity: toggling ? 0.5 : 1,
+      }}>{followed ? '팔로잉' : '팔로우'}</button>
+    </div>
+  );
+}
+
 // Artist cover hero (top banner with gradient)
 function ArtistCoverBanner({ artist, t, theme }) {
   return (
@@ -179,6 +224,18 @@ function ArtistCoverBanner({ artist, t, theme }) {
         padding: '8px 16px', borderRadius: 10, border: 'none',
         background: '#fff', color: '#111', fontWeight: 800, fontSize: 13, cursor: 'pointer',
       }}>가입하기</button>
+
+      {/* Artist Members */}
+      {artist.artistMembers && artist.artistMembers.length > 0 && (
+        <div style={{
+          position: 'absolute', top: 12, left: 24, right: 24,
+          display: 'flex', gap: 8, overflowX: 'auto',
+        }}>
+          {artist.artistMembers.slice().sort((a, b) => a.sortOrder - b.sortOrder).map(m => (
+            <ArtistMemberChip key={m.artistMemberId} member={m} artist={artist} t={t}/>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -226,8 +283,28 @@ function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive,
 // ────────── HIGHLIGHT (summary) ──────────
 function TabHighlight({ t, theme, artist, onNavProfile }) {
   const notices = NOTICES.filter(n => n.artistId === artist.id).slice(0, 5);
-  const artistPost = ARTIST_POSTS.find(p => p.artistId === artist.id);
-  const fanPosts = FAN_POSTS.filter(p => p.artistId === artist.id).slice(2, 8);
+  const mockArtistPost = ARTIST_POSTS.find(p => p.artistId === artist.id);
+  const mockFanPosts = FAN_POSTS.filter(p => p.artistId === artist.id).slice(2, 8);
+
+  const [artistPost, setArtistPost] = React.useState(mockArtistPost);
+  const [fanPosts, setFanPosts] = React.useState(mockFanPosts);
+  const [hotLetters, setHotLetters] = React.useState([]);
+
+  React.useEffect(() => {
+    window.ConnectfinAPI.api(`/api/member/v1/artists/${artist.id}/dashboard`)
+      .then(data => {
+        if (data.latestArtistPost) {
+          setArtistPost(mapArtistPost(data.latestArtistPost));
+        }
+        if (data.hotFanPosts && data.hotFanPosts.length > 0) {
+          setFanPosts(data.hotFanPosts.map(mapFanPost));
+        }
+        if (data.hotFanLetters && data.hotFanLetters.length > 0) {
+          setHotLetters(data.hotFanLetters);
+        }
+      })
+      .catch(() => { /* mock 유지 */ });
+  }, [artist.id]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
@@ -267,6 +344,44 @@ function TabHighlight({ t, theme, artist, onNavProfile }) {
           {fanPosts.map(p => <FanPostMiniCard key={p.id} post={p} artist={artist} t={t}/>)}
         </div>
       </Section>
+
+      {/* Hot Fan Letters */}
+      {hotLetters.length > 0 && (
+        <Section t={t} theme={theme}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <div style={{ fontWeight: 800, fontSize: 15 }}>🔥 Hot Fan Letters</div>
+            <button onClick={() => onNavProfile('fanletter')} style={linkBtn(t)}>더 보기 →</button>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 10 }}>
+            {hotLetters.slice(0, 4).map(fl => (
+              <div key={fl.fanLetterId} style={{
+                borderRadius: 10, overflow: 'hidden', aspectRatio: '3/4',
+                background: fl.image?.imageUrl ? 'transparent' : `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`,
+                position: 'relative',
+              }}>
+                {fl.image?.imageUrl ? (
+                  <img src={fl.image.imageUrl} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }}/>
+                ) : (
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#fff', fontSize: 24 }}>✉</div>
+                )}
+                {fl.artistLiked && (
+                  <div style={{
+                    position: 'absolute', bottom: 6, right: 6,
+                    width: 22, height: 22, borderRadius: '50%',
+                    background: 'rgba(255,255,255,0.9)', display: 'flex',
+                    alignItems: 'center', justifyContent: 'center', fontSize: 11,
+                  }}>💜</div>
+                )}
+                <div style={{
+                  position: 'absolute', bottom: 0, left: 0, right: 0,
+                  padding: '4px 8px', fontSize: 10, color: '#fff',
+                  background: 'linear-gradient(transparent, rgba(0,0,0,0.5))',
+                }}>♡ {window.ConnectfinAPI.formatCount(fl.likeCount)}</div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
     </div>
   );
 }

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -126,6 +126,34 @@ function LikeButton({ t, postType, artistId, postId, initialCount }) {
   );
 }
 
+function mapLiveReplay(live) {
+  return {
+    id: live.id || live.liveId,
+    artistId: live.artistId,
+    title: live.title,
+    duration: live.durationSeconds ? formatDuration(live.durationSeconds) : (live.duration || ''),
+    date: window.ConnectfinAPI.formatTime(live.replayPublishedAt || live.createdAt),
+    plays: '',
+    likes: '',
+    comments: 0,
+    voiceOnly: false,
+    membership: false,
+    liveStatus: live.liveStatus || 'ENDED',
+    thumbnailUrl: live.thumbnailUrl,
+    replayUrl: live.replayUrl,
+    hostDisplayName: live.hostDisplayName,
+  };
+}
+
+function formatDuration(seconds) {
+  if (!seconds || seconds <= 0) return '0:00';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
 // Artist cover hero (top banner with gradient)
 function ArtistCoverBanner({ artist, t, theme }) {
   return (
@@ -251,6 +279,12 @@ function TabFan({ t, theme, artist }) {
   const [hasNext, setHasNext] = React.useState(false);
   const [nextCursor, setNextCursor] = React.useState(null);
 
+  const [activeTab, setActiveTab] = React.useState('latest'); // 'latest' | 'hot'
+  const [hotPosts, setHotPosts] = React.useState([]);
+  const [hotHasNext, setHotHasNext] = React.useState(false);
+  const [hotNextScoreCursor, setHotNextScoreCursor] = React.useState(null);
+  const [hotNextIdCursor, setHotNextIdCursor] = React.useState(null);
+
   React.useEffect(() => {
     setLoading(true);
     window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-posts`)
@@ -276,17 +310,46 @@ function TabFan({ t, theme, artist }) {
       .finally(() => setLoading(false));
   };
 
+  const loadHot = (append = false) => {
+    setLoading(true);
+    let path = `/api/post/v1/artists/${artist.id}/fan-posts/hot`;
+    if (append && hotNextScoreCursor != null) {
+      path += `?scoreCursor=${hotNextScoreCursor}&idCursor=${hotNextIdCursor}`;
+    }
+    window.ConnectfinAPI.api(path)
+      .then(data => {
+        const mapped = data.content.map(mapFanPost);
+        if (append) {
+          setHotPosts(prev => [...prev, ...mapped]);
+        } else {
+          setHotPosts(mapped);
+        }
+        setHotHasNext(data.hasNext);
+        setHotNextScoreCursor(data.nextScoreCursor);
+        setHotNextIdCursor(data.nextIdCursor);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
   return (
     <div>
       <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
-        <Chip t={t} active>전체</Chip>
-        <Chip t={t}><span>🔥</span> Hot</Chip>
+        <Chip t={t} active={activeTab === 'latest'} onClick={() => setActiveTab('latest')}>전체</Chip>
+        <Chip t={t} active={activeTab === 'hot'} onClick={() => { setActiveTab('hot'); if (hotPosts.length === 0) loadHot(); }}><span>🔥</span> Hot</Chip>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        {posts.map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
+        {(activeTab === 'latest' ? posts : hotPosts).map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
       </div>
-      {hasNext && (
+      {activeTab === 'latest' && hasNext && (
         <button onClick={loadMore} disabled={loading} style={{
+          width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>{loading ? '로딩 중...' : '더 보기'}</button>
+      )}
+      {activeTab === 'hot' && hotHasNext && (
+        <button onClick={() => loadHot(true)} disabled={loading} style={{
           width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
           border: `1px solid ${t.line}`, background: 'transparent',
           color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
@@ -373,6 +436,47 @@ function TabFanLetter({ t, theme, artist }) {
   const [hasNext, setHasNext] = React.useState(false);
   const [nextCursor, setNextCursor] = React.useState(null);
 
+  const [activeTab, setActiveTab] = React.useState('latest');
+  const [hotLetters, setHotLetters] = React.useState([]);
+  const [hotHasNext, setHotHasNext] = React.useState(false);
+  const [hotNextOffset, setHotNextOffset] = React.useState(null);
+
+  const loadHotLetters = (append = false) => {
+    setLoading(true);
+    let path = `/api/post/v1/artists/${artist.id}/fan-letters/hot`;
+    if (append && hotNextOffset != null) {
+      path += `?offset=${hotNextOffset}`;
+    }
+    window.ConnectfinAPI.api(path)
+      .then(data => {
+        const mapped = data.content.map(item => ({
+          id: item.fanLetterId,
+          recipientType: item.recipientType,
+          recipientDisplayName: item.recipientDisplayName,
+          recipientProfileImageUrl: item.recipientProfileImageUrl,
+          imageUrl: item.image?.imageUrl || null,
+          thumbnailUrl: item.image?.thumbnailUrl || null,
+          artistLiked: item.artistLiked,
+          artistLikeDisplayName: item.artistLikeDisplayName,
+          artistLikeProfileImageUrl: item.artistLikeProfileImageUrl,
+          createdAt: item.createdAt,
+          likeCount: item.likeCount,
+          author: item.recipientDisplayName,
+          body: null,
+          texture: null,
+        }));
+        if (append) {
+          setHotLetters(prev => [...prev, ...mapped]);
+        } else {
+          setHotLetters(mapped);
+        }
+        setHotHasNext(data.hasNext);
+        setHotNextOffset(data.nextOffset);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
   React.useEffect(() => {
     if (!window.ConnectfinAPI.getToken()) return; // FanLetter 목록은 로그인 필수
     setLoading(true);
@@ -404,15 +508,15 @@ function TabFanLetter({ t, theme, artist }) {
   return (
     <div>
       <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
-        <Chip t={t} active>전체</Chip>
-        <Chip t={t}><span>🔥</span> Hot</Chip>
+        <Chip t={t} active={activeTab === 'latest'} onClick={() => setActiveTab('latest')}>전체</Chip>
+        <Chip t={t} active={activeTab === 'hot'} onClick={() => { setActiveTab('hot'); if (hotLetters.length === 0) loadHotLetters(); }}><span>🔥</span> Hot</Chip>
         <div style={{ flex: 1 }}/>
         <Chip t={t}>🌐 한국어</Chip>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-        {letters.map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => openDetail(l)}/>)}
+        {(activeTab === 'latest' ? letters : hotLetters).map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => openDetail(l)}/>)}
       </div>
-      {hasNext && (
+      {activeTab === 'latest' && hasNext && (
         <button onClick={() => {
           if (!hasNext || !nextCursor || loading) return;
           setLoading(true);
@@ -425,6 +529,13 @@ function TabFanLetter({ t, theme, artist }) {
             .catch(() => {})
             .finally(() => setLoading(false));
         }} disabled={loading} style={{
+          width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>{loading ? '로딩 중...' : '더 보기'}</button>
+      )}
+      {activeTab === 'hot' && hotHasNext && (
+        <button onClick={() => loadHotLetters(true)} disabled={loading} style={{
           width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
           border: `1px solid ${t.line}`, background: 'transparent',
           color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
@@ -640,7 +751,19 @@ function MediaCard({ media, artist, t, small }) {
 
 // ────────── LIVE (리플레이 그리드) ──────────
 function TabLive({ t, theme, artist, onOpenLive }) {
-  const replays = LIVE_REPLAYS.filter(r => r.artistId === artist.id);
+  const mockReplays = LIVE_REPLAYS.filter(r => r.artistId === artist.id);
+  const [replays, setReplays] = React.useState(mockReplays);
+
+  React.useEffect(() => {
+    window.ConnectfinAPI.api(`/api/v1/artists/${artist.id}/lives/vods`)
+      .then(data => {
+        if (data.content && data.content.length > 0) {
+          setReplays(data.content.map(mapLiveReplay));
+        }
+      })
+      .catch(() => { /* mock 유지 */ });
+  }, [artist.id]);
+
   return (
     <div>
       <Section t={t} theme={theme}>
@@ -749,9 +872,9 @@ function Section({ t, theme, children, style }) {
   );
 }
 
-function Chip({ t, active, children }) {
+function Chip({ t, active, children, onClick }) {
   return (
-    <button style={{
+    <button onClick={onClick} style={{
       padding: '6px 14px', borderRadius: 16, border: active ? 'none' : `1px solid ${t.line}`,
       background: active ? (t.name === 'Y2K Pop' ? t.hot : t.hot) : 'transparent',
       color: active ? '#fff' : t.text, fontSize: 12, fontWeight: 700, cursor: 'pointer',

--- a/src/main/resources/static/components/screens-main.jsx
+++ b/src/main/resources/static/components/screens-main.jsx
@@ -161,9 +161,9 @@ function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }
                   <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 10 }}>
                     <ArtistAvatar artist={a} size={40} t={t}/>
                     <div style={{ flex: 1 }}>
-                      <span style={{ fontWeight: 700, fontSize: 14 }}>{item.stageName}</span>
+                      <span style={{ fontWeight: 700, fontSize: 14 }}>{item.post?.writerNickname || item.stageName}</span>
                       <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
-                        {item.artist.name} · {window.ConnectfinAPI.formatTime(item.post.createdAt)}
+                        {item.stageName} · {item.artist.name} · {window.ConnectfinAPI.formatTime(item.post.createdAt)}
                       </div>
                     </div>
                   </div>

--- a/src/main/resources/static/components/screens-main.jsx
+++ b/src/main/resources/static/components/screens-main.jsx
@@ -3,6 +3,7 @@
 function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }) {
   const liveArtists = ARTISTS.filter(a => a.live && liveOn);
   const [viewers, setViewers] = React.useState(liveArtists.map(a => a.viewers));
+  const [dashboard, setDashboard] = React.useState(null);
 
   React.useEffect(() => {
     if (!liveOn) return;
@@ -11,6 +12,13 @@ function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }
     }, 900 / speed);
     return () => clearInterval(id);
   }, [speed, liveOn]);
+
+  React.useEffect(() => {
+    if (!window.ConnectfinAPI.getToken()) return;
+    window.ConnectfinAPI.api('/api/member/v1/home/dashboard')
+      .then(data => setDashboard(data))
+      .catch(() => {});
+  }, []);
 
   return (
     <div style={{ height: '100%', overflowY: 'auto', paddingTop: 54, paddingBottom: 96 }}>
@@ -91,7 +99,87 @@ function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }
         <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18, letterSpacing: -0.4, marginBottom: 10 }}>
           Today's Feed
         </div>
-        {FEED_POSTS.map(post => {
+
+        {/* 대시보드 API 로드 시 — 구독 아티스트 최신 글 */}
+        {dashboard?.subscribedArtistsLatestPosts?.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            {dashboard.subscribedArtistsLatestPosts.map(item => (
+              <div key={item.artist.artistId} style={{ marginBottom: 14 }}>
+                <div style={{
+                  display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8,
+                  fontSize: 12, fontWeight: 700, color: t.textDim,
+                }}>
+                  <span style={{ fontSize: 14 }}>⭐</span>
+                  {item.artist.name}의 최신 소식
+                </div>
+                {item.posts.map(post => {
+                  const a = ARTISTS.find(x => x.id === item.artist.artistId) || { name: item.artist.name, id: item.artist.artistId, color1: t.accent, color2: t.accent2 };
+                  return (
+                    <div key={post.artistPostId} onClick={() => onOpenArtist(item.artist.artistId)} style={{
+                      background: t.surface, borderRadius: 20, padding: 16, marginBottom: 10,
+                      border: `1px solid ${t.accent}40`, cursor: 'pointer',
+                    }}>
+                      <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 10 }}>
+                        <ArtistAvatar artist={a} size={40} t={t}/>
+                        <div style={{ flex: 1 }}>
+                          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                            <span style={{ fontWeight: 700, fontSize: 14 }}>{post.writerNickname}</span>
+                            {post.artistBadge && (
+                              <span style={{ fontSize: 9, fontWeight: 800, padding: '2px 6px', borderRadius: 4, background: t.gradient, color: '#fff' }}>ARTIST ✓</span>
+                            )}
+                          </div>
+                          <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+                            {window.ConnectfinAPI.formatTime(post.createdAt)}
+                          </div>
+                        </div>
+                      </div>
+                      <div style={{ fontSize: 14, lineHeight: 1.55, color: t.text }}>{post.content}</div>
+                      <div style={{ display: 'flex', gap: 18, marginTop: 12, fontSize: 12, color: t.textDim }}>
+                        <span>♡ {window.ConnectfinAPI.formatCount(post.likeCount)}</span>
+                        <span>💬 {post.commentCount}</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 대시보드 API 로드 시 — 팔로우 멤버 최신 글 */}
+        {dashboard?.followedArtistMembersLatestPosts?.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: t.textDim, marginBottom: 10 }}>팔로우 멤버 소식</div>
+            {dashboard.followedArtistMembersLatestPosts.map(item => {
+              if (!item.post) return null;
+              const a = ARTISTS.find(x => x.id === item.artist.artistId) || { name: item.artist.name, id: item.artist.artistId, color1: t.accent, color2: t.accent2 };
+              return (
+                <div key={item.artistMemberId} onClick={() => onOpenArtist(item.artist.artistId)} style={{
+                  background: t.surface, borderRadius: 20, padding: 16, marginBottom: 10,
+                  border: `1px solid ${t.line}`, cursor: 'pointer',
+                }}>
+                  <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 10 }}>
+                    <ArtistAvatar artist={a} size={40} t={t}/>
+                    <div style={{ flex: 1 }}>
+                      <span style={{ fontWeight: 700, fontSize: 14 }}>{item.stageName}</span>
+                      <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>
+                        {item.artist.name} · {window.ConnectfinAPI.formatTime(item.post.createdAt)}
+                      </div>
+                    </div>
+                  </div>
+                  <div style={{ fontSize: 14, lineHeight: 1.55, color: t.text }}>{item.post.content}</div>
+                  <div style={{ display: 'flex', gap: 18, marginTop: 12, fontSize: 12, color: t.textDim }}>
+                    <span>♡ {window.ConnectfinAPI.formatCount(item.post.likeCount)}</span>
+                    <span>💬 {item.post.commentCount}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* 기존 mock 피드 (대시보드가 없거나 비로그인) */}
+        {!dashboard && FEED_POSTS.map(post => {
           const a = ARTISTS.find(x => x.id === post.artistId);
           const isArtist = post.type === 'artist';
           return (
@@ -141,7 +229,7 @@ function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }
           );
         })}
         <div style={{ textAlign: 'center', padding: 20, color: t.textMuted, fontFamily: t.fontMono, fontSize: 11 }}>
-          — Cursor: id &lt; 101 —
+          — {dashboard ? 'Dashboard loaded' : 'Cursor: id < 101'} —
         </div>
       </div>
     </div>

--- a/src/main/resources/static/components/screens-raffle.jsx
+++ b/src/main/resources/static/components/screens-raffle.jsx
@@ -51,11 +51,63 @@ const RAFFLES = [
   },
 ];
 
+function mapRaffle(r) {
+  const endTime = r.startedAt && r.durationMinutes
+    ? new Date(new Date(r.startedAt).getTime() + r.durationMinutes * 60000)
+    : null;
+  const now = new Date();
+  const ended = r.status === 'COMPLETED' || r.status === 'CANCELLED';
+  const remaining = endTime && !ended ? endTime - now : 0;
+
+  let endsAt = '종료됨';
+  if (!ended && remaining > 0) {
+    const h = Math.floor(remaining / 3600000);
+    const m = Math.floor((remaining % 3600000) / 60000);
+    if (h >= 24) endsAt = `${Math.floor(h / 24)}d ${h % 24}h`;
+    else endsAt = `${h}h ${m}m`;
+  }
+
+  return {
+    id: r.id,
+    artistId: r.artistId,
+    title: r.title,
+    category: r.rewardType || 'GENERAL',
+    prize: r.title,
+    winners: r.totalWinners,
+    cost: 0, // API에 cost 필드 없음
+    endsAt,
+    entries: 0,
+    maxWeight: 1,
+    hot: false,
+    ended,
+    desc: '',
+    rules: [],
+    entryCondition: r.entryCondition,
+    status: r.status,
+  };
+}
+
 function RaffleListScreen({ t, onBack, onOpenRaffle }) {
   const [filter, setFilter] = React.useState('all');
-  const filtered = filter === 'all' ? RAFFLES.filter(r => !r.ended)
-    : filter === 'ended' ? RAFFLES.filter(r => r.ended)
-    : RAFFLES.filter(r => r.category === filter);
+  const [raffles, setRaffles] = React.useState(RAFFLES);
+
+  React.useEffect(() => {
+    // 모든 아티스트의 래플을 한번에 로드
+    Promise.all(
+      ARTISTS.map(a =>
+        window.ConnectfinAPI.api(`/api/v1/artists/${a.id}/raffles`)
+          .then(data => (data || []).map(r => ({ ...mapRaffle(r), artistId: a.id })))
+          .catch(() => [])
+      )
+    ).then(results => {
+      const all = results.flat();
+      if (all.length > 0) setRaffles(all);
+    });
+  }, []);
+
+  const filtered = filter === 'all' ? raffles.filter(r => !r.ended)
+    : filter === 'ended' ? raffles.filter(r => r.ended)
+    : raffles.filter(r => r.category === filter);
 
   return (
     <div style={{ height: '100%', overflowY: 'auto', paddingTop: 60, paddingBottom: 96 }}>
@@ -184,22 +236,43 @@ function RaffleListScreen({ t, onBack, onOpenRaffle }) {
 }
 
 function RaffleDetailScreen({ t, theme, raffleId, onBack, onEnter }) {
-  const r = RAFFLES.find(x => x.id === raffleId) || RAFFLES[0];
+  const mockR = RAFFLES.find(x => x.id === raffleId) || RAFFLES[0];
+  const [r, setR] = React.useState(mockR);
+  const [myEntry, setMyEntry] = React.useState(null);
   const a = ARTISTS.find(x => x.id === r.artistId);
   const [weight, setWeight] = React.useState(1);
   const [agreed, setAgreed] = React.useState(false);
   const [entering, setEntering] = React.useState(false);
-  const [result, setResult] = React.useState(null); // 'submitted'
+  const [result, setResult] = React.useState(null); // 'submitted' | 'error'
   const totalCost = r.cost * weight;
   const myBalance = 142;
 
-  const submit = () => {
-    if (r.ended || !agreed || totalCost > myBalance || entering) return;
+  React.useEffect(() => {
+    if (!r.artistId) return;
+    // 래플 상세
+    window.ConnectfinAPI.api(`/api/v1/artists/${r.artistId}/raffles/${raffleId}`)
+      .then(data => setR(prev => ({ ...prev, ...mapRaffle(data), entered: data.entered })))
+      .catch(() => {});
+    // 내 응모 결과
+    if (window.ConnectfinAPI.getToken()) {
+      window.ConnectfinAPI.api(`/api/v1/artists/${r.artistId}/raffles/${raffleId}/entries/me`)
+        .then(data => setMyEntry(data))
+        .catch(() => {});
+    }
+  }, [raffleId]);
+
+  const submit = async () => {
+    if (r.ended || !agreed || entering) return;
+    if (!window.ConnectfinAPI.getToken()) return;
     setEntering(true);
-    setTimeout(() => {
-      setEntering(false);
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/artists/${r.artistId}/raffles/${raffleId}/entries`, { method: 'POST' });
       setResult('submitted');
-    }, 1400);
+    } catch (err) {
+      setResult('error');
+    } finally {
+      setEntering(false);
+    }
   };
 
   return (

--- a/src/main/resources/static/components/screens-realtime.jsx
+++ b/src/main/resources/static/components/screens-realtime.jsx
@@ -8,11 +8,12 @@ function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
   const [viewers, setViewers] = React.useState(a.viewers || 58_000);
   const [hearts, setHearts] = React.useState([]);
   const [input, setInput] = React.useState('');
+  const [stompConnected, setStompConnected] = React.useState(false);
   const listRef = React.useRef(null);
   const nextId = React.useRef(100);
 
   React.useEffect(() => {
-    if (!liveOn) return;
+    if (!liveOn || stompConnected) return; // STOMP 연결 시 mock 비활성화
     const id = setInterval(() => {
       const seed = LIVE_SEEDS[Math.floor(Math.random() * LIVE_SEEDS.length)];
       setMessages(m => [...m.slice(-40), { ...seed, id: nextId.current++, t: seed.t || 'fan' }]);
@@ -22,7 +23,34 @@ function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
       }
     }, 700 / speed);
     return () => clearInterval(id);
-  }, [speed, liveOn]);
+  }, [speed, liveOn, stompConnected]);
+
+  // STOMP 라이브 채팅 연결
+  React.useEffect(() => {
+    if (!liveOn || !window.ConnectfinAPI.getToken()) return;
+
+    window.ConnectfinAPI.connectStomp(
+      () => {
+        setStompConnected(true);
+        window.ConnectfinAPI.subscribeLive(a.id, (batch) => {
+          const mapped = batch.map(msg => ({
+            id: msg.id || nextId.current++,
+            u: msg.senderUserId === 'me' ? 'me' : `user_${msg.senderUserId}`,
+            m: msg.message,
+            t: 'fan',
+          }));
+          setMessages(prev => [...prev.slice(-40), ...mapped]);
+        });
+      },
+      (err) => {
+        console.warn('STOMP connection failed, using mock:', err);
+      }
+    );
+
+    return () => {
+      window.ConnectfinAPI.unsubscribe(`live:${a.id}`);
+    };
+  }, [liveOn, a.id]);
 
   React.useEffect(() => {
     if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
@@ -30,6 +58,11 @@ function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
 
   const send = () => {
     if (!input.trim()) return;
+    if (stompConnected) {
+      // STOMP로 전송 — 서버가 브로드캐스트하면 subscribeLive에서 수신
+      window.ConnectfinAPI.sendLiveChat(a.id, input);
+    }
+    // 로컬에도 즉시 추가 (optimistic)
     setMessages(m => [...m, { id: nextId.current++, u: 'me', m: input, t: 'me' }]);
     setInput('');
   };


### PR DESCRIPTION
## Summary

프론트엔드 정적 컴포넌트를 mock 데이터에서 실 백엔드 API로 대거 교체. 세 단위 작업이 한 브랜치에 순차 누적됨:

- **#119** 라이브/VOD, DM 목록/메시지, 래플(목록·상세·응모), Fan Post/Fan Letter HOT 탭 연동
- **#120** 홈 대시보드 / 아티스트 Highlight 대시보드 / Follow 토글 (멤버 캐러셀 포함)
- **#123** STOMP over SockJS 클라이언트 도입 — 라이브 채팅 구독/전송, DM 실시간 구독/전송

모든 API 호출은 실패 시 기존 mock 데이터로 fallback 되도록 구성 (로그인 전/네트워크 실패에서도 화면이 비지 않음).

## 변경 파일

| 파일 | 주요 변경 |
|---|---|
| `api-client.jsx` | STOMP 함수 7개 추가 (connectStomp 중복 연결 가드, subscribe/send Live·Dm, unsubscribe, disconnectStomp) |
| `desktop-profile.jsx` | mapLiveReplay/formatDuration, TabLive VOD, TabFan/TabFanLetter HOT, Chip onClick, TabHighlight dashboard, HOT Fan Letters 섹션, ArtistMemberChip 신규, ArtistCoverBanner 멤버 캐러셀 |
| `desktop-global.jsx` | DesktopHome liveNow API (ARTISTS 순회 + LIVE 필터) |
| `desktop-dm.jsx` | rooms + messages REST, STOMP subscribeDm + sendDm |
| `screens-raffle.jsx` | mapRaffle + list/detail/entry API |
| `screens-realtime.jsx` | LiveScreen stompConnected state + subscribeLive + sendLiveChat (setInterval mock은 fallback) |
| `screens-main.jsx` | HomeScreen dashboard API (구독 아티스트/팔로우 멤버/mock 삼분) + writerNickname 표시 fix |

## 커밋 내역
- `a5c70c2` Feat: 라이브/VOD, DM, 래플, HOT 탭 API 연동
- `ea13bde` Feat: 홈/아티스트 대시보드, Follow 토글 연동
- `118faad` Feat: STOMP 라이브 채팅 + DM 실시간 연동
- `7b8bb24` Fix: HomeScreen 팔로우 멤버 피드 작성자 이름을 writerNickname으로 표시

## 주의사항
- **STOMP 페이로드**: 라이브/DM 둘 다 `@Payload String` — `publish.body`에 텍스트 문자열 그대로 (JSON 래핑 X)
- **라이브 채팅 배치**: `/sub/live/{id}`는 서버가 300ms마다 List로 flush → 콜백은 배열 수신
- **중복 연결 방지**: `connectStomp` 내부에 `stompClient.connected` 가드. LiveScreen과 DMConversationPanel이 각각 호출해도 단일 연결 재사용
- **FanPost HOT**: ScoreCursor(`nextScoreCursor` + `nextIdCursor`) 복합 커서
- **FanLetter HOT**: Offset 기반 (`nextOffset`) — 일반 cursor와 다름
- **v3 ArtistPost 좋아요**: 202 Accepted + `expectedReacted`만 돌려줌 (count는 optimistic 유지)
- **대시보드 API**: 홈 `/api/member/v1/home/dashboard`는 로그인 필수. 아티스트 `/api/member/v1/artists/{id}/dashboard`도 authenticated. 실패 시 mock 유지

## Test plan
- [ ] `./gradlew compileJava` 성공 (로컬 확인됨)
- [ ] 로그인 전: 홈/아티스트 프로필/래플 화면 모두 mock 데이터로 렌더링 되어 비지 않음
- [ ] 로그인 후 홈 진입: 구독 아티스트/팔로우 멤버 피드 표시
- [ ] 아티스트 프로필 Highlight: 대시보드 + HOT Fan Letters 섹션 표시
- [ ] ArtistCoverBanner: 멤버 캐러셀 표시 + Follow 토글 동작
- [ ] FanPost/FanLetter 탭에서 🔥 Hot Chip 전환 및 더 보기
- [ ] 래플 목록 → 상세 → 응모 submit이 실제 POST 전송 및 성공 모달
- [ ] DM 진입 시 히스토리 로드 + STOMP 구독 + 전송 시 수신 echo 확인
- [ ] 라이브 진입 시 STOMP 구독, 실패 시 setInterval mock fallback 유지

Closes #119
Closes #120
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)