### PR TITLE
Fix: STOMP 구독 중복 방지, catch 로깅, 에코 중복 필터링

### DIFF
--- a/src/main/resources/static/components/api-client.jsx
+++ b/src/main/resources/static/components/api-client.jsx
@@ -201,6 +201,8 @@ const ConnectfinAPI = (() => {
   // 라이브 채팅 구독 — 서버가 300ms마다 배치(List) 전송
   function subscribeLive(liveId, onBatch) {
     if (!stompClient || !stompClient.connected) return null;
+    const subKey = `live:${liveId}`;
+    if (stompSubscriptions[subKey]) stompSubscriptions[subKey].unsubscribe();
     const sub = stompClient.subscribe(`/sub/live/${liveId}`, (message) => {
       try {
         const batch = JSON.parse(message.body);
@@ -209,7 +211,7 @@ const ConnectfinAPI = (() => {
         console.error('Live chat parse error:', e);
       }
     });
-    stompSubscriptions[`live:${liveId}`] = sub;
+    stompSubscriptions[subKey] = sub;
     return sub;
   }
 
@@ -225,6 +227,8 @@ const ConnectfinAPI = (() => {
   // DM 구독 — 단건 메시지 수신
   function subscribeDm(roomId, onMessage) {
     if (!stompClient || !stompClient.connected) return null;
+    const subKey = `dm:${roomId}`;
+    if (stompSubscriptions[subKey]) stompSubscriptions[subKey].unsubscribe();
     const sub = stompClient.subscribe(`/sub/dm/${roomId}`, (message) => {
       try {
         const msg = JSON.parse(message.body);
@@ -233,7 +237,7 @@ const ConnectfinAPI = (() => {
         console.error('DM parse error:', e);
       }
     });
-    stompSubscriptions[`dm:${roomId}`] = sub;
+    stompSubscriptions[subKey] = sub;
     return sub;
   }
 

--- a/src/main/resources/static/components/desktop-dm.jsx
+++ b/src/main/resources/static/components/desktop-dm.jsx
@@ -23,7 +23,7 @@ function DesktopDMScreen({ t, theme, onExit }) {
           setActiveId(mapped[0].id);
         }
       })
-      .catch(() => { /* mock 유지 */ });
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
   }, []);
 
   const activeThread = rooms.find(x => x.id === activeId) || rooms[0];
@@ -200,7 +200,7 @@ function DMConversationPanel({ thread, artist, t, theme }) {
           })));
         }
       })
-      .catch(() => { /* mock 유지 */ });
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
   }, [thread?.id]);
 
   // STOMP DM 실시간 수신
@@ -210,16 +210,25 @@ function DMConversationPanel({ thread, artist, t, theme }) {
     window.ConnectfinAPI.connectStomp(
       () => {
         window.ConnectfinAPI.subscribeDm(thread.id, (msg) => {
-          setMessages(prev => [...prev, {
-            from: msg.senderType === 'USER' ? 'me' : (artist?.name || 'Artist'),
-            m: msg.content,
-            time: window.ConnectfinAPI.formatTime(msg.sentAt),
-            mine: msg.senderType === 'USER',
-            id: msg.id,
-          }]);
+          setMessages(prev => {
+            // 1차: 같은 id의 메시지가 이미 있으면 (optimistic 추가분) 스킵
+            if (msg.id && prev.some(m => m.id === msg.id)) return prev;
+            // 2차: 내가 보낸 optimistic 추가분의 에코 (id 매칭 실패 시 content + '방금' 체크)
+            if (msg.senderType === 'USER') {
+              const recentLocal = prev.filter(m => m.mine && m.time === '방금');
+              if (recentLocal.some(m => m.m === msg.content)) return prev;
+            }
+            return [...prev, {
+              from: msg.senderType === 'USER' ? 'me' : (artist?.name || 'Artist'),
+              m: msg.content,
+              time: window.ConnectfinAPI.formatTime(msg.sentAt),
+              mine: msg.senderType === 'USER',
+              id: msg.id,
+            }];
+          });
         });
       },
-      () => {} // 연결 실패 시 무시 — REST fallback으로 이미 히스토리 로드됨
+      (err) => { console.warn('STOMP connect fallback:', err?.message || err); }
     );
 
     return () => {

--- a/src/main/resources/static/components/desktop-global.jsx
+++ b/src/main/resources/static/components/desktop-global.jsx
@@ -17,7 +17,7 @@ function DesktopHome({ t, theme, onArtistOpen, onOpenLive, onNavGlobal }) {
           .then(data => (data || []).filter(l => l.liveStatus === 'LIVE').map(l => ({
             ...l, artistId: a.id, artistName: a.name, artistColor1: a.color1, artistColor2: a.color2,
           })))
-          .catch(() => [])
+          .catch(err => { console.warn('API batch item failed:', err?.message || err); return []; })
       )
     ).then(results => {
       const allLive = results.flat();

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -247,7 +247,7 @@ function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive,
   React.useEffect(() => {
     window.ConnectfinAPI.api(`/api/member/v2/artists/${artist.id}`)
       .then(data => setArtistDetail(data))
-      .catch(() => { /* mock 유지 */ });
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
   }, [artist.id]);
 
   const displayArtist = artistDetail ? {
@@ -303,7 +303,7 @@ function TabHighlight({ t, theme, artist, onNavProfile }) {
           setHotLetters(data.hotFanLetters);
         }
       })
-      .catch(() => { /* mock 유지 */ });
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
   }, [artist.id]);
 
   return (
@@ -408,7 +408,7 @@ function TabFan({ t, theme, artist }) {
         setHasNext(data.hasNext);
         setNextCursor(data.nextCursor);
       })
-      .catch(() => { /* mock 유지 */ })
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); })
       .finally(() => setLoading(false));
   }, [artist.id]);
 
@@ -421,7 +421,7 @@ function TabFan({ t, theme, artist }) {
         setHasNext(data.hasNext);
         setNextCursor(data.nextCursor);
       })
-      .catch(() => {})
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); })
       .finally(() => setLoading(false));
   };
 
@@ -443,7 +443,7 @@ function TabFan({ t, theme, artist }) {
         setHotNextScoreCursor(data.nextScoreCursor);
         setHotNextIdCursor(data.nextIdCursor);
       })
-      .catch(() => {})
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); })
       .finally(() => setLoading(false));
   };
 
@@ -490,7 +490,7 @@ function TabArtistPosts({ t, theme, artist }) {
         setHasNext(data.hasNext);
         setNextCursor(data.nextCursor);
       })
-      .catch(() => { /* mock 유지 */ })
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); })
       .finally(() => setLoading(false));
   }, [artist.id]);
 
@@ -503,7 +503,7 @@ function TabArtistPosts({ t, theme, artist }) {
         setHasNext(data.hasNext);
         setNextCursor(data.nextCursor);
       })
-      .catch(() => {})
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); })
       .finally(() => setLoading(false));
   };
 
@@ -588,7 +588,7 @@ function TabFanLetter({ t, theme, artist }) {
         setHotHasNext(data.hasNext);
         setHotNextOffset(data.nextOffset);
       })
-      .catch(() => {})
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); })
       .finally(() => setLoading(false));
   };
 
@@ -601,7 +601,7 @@ function TabFanLetter({ t, theme, artist }) {
         setHasNext(data.hasNext);
         setNextCursor(data.nextCursor);
       })
-      .catch(() => { /* mock 유지 */ })
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); })
       .finally(() => setLoading(false));
   }, [artist.id]);
 
@@ -611,7 +611,7 @@ function TabFanLetter({ t, theme, artist }) {
     if (window.ConnectfinAPI.getToken() && letter.id) {
       window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters/${letter.id}`)
         .then(data => setSelectedDetail(data))
-        .catch(() => setSelectedDetail(null));
+        .catch(err => { console.warn('Fan letter detail load failed:', err?.message || err); setSelectedDetail(null); });
     }
   };
 
@@ -641,7 +641,7 @@ function TabFanLetter({ t, theme, artist }) {
               setHasNext(data.hasNext);
               setNextCursor(data.nextCursor);
             })
-            .catch(() => {})
+            .catch(err => { console.warn('API error suppressed:', err?.message || err); })
             .finally(() => setLoading(false));
         }} disabled={loading} style={{
           width: '100%', padding: '12px 0', marginTop: 12, borderRadius: 10,
@@ -876,7 +876,7 @@ function TabLive({ t, theme, artist, onOpenLive }) {
           setReplays(data.content.map(mapLiveReplay));
         }
       })
-      .catch(() => { /* mock 유지 */ });
+      .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
   }, [artist.id]);
 
   return (

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -290,7 +290,7 @@ function ArtistSearchSection({ t, theme, onArtistOpen }) {
   React.useEffect(() => {
     window.ConnectfinAPI.api('/api/member/v1/artists/search/popular?limit=5')
       .then(data => setPopular(data || []))
-      .catch(() => {});
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); });
   }, []);
 
   // 검색 (debounce 300ms)
@@ -305,7 +305,7 @@ function ArtistSearchSection({ t, theme, onArtistOpen }) {
     debounceRef.current = setTimeout(() => {
       window.ConnectfinAPI.api(`/api/member/v2/artists/search?keyword=${encodeURIComponent(query)}`)
         .then(data => setResults(data.content || []))
-        .catch(() => setResults([]));
+        .catch(err => { console.warn('Search failed:', err?.message || err); setResults([]); });
     }, 300);
     return () => clearTimeout(debounceRef.current);
   }, [query]);

--- a/src/main/resources/static/components/screens-main.jsx
+++ b/src/main/resources/static/components/screens-main.jsx
@@ -17,7 +17,7 @@ function HomeScreen({ t, theme, speed, liveOn, onNav, onOpenLive, onOpenArtist }
     if (!window.ConnectfinAPI.getToken()) return;
     window.ConnectfinAPI.api('/api/member/v1/home/dashboard')
       .then(data => setDashboard(data))
-      .catch(() => {});
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); });
   }, []);
 
   return (

--- a/src/main/resources/static/components/screens-raffle.jsx
+++ b/src/main/resources/static/components/screens-raffle.jsx
@@ -97,7 +97,7 @@ function RaffleListScreen({ t, onBack, onOpenRaffle }) {
       ARTISTS.map(a =>
         window.ConnectfinAPI.api(`/api/v1/artists/${a.id}/raffles`)
           .then(data => (data || []).map(r => ({ ...mapRaffle(r), artistId: a.id })))
-          .catch(() => [])
+          .catch(err => { console.warn('API batch item failed:', err?.message || err); return []; })
       )
     ).then(results => {
       const all = results.flat();
@@ -252,12 +252,12 @@ function RaffleDetailScreen({ t, theme, raffleId, onBack, onEnter }) {
     // 래플 상세
     window.ConnectfinAPI.api(`/api/v1/artists/${r.artistId}/raffles/${raffleId}`)
       .then(data => setR(prev => ({ ...prev, ...mapRaffle(data), entered: data.entered })))
-      .catch(() => {});
+      .catch(err => { console.warn('API error suppressed:', err?.message || err); });
     // 내 응모 결과
     if (window.ConnectfinAPI.getToken()) {
       window.ConnectfinAPI.api(`/api/v1/artists/${r.artistId}/raffles/${raffleId}/entries/me`)
         .then(data => setMyEntry(data))
-        .catch(() => {});
+        .catch(err => { console.warn('API error suppressed:', err?.message || err); });
     }
   }, [raffleId]);
 

--- a/src/main/resources/static/components/screens-realtime.jsx
+++ b/src/main/resources/static/components/screens-realtime.jsx
@@ -33,13 +33,21 @@ function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
       () => {
         setStompConnected(true);
         window.ConnectfinAPI.subscribeLive(a.id, (batch) => {
-          const mapped = batch.map(msg => ({
-            id: msg.id || nextId.current++,
-            u: msg.senderUserId === 'me' ? 'me' : `user_${msg.senderUserId}`,
-            m: msg.message,
-            t: 'fan',
-          }));
-          setMessages(prev => [...prev.slice(-40), ...mapped]);
+          setMessages(prev => {
+            // 서버 에코에서 이미 로컬에 추가한 내 메시지를 필터링
+            const localTexts = new Set(prev.filter(m => m._local).map(m => m.m));
+            const mapped = batch
+              .filter(msg => !localTexts.has(msg.message))
+              .map(msg => ({
+                id: msg.id || nextId.current++,
+                u: `user_${msg.senderUserId}`,
+                m: msg.message,
+                t: 'fan',
+              }));
+            // 에코 필터 후 로컬 플래그 제거 (1회성)
+            const cleaned = prev.map(m => m._local ? { ...m, _local: false } : m);
+            return [...cleaned.slice(-40), ...mapped];
+          });
         });
       },
       (err) => {
@@ -62,8 +70,8 @@ function LiveScreen({ t, theme, artistId, speed, liveOn, onBack, onNav }) {
       // STOMP로 전송 — 서버가 브로드캐스트하면 subscribeLive에서 수신
       window.ConnectfinAPI.sendLiveChat(a.id, input);
     }
-    // 로컬에도 즉시 추가 (optimistic)
-    setMessages(m => [...m, { id: nextId.current++, u: 'me', m: input, t: 'me' }]);
+    // 로컬에도 즉시 추가 (optimistic) — _local 플래그로 서버 에코 1회 필터링
+    setMessages(m => [...m, { id: nextId.current++, u: 'me', m: input, t: 'me', _local: true }]);
     setInput('');
   };
 


### PR DESCRIPTION
## Summary

F-3까지 머지된 프론트엔드 통합 코드의 3가지 보강:

1. **STOMP 구독 중복 방지** — `api-client.jsx`의 `subscribeLive`/`subscribeDm`에 기존 구독 해제 가드 추가. 탭 전환/재진입 시 subscription 누수 차단
2. **Empty catch → console.warn** — 전 JSX의 무음 삼키기 catch(7개 파일, 22건)를 `console.warn`으로 교체. 기존 동작(예: `setResults([])`, `setSelectedDetail(null)`)은 그대로 보존
3. **STOMP 에코 중복 방지**
   - **라이브**: 로컬 메시지에 `_local: true` 플래그 → 서버 에코 1회 필터링 → 플래그 제거
   - **DM**: 1차 `msg.id` 중복 체크, 2차 content + `time === '방금'` 매칭으로 optimistic 에코 필터

## 변경 파일

| 파일 | 변경 |
|---|---|
| `api-client.jsx` | subscribeLive/subscribeDm 중복 구독 가드 |
| `desktop-profile.jsx` | catch 12건 교체 (mock 유지, 빈 catch, setSelectedDetail) |
| `desktop-dm.jsx` | mock 유지 catch 2건 + subscribeDm 중복 체크 + STOMP 에러 콜백 로깅 |
| `desktop-global.jsx` | Promise.all 내부 catch |
| `desktop-shell.jsx` | 빈 catch + setResults catch |
| `screens-raffle.jsx` | Promise.all + 빈 catch 2건 |
| `screens-main.jsx` | 빈 catch |
| `screens-realtime.jsx` | send `_local: true`, subscribeLive `localTexts` 필터 |

## 주의사항
- **_local 플래그는 1회성**: 에코를 한 번 필터링한 뒤 `_local: false`로 해제해, 동일 텍스트를 다른 사용자가 보낼 때 잘못 필터링되지 않도록 함
- **DM은 id 우선**: optimistic 추가분은 로컬 nextId를 쓰므로 서버 id와 다를 수 있음 → id 매칭 실패 시 content + '방금' 매칭으로 fallback
- **catch 로깅 메시지**: 원인 파악 용이를 위해 상황별로 분리 (`API fallback to mock`, `API error suppressed`, `API batch item failed`, `STOMP connect fallback`, `Search failed`, `Fan letter detail load failed`)

## Test plan
- [ ] `./gradlew compileJava` 성공 (로컬 확인됨)
- [ ] `grep -r ".catch(() =>" static/components/*.jsx` 결과 0건 (로컬 확인됨)
- [ ] 라이브 채팅에서 내가 보낸 메시지가 중복 표시되지 않음
- [ ] DM에서 내가 보낸 메시지가 중복 표시되지 않음
- [ ] 아티스트 프로필 탭 빠르게 전환 시 STOMP 구독 누수 없음 (DevTools Network/Console)
- [ ] API 실패 시 DevTools 콘솔에 상황별 `console.warn` 메시지 노출 + mock/기존 동작 유지

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)