### PR TITLE
Test: DM 인가/발신자 검증 + 래플 비로그인 조회 회귀 테스트 추가

### DIFF
--- a/src/test/java/com/example/infinite/domain/dm/service/DmServiceTest.java
+++ b/src/test/java/com/example/infinite/domain/dm/service/DmServiceTest.java
@@ -1,0 +1,113 @@
+package com.example.infinite.domain.dm.service;
+
+import com.example.infinite.domain.dm.entity.DmMessage;
+import com.example.infinite.domain.dm.entity.DmRoom;
+import com.example.infinite.domain.dm.enums.SenderType;
+import com.example.infinite.domain.dm.error.DmErrorCode;
+import com.example.infinite.domain.dm.error.DmException;
+import com.example.infinite.domain.dm.repository.DmMessageRepository;
+import com.example.infinite.domain.dm.repository.DmRoomRepository;
+import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
+import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DmService 단위 테스트")
+class DmServiceTest {
+
+    @Mock DmRoomRepository dmRoomRepository;
+    @Mock DmMessageRepository dmMessageRepository;
+    @Mock DmSubscriptionRepository dmSubscriptionRepository;
+    @Mock SimpMessagingTemplate messagingTemplate;
+    @Mock ArtistMemberRepository artistMemberRepository;
+
+    @InjectMocks DmService dmService;
+
+    // DmRoom은 @Builder 로 필드를 주입하지만 id는 @GeneratedValue 라서 리플렉션으로 세팅
+    private DmRoom createTestRoom(Long roomId, Long userId, Long artistId) {
+        DmRoom room = DmRoom.builder()
+                .userId(userId)
+                .artistId(artistId)
+                .build();
+        try {
+            var idField = DmRoom.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(room, roomId);
+        } catch (Exception e) {
+            throw new RuntimeException("테스트 DmRoom ID 설정 실패", e);
+        }
+        return room;
+    }
+
+    @Nested
+    @DisplayName("broadcast()")
+    class BroadcastTest {
+
+        @Test
+        @DisplayName("아티스트 소속 멤버가 아닌 사용자의 broadcast는 DM_BROADCAST_UNAUTHORIZED 예외가 발생한다")
+        void broadcast_byNonArtistMember_throwsUnauthorized() {
+            Long artistId = 10L;
+            Long nonMemberId = 999L;
+
+            when(artistMemberRepository.existsByArtistIdAndMemberId(artistId, nonMemberId))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> dmService.broadcast(artistId, nonMemberId, "전체 공지"))
+                    .isInstanceOf(DmException.class)
+                    .satisfies(ex -> {
+                        DmException dmEx = (DmException) ex;
+                        assertThat(dmEx.getErrorCode()).isEqualTo(DmErrorCode.DM_BROADCAST_UNAUTHORIZED);
+                    });
+
+            verify(dmMessageRepository, never()).save(any());
+            verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("sendMessage()")
+    class SendMessageTest {
+
+        @Test
+        @DisplayName("아티스트 소속 멤버가 DM을 보내면 SenderType.ARTIST로 저장된다")
+        void sendMessage_byArtistMember_setSenderTypeArtist() {
+            Long roomId = 1L;
+            Long artistId = 10L;
+            Long artistMemberId = 100L;
+
+            DmRoom room = createTestRoom(roomId, 200L, artistId);
+
+            when(dmRoomRepository.findById(roomId)).thenReturn(Optional.of(room));
+            when(artistMemberRepository.existsByArtistIdAndMemberId(artistId, artistMemberId))
+                    .thenReturn(true);
+            when(dmMessageRepository.save(any(DmMessage.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            dmService.sendMessage(roomId, artistMemberId, "안녕하세요 팬 여러분");
+
+            ArgumentCaptor<DmMessage> captor = ArgumentCaptor.forClass(DmMessage.class);
+            verify(dmMessageRepository).save(captor.capture());
+
+            DmMessage saved = captor.getValue();
+            assertThat(saved.getSenderType()).isEqualTo(SenderType.ARTIST);
+        }
+    }
+}

--- a/src/test/java/com/example/infinite/domain/raffle/service/RaffleServiceTest.java
+++ b/src/test/java/com/example/infinite/domain/raffle/service/RaffleServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.infinite.domain.raffle.service;
+
+import com.example.infinite.domain.raffle.dto.RaffleDetailResponse;
+import com.example.infinite.domain.raffle.entity.Raffle;
+import com.example.infinite.domain.raffle.enums.EntryCondition;
+import com.example.infinite.domain.raffle.enums.RewardType;
+import com.example.infinite.domain.raffle.repository.RaffleEntryRepository;
+import com.example.infinite.domain.raffle.repository.RaffleRepository;
+import com.example.infinite.domain.raffle.repository.RaffleSlotRepository;
+import com.example.infinite.domain.raffle.repository.RaffleSlotWinnerRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RaffleService 단위 테스트")
+class RaffleServiceTest {
+
+    @Mock RaffleRepository raffleRepository;
+    @Mock RaffleSlotRepository raffleSlotRepository;
+    @Mock RaffleSlotWinnerRepository raffleSlotWinnerRepository;
+    @Mock RaffleEntryRepository raffleEntryRepository;
+    @Mock ReservoirSampler reservoirSampler;
+    @Mock RaffleSchedulerService schedulerService;
+    @Mock StringRedisTemplate stringRedisTemplate;
+    @Mock RaffleNotificationService raffleNotificationService;
+
+    @InjectMocks RaffleService raffleService;
+
+    @Nested
+    @DisplayName("getRaffleDetail()")
+    class GetRaffleDetailTest {
+
+        @Test
+        @DisplayName("비로그인 사용자(userId=null)의 래플 상세 조회 시 entered=false로 정상 응답한다")
+        void getRaffleDetail_withNullUserId_returnsEnteredFalse() {
+            Long artistId = 10L;
+            Long raffleId = 1L;
+
+            Raffle raffle = Raffle.builder()
+                    .artistId(artistId)
+                    .title("팬미팅 초대권")
+                    .entryCondition(EntryCondition.ALL)
+                    .rewardType(RewardType.MEMBERSHIP_EXTENSION)
+                    .totalWinners(1)
+                    .durationMinutes(60)
+                    .build();
+
+            try {
+                var idField = Raffle.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(raffle, raffleId);
+            } catch (Exception e) {
+                throw new RuntimeException("테스트 Raffle ID 설정 실패", e);
+            }
+
+            when(raffleRepository.findById(raffleId)).thenReturn(Optional.of(raffle));
+
+            RaffleDetailResponse response = raffleService.getRaffleDetail(artistId, raffleId, null);
+
+            assertThat(response).isNotNull();
+            assertThat(response.entered()).isFalse();
+            assertThat(response.title()).isEqualTo("팬미팅 초대권");
+
+            verify(raffleEntryRepository, never()).existsByRaffleIdAndUserId(anyLong(), anyLong());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR #129 (DM/Raffle hotfix) 후속 회귀 테스트 3건을 추가함. 외부 의존성 없는 순수 Mockito 단위 테스트.

- **`DmServiceTest.broadcast()` (1건)**: 아티스트 비소속 멤버의 `broadcast()` 호출 → `DM_BROADCAST_UNAUTHORIZED` 예외 + 메시지 저장·STOMP 전송 차단까지 검증.
- **`DmServiceTest.sendMessage()` (1건)**: 아티스트 소속 멤버(memberId ≠ artistId)가 DM 발신 시 `SenderType.ARTIST` 로 저장되는지 `ArgumentCaptor` 로 확인 — ID 축 혼재 재발 방지.
- **`RaffleServiceTest.getRaffleDetail()` (1건)**: 비로그인(`userId=null`) 상세 조회 시 `entered=false` 정상 응답 + `existsByRaffleIdAndUserId` 미호출 — NPE 회귀 방지.

## Test plan

- [x] 신규 3건 모두 로컬 `./gradlew test` 로 PASSED
- [x] 기존 `ReservoirSamplerUnitTest` 4건 그대로 PASSED (회귀 없음)
- [ ] CI 에서 동일하게 녹색인지 확인
- 참고: 기존 환경 의존 테스트(`DemoApplicationTests.contextLoads`, `*IntegrationTest`)는 로컬 MySQL / Docker 미기동으로 실패하는 기 존재 이슈 — 본 PR 범위 밖

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)