### PR TITLE
Perf: 인덱스 설계 + EXPLAIN 검증 — DM 방/래플 응모 조회 최적화

### DIFF
--- a/docs/index-analysis.md
+++ b/docs/index-analysis.md
@@ -1,0 +1,84 @@
+# 인덱스 설계 분석 및 EXPLAIN 검증
+
+> 강혁 도메인(DM / Raffle / Live)의 쿼리-인덱스 매핑을 분석하고, 누락 인덱스를 추가한 뒤 5만건+ 더미 데이터로 EXPLAIN 결과를 비교 수집했다.
+
+## 1. 검증 환경
+
+| 항목 | 값 |
+|------|-----|
+| DBMS | MySQL 8.4 (로컬) |
+| 데이터 규모 | dm_messages 50,000 / raffle_entries 50,000 / live_chat_messages 50,000 + 마스터 300건 |
+| 더미 데이터 삽입 시간 | 2.6초 (`SET autocommit = 0; CALL ...; COMMIT` 으로 트랜잭션 묶음) |
+
+## 2. 추가한 인덱스
+
+### B-1. `idx_dm_room_artist` on `dm_rooms (artist_id)`
+
+- **문제 쿼리**: `DmRoomRepository.findByArtistId(artistId)` — broadcast 호출 시 아티스트의 전체 DM 방을 조회
+- **원인**: 기존 `uk_dm_room_user_artist (user_id, artist_id)` 는 `user_id` 접두사 조건이 없으면 활용 불가
+- **추가 이유**: InnoDB 가 PK(`id`)를 보조 인덱스 리프에 자동 포함하므로 `(artist_id)` 단독 선언으로 `(artist_id, id)` 효과
+
+### B-2. `idx_raffle_entry_user_entered` on `raffle_entries (user_id, entered_at)`
+
+- **문제 쿼리**: `RaffleEntryRepository.findByUserIdOrderByEnteredAtDesc(userId)` — "내 응모 내역" 조회
+- **원인**: 기존 `uk_raffle_entry_user (raffle_id, user_id)` 는 `user_id` 가 두 번째 컬럼이라 단독 조회에 쓸 수 없음 + `entered_at` 정렬도 커버 불가
+- **추가 이유**: `(user_id, entered_at)` 복합으로 WHERE 필터 + ORDER BY 정렬을 인덱스 한 번에 처리 → filesort 제거
+
+### B-3. DmMessage / LiveChatMessage 커서 쿼리 — 추가 불필요
+
+실측 EXPLAIN 결과 두 테이블 모두 `ORDER BY id DESC` 쿼리를 **PK Backward index scan** 으로 처리. filesort 없음 → 인덱스 추가 불요. (지시서 판단 기준: `type: ref` + `Extra`에 `filesort` 없으면 기존 인덱스 충분)
+
+## 3. EXPLAIN 결과 — Before / After 비교
+
+```
+══════════════════════════════════════
+ EXPLAIN 결과 ①: DmRoom.findByArtistId
+──────────────────────────────────────
+ [Before] type=ALL,  key=NULL,                rows=100,   Extra=Using where
+ [After]  type=ref,  key=idx_dm_room_artist,  rows=20,    Extra=(none)
+══════════════════════════════════════
+
+══════════════════════════════════════
+ EXPLAIN 결과 ②: RaffleEntry.findByUserIdOrderByEnteredAtDesc
+──────────────────────────────────────
+ [Before] type=ALL,  key=NULL,                           rows=49,504, Extra=Using where; Using filesort
+ [After]  type=ref,  key=idx_raffle_entry_user_entered,  rows=50,     Extra=Backward index scan
+══════════════════════════════════════
+
+══════════════════════════════════════
+ EXPLAIN 결과 ③: DmMessage cursor (dm_room_id=1 AND id<400 ORDER BY id DESC)
+──────────────────────────────────────
+ type=range, key=PRIMARY, rows=399, Extra=Using where; Backward index scan
+  → 변화 없음 (PK 사용으로 filesort 없음 → 인덱스 추가 불필요)
+══════════════════════════════════════
+
+══════════════════════════════════════
+ EXPLAIN 결과 ④: LiveChatMessage cursor (live_stream_id=1 AND id<400 ORDER BY id DESC)
+──────────────────────────────────────
+ type=range, key=PRIMARY, rows=399, Extra=Using where; Backward index scan
+  → 변화 없음 (동일 이유로 인덱스 추가 불필요)
+══════════════════════════════════════
+
+══════════════════════════════════════
+ EXPLAIN 결과 ⑤: RealtimeLive VOD cursor (artist_id=1 AND live_status='ENDED' AND id<50 ORDER BY id DESC)
+──────────────────────────────────────
+ type=ref, key=idx_live_artist_created, rows=20,
+ Extra=Using index condition; Using where; Using filesort
+  → 옵티마이저가 (artist_id, created_at) 인덱스를 선택 → id DESC 정렬에 filesort 발생
+  → 본 Phase 범위 외. 현재 빈도·비용을 고려하면 허용 가능 (데이터 소규모, 저빈도 조회)
+══════════════════════════════════════
+```
+
+### 핵심 수치
+
+| 쿼리 | Before rows | After rows | 개선 |
+|------|-------------|------------|------|
+| DmRoom.findByArtistId | 100 (풀 스캔) | 20 | 5× (100% → 20%) |
+| RaffleEntry.findByUser… | 49,504 (풀 스캔 + filesort) | 50 | **990×** + filesort 제거 |
+
+## 4. 엔티티 영속화
+
+수동 `CREATE INDEX`는 EXPLAIN 검증용이며, 엔티티 `@Index` 선언으로 `ddl-auto: create-drop/update` 가 자동 생성하도록 반영했다.
+
+- `DmRoom.java`: `idx_dm_room_artist` 추가
+- `RaffleEntry.java`: `idx_raffle_entry_user_entered` 추가

--- a/src/main/java/com/example/infinite/domain/dm/entity/DmRoom.java
+++ b/src/main/java/com/example/infinite/domain/dm/entity/DmRoom.java
@@ -12,7 +12,8 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @Entity
 @Table(name = "dm_rooms", indexes = {
-        @Index(name = "uk_dm_room_user_artist", columnList = "user_id, artist_id", unique = true)
+        @Index(name = "uk_dm_room_user_artist", columnList = "user_id, artist_id", unique = true),
+        @Index(name = "idx_dm_room_artist", columnList = "artist_id")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE dm_rooms SET deleted_at = current_timestamp WHERE id = ?")

--- a/src/main/java/com/example/infinite/domain/raffle/entity/RaffleEntry.java
+++ b/src/main/java/com/example/infinite/domain/raffle/entity/RaffleEntry.java
@@ -11,7 +11,8 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @Table(name = "raffle_entries", indexes = {
-        @Index(name = "uk_raffle_entry_user", columnList = "raffle_id, user_id", unique = true)
+        @Index(name = "uk_raffle_entry_user", columnList = "raffle_id, user_id", unique = true),
+        @Index(name = "idx_raffle_entry_user_entered", columnList = "user_id, entered_at")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RaffleEntry {


### PR DESCRIPTION
## Summary
- `DmRoom` 에 `idx_dm_room_artist (artist_id)` 추가 — broadcast 경로의 `findByArtistId` 풀 스캔 제거
- `RaffleEntry` 에 `idx_raffle_entry_user_entered (user_id, entered_at)` 추가 — "내 응모 내역" 조회의 풀 스캔 + filesort 제거
- `docs/index-analysis.md` 신규 — 쿼리-인덱스 매핑 분석 및 5만건 더미 데이터 기반 EXPLAIN Before/After 기록

## EXPLAIN 실측 결과 (MySQL 8.4, 5만건 더미)

| 쿼리 | Before | After |
|---|---|---|
| `DmRoom.findByArtistId` | type=ALL, key=NULL, rows=100 | type=ref, key=`idx_dm_room_artist`, rows=20 |
| `RaffleEntry.findByUser…` | type=ALL, rows=49,504, **Using filesort** | type=ref, key=`idx_raffle_entry_user_entered`, rows=50, Backward index scan |

## 추가 검증
- `DmMessage` / `LiveChatMessage` 커서 쿼리(`ORDER BY id DESC`) → PK Backward index scan 사용, filesort 없음 → **인덱스 추가 불필요**
- `RealtimeLive` VOD 커서는 옵티마이저가 `(artist_id, created_at)` 인덱스를 선택해 filesort 발생하지만, 빈도·데이터 규모상 본 PR 범위 외

## Test plan
- [x] 로컬 MySQL 8.4 에 5만건+ 더미 데이터 삽입 후 EXPLAIN 비교 (Before/After)
- [x] 수동 `CREATE INDEX` 로 After 확인 → 엔티티 `@Index` 선언으로 영속화
- [ ] CI/통합 테스트 회귀 없음 (기존 단위/통합 테스트 통과 확인)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)