### PR TITLE
Fix: DM 발신자 ID 축 혼재 수정 및 broadcast 인가 검증 추가

### DIFF
--- a/src/main/java/com/example/infinite/domain/dm/controller/DmMessageHandler.java
+++ b/src/main/java/com/example/infinite/domain/dm/controller/DmMessageHandler.java
@@ -52,7 +52,7 @@ public class DmMessageHandler {
         }
 
         try {
-            dmService.broadcast(artistId, content);
+            dmService.broadcast(artistId, senderId, content);
         } catch (Exception e) {
             log.warn("DM broadcast 실패: artistId={}, senderId={}, error={}",
                     artistId, senderId, e.getMessage());

--- a/src/main/java/com/example/infinite/domain/dm/error/DmErrorCode.java
+++ b/src/main/java/com/example/infinite/domain/dm/error/DmErrorCode.java
@@ -14,7 +14,8 @@ public enum DmErrorCode implements ErrorCodeType {
     DM_REPLY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "DM003", "아티스트 답장 전 최대 3건까지만 보낼 수 있습니다."),
     DM_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "DM004", "이미 해당 아티스트와의 DM 룸이 존재합니다."),
     DM_NOT_ROOM_MEMBER(HttpStatus.FORBIDDEN, "DM005", "해당 DM 룸의 참여자가 아닙니다."),
-    DM_ARTIST_MISMATCH(HttpStatus.FORBIDDEN, "DM006", "해당 아티스트의 DM이 아닙니다.");
+    DM_ARTIST_MISMATCH(HttpStatus.FORBIDDEN, "DM006", "해당 아티스트의 DM이 아닙니다."),
+    DM_BROADCAST_UNAUTHORIZED(HttpStatus.FORBIDDEN, "DM007", "해당 아티스트의 소속 멤버만 브로드캐스트할 수 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/infinite/domain/dm/service/DmService.java
+++ b/src/main/java/com/example/infinite/domain/dm/service/DmService.java
@@ -9,6 +9,7 @@ import com.example.infinite.domain.dm.error.DmErrorCode;
 import com.example.infinite.domain.dm.error.DmException;
 import com.example.infinite.domain.dm.repository.DmMessageRepository;
 import com.example.infinite.domain.dm.repository.DmRoomRepository;
+import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
 import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
 import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
 import com.example.infinite.global.common.dto.CursorSliceResponse;
@@ -33,6 +34,7 @@ public class DmService {
     private final DmMessageRepository dmMessageRepository;
     private final DmSubscriptionRepository dmSubscriptionRepository;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ArtistMemberRepository artistMemberRepository;
 
     public List<DmRoomResponse> getMyRooms(Long userId) {
         return dmRoomRepository.findByUserId(userId).stream()
@@ -68,7 +70,11 @@ public class DmService {
      * 해당 아티스트의 모든 DM 룸에 메시지 생성 + 각 룸 구독자에게 STOMP 전송.
      */
     @Transactional
-    public void broadcast(Long artistId, String content) {
+    public void broadcast(Long artistId, Long senderId, String content) {
+        if (!artistMemberRepository.existsByArtistIdAndMemberId(artistId, senderId)) {
+            throw new DmException(DmErrorCode.DM_BROADCAST_UNAUTHORIZED);
+        }
+
         List<DmRoom> rooms = dmRoomRepository.findByArtistId(artistId);
 
         for (DmRoom room : rooms) {
@@ -85,7 +91,8 @@ public class DmService {
             );
         }
 
-        log.info("아티스트 DM 일괄 발송 완료: artistId={}, rooms={}", artistId, rooms.size());
+        log.info("아티스트 DM 일괄 발송 완료: artistId={}, senderId={}, rooms={}",
+                artistId, senderId, rooms.size());
     }
 
     /**
@@ -97,7 +104,7 @@ public class DmService {
         DmRoom room = findRoomOrThrow(roomId);
 
         SenderType senderType;
-        if (room.getArtistId().equals(senderId)) {
+        if (artistMemberRepository.existsByArtistIdAndMemberId(room.getArtistId(), senderId)) {
             senderType = SenderType.ARTIST;
         } else if (room.getUserId().equals(senderId)) {
             senderType = SenderType.USER;
@@ -139,7 +146,10 @@ public class DmService {
     }
 
     private void validateRoomAccess(DmRoom room, Long userId) {
-        if (!room.getUserId().equals(userId) && !room.getArtistId().equals(userId)) {
+        boolean isUser = room.getUserId().equals(userId);
+        boolean isArtistMember = artistMemberRepository.existsByArtistIdAndMemberId(
+                room.getArtistId(), userId);
+        if (!isUser && !isArtistMember) {
             throw new DmException(DmErrorCode.DM_NOT_ROOM_MEMBER);
         }
     }

--- a/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
+++ b/src/main/java/com/example/infinite/domain/raffle/controller/RaffleController.java
@@ -46,7 +46,7 @@ public class RaffleController {
             @PathVariable Long artistId,
             @PathVariable Long raffleId,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
-        Long userId = memberDetails.getMemberId();
+        Long userId = (memberDetails != null) ? memberDetails.getMemberId() : null;
         RaffleDetailResponse response = raffleService.getRaffleDetail(artistId, raffleId, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
+++ b/src/main/java/com/example/infinite/domain/raffle/service/RaffleService.java
@@ -248,7 +248,8 @@ public class RaffleService {
 
     public RaffleDetailResponse getRaffleDetail(Long artistId, Long raffleId, Long userId) {
         Raffle raffle = findRaffleWithArtistCheck(artistId, raffleId);
-        boolean entered = raffleEntryRepository.existsByRaffleIdAndUserId(raffleId, userId);
+        boolean entered = (userId != null)
+                && raffleEntryRepository.existsByRaffleIdAndUserId(raffleId, userId);
         return RaffleDetailResponse.of(raffle, entered);
     }
 


### PR DESCRIPTION
## Summary

- **DM 축 혼재 수정**: `DmService.sendMessage()` / `validateRoomAccess()` 에서 `room.getArtistId()`(artists.id) 와 `senderId`(members.id) 를 직접 비교하던 로직을 `ArtistMemberRepository.existsByArtistIdAndMemberId()` 검증으로 전환. 아티스트 소속 멤버의 DM 발신이 정상 동작.
- **broadcast 인가 검증**: `DmService.broadcast()` 가 senderId 없이 호출돼 누구나 아티스트 일괄 발송이 가능하던 보안 결함 해결. 시그니처에 `senderId` 추가 + 아티스트 소속 검증 + `DmErrorCode.DM_BROADCAST_UNAUTHORIZED` (DM007) 신규.
- **Raffle 비로그인 NPE 방지**: `/api/v1/artists/*/raffles/*` 가 SecurityConfig 에서 permitAll 인데도 컨트롤러가 `@AuthenticationPrincipal` 을 non-null 로 사용해 비로그인 접근 시 NPE. 컨트롤러·서비스에 null 분기 추가.

## Test plan

- [ ] 아티스트 소속 멤버(memberId)로 STOMP `/pub/dm/{roomId}` 전송 시 `SenderType.ARTIST` 로 저장되는지 확인
- [ ] 일반 유저(memberId)로 전송 시 구독 검증 + 답장 제한이 그대로 동작하는지 확인
- [ ] 룸 참여자가 아닌 유저로 전송 시 `DM_NOT_ROOM_MEMBER` 예외 발생 확인
- [ ] 아티스트 소속 멤버가 `/pub/dm/broadcast/{artistId}` 전송 시 해당 아티스트의 모든 룸에 fan-out 되는지 확인
- [ ] 비소속 멤버가 broadcast 시 `DM_BROADCAST_UNAUTHORIZED` (DM007, 403) 반환 확인
- [ ] 아티스트 소속 멤버가 `GET /api/v1/dm/rooms/{roomId}/messages` 접근 시 정상 조회되는지 확인
- [ ] 비로그인 사용자가 `GET /api/v1/artists/{id}/raffles/{id}` 접근 시 `entered=false` 로 정상 응답 (NPE 없음)
- [ ] 로그인 사용자가 접근 시 응모 여부(`entered`)가 정확히 반영되는지 확인

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)