### PR TITLE
[Perf] payment 도메인 DB 인덱스 누락 보완

### DIFF
--- a/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeHistory.java
@@ -11,7 +11,10 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "auto_charge_histories")
+@Table(name = "auto_charge_histories",
+        indexes = {
+                @Index(name = "idx_auto_charge_histories_user_id", columnList = "user_id")
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE auto_charge_histories SET deleted_at = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeSetting.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/AutoChargeSetting.java
@@ -11,7 +11,10 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "auto_charge_settings")
+@Table(name = "auto_charge_settings",
+        indexes = {
+                @Index(name = "uidx_auto_charge_settings_user_id", columnList = "user_id", unique = true)
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE auto_charge_settings SET deleted_at = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/example/infinite/domain/payment/entity/BillingKey.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/BillingKey.java
@@ -11,7 +11,10 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "billing_keys")
+@Table(name = "billing_keys",
+        indexes = {
+                @Index(name = "idx_billing_keys_user_default", columnList = "user_id, default_card")
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE billing_keys SET deleted_at = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/example/infinite/domain/payment/entity/JellyTransaction.java
+++ b/src/main/java/com/example/infinite/domain/payment/entity/JellyTransaction.java
@@ -11,7 +11,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "jelly_transactions")
+@Table(name = "jelly_transactions",
+        indexes = {
+                @Index(name = "idx_jelly_transactions_user_id", columnList = "user_id"),
+                @Index(name = "idx_jelly_transactions_user_type_created", columnList = "user_id, type, created_at")
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JellyTransaction extends BaseEntity {
 


### PR DESCRIPTION
  ## 💡 기능 상세 내용                                                                                                                                                                                                              
  - [ ] `auto_charge_settings.user_id` UNIQUE 인덱스 추가 — 중복 데이터 시 런타임 예외 방지                                                                                                                                       
  - [ ] `jelly_transactions` `(user_id)`, `(user_id, type, created_at)` 복합 인덱스 추가
  - [ ] `billing_keys` `(user_id, default_card)` 복합 인덱스 추가
  - [ ] `auto_charge_histories.user_id` 인덱스 추가

  > `payment_orders.payment_id`는 `@Column(unique = true)` 이미 선언되어 있어 대상 제외

  ## ✅ 완료 조건 (Acceptance Criteria)
  - [ ] 각 엔티티 `@Table`에 `indexes` 속성이 추가되어 있다
  - [ ] `auto_charge_settings.user_id`에 unique = true가 적용되어 있다
  - [ ] 애플리케이션 기동 후 DDL 로그에서 인덱스 생성이 확인된다

  ## 🔗 기타 참고 사항
  - close #141 