### PR TITLE
Feat: 데스크톱 프로토타입 API 연동 묶음 (회원가입~Admin)

### DIFF
--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -20,6 +20,7 @@ function mapFanPost(fp) {
     fanMembershipSubscribed: fp.fanMembershipSubscribed,
     dmSubscribed: fp.dmSubscribed,
     writerProfileImageUrl: fp.writerProfileImageUrl,
+    writerId: fp.writerId,
   };
 }
 
@@ -41,6 +42,7 @@ function mapArtistPost(ap) {
     hashtags: ap.hashtags || [],
     artistBadge: ap.artistBadge,
     writerProfileImageUrl: ap.writerProfileImageUrl,
+    writerId: ap.writerId,
   };
 }
 
@@ -498,7 +500,15 @@ function TabFan({ t, theme, artist }) {
         </div>
       )}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        {(activeTab === 'latest' ? posts : hotPosts).map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
+        {(activeTab === 'latest' ? posts : hotPosts).map(p => (
+          <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}
+            authUser={window.__connectfinAuthUser}
+            onDeleted={(deletedId) => {
+              setPosts(prev => prev.filter(x => x.id !== deletedId));
+              setHotPosts(prev => prev.filter(x => x.id !== deletedId));
+            }}
+          />
+        ))}
       </div>
       {activeTab === 'latest' && hasNext && (
         <button onClick={loadMore} disabled={loading} style={{
@@ -1158,6 +1168,31 @@ function ArtistPostCard({ post, artist, t, inline }) {
       .catch(err => { console.warn('Replies load failed:', err?.message || err); });
   };
 
+  const deleteComment = async (commentId) => {
+    if (!confirm('이 댓글을 삭제하시겠습니까?')) return;
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${artistId}/artist-posts/${artistPostId}/comments/${commentId}`,
+        { method: 'DELETE' }
+      );
+      loadComments();
+    } catch (err) {
+      alert('삭제 실패: ' + (err.message || ''));
+    }
+  };
+
+  const toggleCommentLike = async (commentId) => {
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${artistId}/artist-posts/${artistPostId}/comments/${commentId}/likes/toggle`,
+        { method: 'POST' }
+      );
+      loadComments();
+    } catch (err) {
+      console.warn('Comment like failed:', err?.message || err);
+    }
+  };
+
   return (
     <div style={{ padding: inline ? 0 : 18, border: inline ? 'none' : `1px solid ${t.line}`, borderRadius: 12, background: inline ? 'transparent' : 'transparent' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
@@ -1206,6 +1241,12 @@ function ArtistPostCard({ post, artist, t, inline }) {
                     <div style={{ flex: 1 }}>
                       <span style={{ fontWeight: 600, marginRight: 6 }}>{c.writerNickname}</span>
                       <span style={{ color: t.text }}>{c.content}</span>
+                      <div style={{ display: 'flex', gap: 10, marginTop: 4, fontSize: 11, color: t.textDim }}>
+                        <button onClick={() => toggleCommentLike(c.commentId)} style={{ background: 'transparent', border: 'none', color: t.textDim, fontSize: 11, cursor: 'pointer', padding: 0 }}>♡ {c.likeCount || 0}</button>
+                        {window.__connectfinAuthUser?.id && c.writerId && window.__connectfinAuthUser.id === c.writerId && (
+                          <button onClick={() => deleteComment(c.commentId)} style={{ background: 'transparent', border: 'none', color: t.textDim, fontSize: 11, cursor: 'pointer', padding: 0 }}>삭제</button>
+                        )}
+                      </div>
                       {c.replyCount > 0 && !expandedReplies[c.commentId] && (
                         <button onClick={() => loadReplies(c.commentId)} style={{ display: 'block', background: 'transparent', border: 'none', color: t.accent, fontSize: 11, cursor: 'pointer', padding: 0, marginTop: 4 }}>답글 {c.replyCount}개 보기</button>
                       )}
@@ -1235,7 +1276,7 @@ function ArtistPostCard({ post, artist, t, inline }) {
   );
 }
 
-function FanPostFullCard({ post, artist, t, theme }) {
+function FanPostFullCard({ post, artist, t, theme, authUser, onDeleted }) {
   const [commentInput, setCommentInput] = React.useState('');
   const [commentSubmitting, setCommentSubmitting] = React.useState(false);
   const [comments, setComments] = React.useState([]);
@@ -1276,6 +1317,44 @@ function FanPostFullCard({ post, artist, t, theme }) {
       .catch(err => { console.warn('Replies load failed:', err?.message || err); });
   };
 
+  const deletePost = async () => {
+    if (!confirm('이 게시글을 삭제하시겠습니까?')) return;
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}`,
+        { method: 'DELETE' }
+      );
+      if (onDeleted) onDeleted(post.id);
+    } catch (err) {
+      alert('삭제 실패: ' + (err.message || ''));
+    }
+  };
+
+  const deleteComment = async (commentId) => {
+    if (!confirm('이 댓글을 삭제하시겠습니까?')) return;
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}/comments/${commentId}`,
+        { method: 'DELETE' }
+      );
+      loadComments();
+    } catch (err) {
+      alert('삭제 실패: ' + (err.message || ''));
+    }
+  };
+
+  const toggleCommentLike = async (commentId) => {
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}/comments/${commentId}/likes/toggle`,
+        { method: 'POST' }
+      );
+      loadComments();
+    } catch (err) {
+      console.warn('Comment like failed:', err?.message || err);
+    }
+  };
+
   return (
     <div style={{
       padding: 18, border: `1px solid ${t.line}`, borderRadius: 12,
@@ -1288,7 +1367,7 @@ function FanPostFullCard({ post, artist, t, theme }) {
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           color: '#fff', fontWeight: 800, fontSize: 11,
         }}>{post.author.slice(0, 2)}</div>
-        <div>
+        <div style={{ flex: 1 }}>
           <div style={{ fontWeight: 700, fontSize: 13 }}>
             {post.author}
             {post.fanMembershipSubscribed && <span style={{ color: t.accent2, marginLeft: 4 }}>✓</span>}
@@ -1297,6 +1376,11 @@ function FanPostFullCard({ post, artist, t, theme }) {
           </div>
           <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono }}>{post.timeAgo}</div>
         </div>
+        {authUser?.id && post.writerId && authUser.id === post.writerId && (
+          <button onClick={deletePost} style={{
+            background: 'transparent', border: 'none', color: t.textDim, fontSize: 11, cursor: 'pointer', padding: 0,
+          }}>삭제</button>
+        )}
       </div>
       {post.tag && <div style={{ color: t.hot, fontSize: 13, fontWeight: 700, marginBottom: 4 }}>{post.tag}</div>}
       {post.hashtags && post.hashtags.length > 0 && (
@@ -1347,6 +1431,12 @@ function FanPostFullCard({ post, artist, t, theme }) {
                     <div style={{ flex: 1 }}>
                       <span style={{ fontWeight: 600, marginRight: 6 }}>{c.writerNickname}</span>
                       <span style={{ color: t.text }}>{c.content}</span>
+                      <div style={{ display: 'flex', gap: 10, marginTop: 4, fontSize: 11, color: t.textDim }}>
+                        <button onClick={() => toggleCommentLike(c.commentId)} style={{ background: 'transparent', border: 'none', color: t.textDim, fontSize: 11, cursor: 'pointer', padding: 0 }}>♡ {c.likeCount || 0}</button>
+                        {authUser?.id && c.writerId && authUser.id === c.writerId && (
+                          <button onClick={() => deleteComment(c.commentId)} style={{ background: 'transparent', border: 'none', color: t.textDim, fontSize: 11, cursor: 'pointer', padding: 0 }}>삭제</button>
+                        )}
+                      </div>
                       {c.replyCount > 0 && !expandedReplies[c.commentId] && (
                         <button onClick={() => loadReplies(c.commentId)} style={{ display: 'block', background: 'transparent', border: 'none', color: t.accent, fontSize: 11, cursor: 'pointer', padding: 0, marginTop: 4 }}>답글 {c.replyCount}개 보기</button>
                       )}

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -400,6 +400,30 @@ function TabFan({ t, theme, artist }) {
   const [hotNextScoreCursor, setHotNextScoreCursor] = React.useState(null);
   const [hotNextIdCursor, setHotNextIdCursor] = React.useState(null);
 
+  const [showWriteForm, setShowWriteForm] = React.useState(false);
+  const [writeContent, setWriteContent] = React.useState('');
+  const [writeSubmitting, setWriteSubmitting] = React.useState(false);
+
+  const submitFanPost = async () => {
+    if (!writeContent.trim() || writeSubmitting) return;
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    setWriteSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('content', writeContent.trim());
+      await window.ConnectfinAPI.apiMultipart(`/api/post/v1/artists/${artist.id}/fan-posts`, formData);
+      setWriteContent('');
+      setShowWriteForm(false);
+      window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-posts`)
+        .then(data => { setPosts(data.content.map(mapFanPost)); setHasNext(data.hasNext); setNextCursor(data.nextCursor); })
+        .catch(err => { console.warn('Refresh failed:', err?.message || err); });
+    } catch (err) {
+      alert('작성 실패: ' + (err.message || '알 수 없는 오류'));
+    } finally {
+      setWriteSubmitting(false);
+    }
+  };
+
   React.useEffect(() => {
     setLoading(true);
     window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-posts`)
@@ -453,6 +477,26 @@ function TabFan({ t, theme, artist }) {
         <Chip t={t} active={activeTab === 'latest'} onClick={() => setActiveTab('latest')}>전체</Chip>
         <Chip t={t} active={activeTab === 'hot'} onClick={() => { setActiveTab('hot'); if (hotPosts.length === 0) loadHot(); }}><span>🔥</span> Hot</Chip>
       </div>
+      {!showWriteForm ? (
+        <button onClick={() => setShowWriteForm(true)} style={{
+          width: '100%', padding: '12px 0', marginBottom: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>✏️ 팬포스트 작성</button>
+      ) : (
+        <div style={{ padding: 14, marginBottom: 12, borderRadius: 12, border: `1px solid ${t.accent}`, background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface }}>
+          <textarea value={writeContent} onChange={e => setWriteContent(e.target.value)}
+            placeholder="팬포스트를 작성해 보세요..." maxLength={5000}
+            style={{ width: '100%', minHeight: 80, padding: 10, borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.text, fontSize: 13, fontFamily: t.font, resize: 'vertical' }}/>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
+            <span style={{ fontSize: 11, color: t.textDim }}>{writeContent.length} / 5000</span>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button onClick={() => { setShowWriteForm(false); setWriteContent(''); }} style={{ padding: '6px 14px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.textDim, fontSize: 12, cursor: 'pointer' }}>취소</button>
+              <button onClick={submitFanPost} disabled={writeSubmitting || !writeContent.trim()} style={{ padding: '6px 14px', borderRadius: 8, border: 'none', background: t.accent, color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer', opacity: writeSubmitting || !writeContent.trim() ? 0.5 : 1 }}>{writeSubmitting ? '작성 중...' : '게시'}</button>
+            </div>
+          </div>
+        </div>
+      )}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
         {(activeTab === 'latest' ? posts : hotPosts).map(p => <FanPostFullCard key={p.id} post={p} artist={artist} t={t} theme={theme}/>)}
       </div>
@@ -556,6 +600,32 @@ function TabFanLetter({ t, theme, artist }) {
   const [hotHasNext, setHotHasNext] = React.useState(false);
   const [hotNextOffset, setHotNextOffset] = React.useState(null);
 
+  const [showLetterForm, setShowLetterForm] = React.useState(false);
+  const [letterSubmitting, setLetterSubmitting] = React.useState(false);
+  const [letterRecipientType, setLetterRecipientType] = React.useState('ARTIST');
+  const [letterImage, setLetterImage] = React.useState(null);
+
+  const submitFanLetter = async () => {
+    if (letterSubmitting) return;
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    setLetterSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('recipientType', letterRecipientType);
+      if (letterImage) formData.append('image', letterImage);
+      await window.ConnectfinAPI.apiMultipart(`/api/post/v1/artists/${artist.id}/fan-letters`, formData);
+      setLetterImage(null);
+      setShowLetterForm(false);
+      window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters`)
+        .then(data => { setLetters(data.content.map(mapFanLetterListItem)); setHasNext(data.hasNext); setNextCursor(data.nextCursor); })
+        .catch(err => { console.warn('Refresh failed:', err?.message || err); });
+    } catch (err) {
+      alert('작성 실패: ' + (err.message || '멤버십 구독이 필요합니다'));
+    } finally {
+      setLetterSubmitting(false);
+    }
+  };
+
   const loadHotLetters = (append = false) => {
     setLoading(true);
     let path = `/api/post/v1/artists/${artist.id}/fan-letters/hot`;
@@ -628,6 +698,38 @@ function TabFanLetter({ t, theme, artist }) {
         <div style={{ flex: 1 }}/>
         <Chip t={t}>🌐 한국어</Chip>
       </div>
+      {!showLetterForm ? (
+        <button onClick={() => setShowLetterForm(true)} style={{
+          width: '100%', padding: '12px 0', marginBottom: 12, borderRadius: 10,
+          border: `1px solid ${t.line}`, background: 'transparent',
+          color: t.textDim, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: t.font,
+        }}>💌 팬레터 보내기</button>
+      ) : (
+        <div style={{ padding: 14, marginBottom: 12, borderRadius: 12, border: `1px solid ${t.accent}`, background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface }}>
+          <div style={{ fontSize: 12, color: t.textDim, marginBottom: 8 }}>받는 대상</div>
+          <div style={{ display: 'flex', gap: 6, marginBottom: 12 }}>
+            {['ARTIST', 'ARTIST_MEMBER'].map(rt => (
+              <button key={rt} onClick={() => setLetterRecipientType(rt)} style={{
+                padding: '6px 12px', borderRadius: 8, fontSize: 12, cursor: 'pointer', fontFamily: t.font,
+                border: letterRecipientType === rt ? `1px solid ${t.accent}` : `1px solid ${t.line}`,
+                background: letterRecipientType === rt ? t.accent : 'transparent',
+                color: letterRecipientType === rt ? '#fff' : t.text,
+              }}>{rt === 'ARTIST' ? '그룹 전체' : '멤버 지정'}</button>
+            ))}
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', borderRadius: 8, border: `1px dashed ${t.line}`, cursor: 'pointer', fontSize: 12, color: t.textDim, marginBottom: 12 }}>
+            📷 {letterImage ? letterImage.name : '이미지 선택 (선택사항)'}
+            <input type="file" accept="image/*" onChange={e => setLetterImage(e.target.files[0] || null)} style={{ display: 'none' }}/>
+          </label>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: 10, color: t.textDim }}>팬 멤버십 구독자만 작성 가능</span>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button onClick={() => { setShowLetterForm(false); setLetterImage(null); }} style={{ padding: '6px 14px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.textDim, fontSize: 12, cursor: 'pointer' }}>취소</button>
+              <button onClick={submitFanLetter} disabled={letterSubmitting} style={{ padding: '6px 14px', borderRadius: 8, border: 'none', background: t.accent, color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer', opacity: letterSubmitting ? 0.5 : 1 }}>{letterSubmitting ? '전송 중...' : '보내기'}</button>
+            </div>
+          </div>
+        </div>
+      )}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
         {(activeTab === 'latest' ? letters : hotLetters).map(l => <FanLetterCard key={l.id} letter={l} artist={artist} t={t} theme={theme} onClick={() => openDetail(l)}/>)}
       </div>
@@ -1014,6 +1116,48 @@ function moreBtn(t) {
 }
 
 function ArtistPostCard({ post, artist, t, inline }) {
+  const [commentInput, setCommentInput] = React.useState('');
+  const [commentSubmitting, setCommentSubmitting] = React.useState(false);
+  const [comments, setComments] = React.useState([]);
+  const [showComments, setShowComments] = React.useState(false);
+  const [expandedReplies, setExpandedReplies] = React.useState({});
+
+  const artistId = post.artistId || artist.id;
+  const artistPostId = post.artistPostId || post.id;
+
+  const loadComments = () => {
+    if (!artistPostId) return;
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artistId}/artist-posts/${artistPostId}`)
+      .then(data => { if (data.comments?.content) setComments(data.comments.content); })
+      .catch(err => { console.warn('Comments load failed:', err?.message || err); });
+  };
+
+  const submitComment = async () => {
+    if (!commentInput.trim() || commentSubmitting) return;
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    setCommentSubmitting(true);
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${artistId}/artist-posts/${artistPostId}/comments`,
+        { method: 'POST', body: JSON.stringify({ content: commentInput.trim(), parentId: null }) }
+      );
+      setCommentInput('');
+      loadComments();
+    } catch (err) {
+      alert('댓글 작성 실패: ' + (err.message || ''));
+    } finally {
+      setCommentSubmitting(false);
+    }
+  };
+
+  const loadReplies = (commentId) => {
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${artistId}/artist-posts/${artistPostId}/comments/${commentId}/replies`)
+      .then(data => {
+        setExpandedReplies(prev => ({ ...prev, [commentId]: data.content || [] }));
+      })
+      .catch(err => { console.warn('Replies load failed:', err?.message || err); });
+  };
+
   return (
     <div style={{ padding: inline ? 0 : 18, border: inline ? 'none' : `1px solid ${t.line}`, borderRadius: 12, background: inline ? 'transparent' : 'transparent' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
@@ -1046,11 +1190,92 @@ function ArtistPostCard({ post, artist, t, inline }) {
         )}
         <span>💬 {post.comments}</span>
       </div>
+      {artistPostId && !inline && (
+        <div style={{ marginTop: 12, borderTop: `1px solid ${t.line}`, paddingTop: 10 }}>
+          {post.comments > 0 && !showComments && (
+            <button onClick={() => { setShowComments(true); loadComments(); }} style={{
+              background: 'transparent', border: 'none', color: t.textDim, fontSize: 12, cursor: 'pointer', padding: 0, marginBottom: 8,
+            }}>💬 댓글 {post.comments}개 보기</button>
+          )}
+          {showComments && comments.length > 0 && (
+            <div style={{ marginBottom: 10 }}>
+              {comments.map(c => (
+                <div key={c.commentId} style={{ marginBottom: 10 }}>
+                  <div style={{ display: 'flex', gap: 8, fontSize: 12 }}>
+                    <div style={{ width: 24, height: 24, borderRadius: '50%', flexShrink: 0, background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: 8, fontWeight: 800 }}>{(c.writerNickname || '?').slice(0, 2)}</div>
+                    <div style={{ flex: 1 }}>
+                      <span style={{ fontWeight: 600, marginRight: 6 }}>{c.writerNickname}</span>
+                      <span style={{ color: t.text }}>{c.content}</span>
+                      {c.replyCount > 0 && !expandedReplies[c.commentId] && (
+                        <button onClick={() => loadReplies(c.commentId)} style={{ display: 'block', background: 'transparent', border: 'none', color: t.accent, fontSize: 11, cursor: 'pointer', padding: 0, marginTop: 4 }}>답글 {c.replyCount}개 보기</button>
+                      )}
+                      {expandedReplies[c.commentId] && expandedReplies[c.commentId].map(r => (
+                        <div key={r.commentId} style={{ display: 'flex', gap: 6, marginTop: 6, marginLeft: 16, fontSize: 11 }}>
+                          <div style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0, background: t.line, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 7, fontWeight: 700, color: t.textDim }}>{(r.writerNickname || '?').slice(0, 2)}</div>
+                          <div><span style={{ fontWeight: 600, marginRight: 4 }}>{r.writerNickname}</span>{r.content}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input type="text" value={commentInput} onChange={e => setCommentInput(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitComment(); } }}
+              placeholder="댓글 달기..." style={{ flex: 1, padding: '8px 12px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.text, fontSize: 12, fontFamily: t.font }}/>
+            <button onClick={submitComment} disabled={commentSubmitting || !commentInput.trim()} style={{
+              padding: '6px 12px', borderRadius: 8, border: 'none', background: t.accent, color: '#fff', fontSize: 11, fontWeight: 600, cursor: 'pointer', opacity: commentSubmitting || !commentInput.trim() ? 0.5 : 1,
+            }}>{commentSubmitting ? '...' : '게시'}</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
 function FanPostFullCard({ post, artist, t, theme }) {
+  const [commentInput, setCommentInput] = React.useState('');
+  const [commentSubmitting, setCommentSubmitting] = React.useState(false);
+  const [comments, setComments] = React.useState([]);
+  const [showComments, setShowComments] = React.useState(false);
+  const [expandedReplies, setExpandedReplies] = React.useState({});
+
+  const loadComments = () => {
+    if (!post.artistId || !post.id) return;
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}`)
+      .then(data => { if (data.comments?.content) setComments(data.comments.content); })
+      .catch(err => { console.warn('Comments load failed:', err?.message || err); });
+  };
+
+  const submitComment = async () => {
+    if (!commentInput.trim() || commentSubmitting) return;
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    if (!post.artistId || !post.id) return;
+    setCommentSubmitting(true);
+    try {
+      await window.ConnectfinAPI.api(
+        `/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}/comments`,
+        { method: 'POST', body: JSON.stringify({ content: commentInput.trim(), parentId: null }) }
+      );
+      setCommentInput('');
+      loadComments();
+    } catch (err) {
+      alert('댓글 작성 실패: ' + (err.message || ''));
+    } finally {
+      setCommentSubmitting(false);
+    }
+  };
+
+  const loadReplies = (commentId) => {
+    window.ConnectfinAPI.api(`/api/post/v1/artists/${post.artistId}/fan-posts/${post.id}/comments/${commentId}/replies`)
+      .then(data => {
+        setExpandedReplies(prev => ({ ...prev, [commentId]: data.content || [] }));
+      })
+      .catch(err => { console.warn('Replies load failed:', err?.message || err); });
+  };
+
   return (
     <div style={{
       padding: 18, border: `1px solid ${t.line}`, borderRadius: 12,
@@ -1106,6 +1331,47 @@ function FanPostFullCard({ post, artist, t, theme }) {
         )}
         {post.comments !== null && <span>💬 {post.comments}</span>}
       </div>
+      {post.artistId && post.id && (
+        <div style={{ marginTop: 12, borderTop: `1px solid ${t.line}`, paddingTop: 10 }}>
+          {post.comments > 0 && !showComments && (
+            <button onClick={() => { setShowComments(true); loadComments(); }} style={{
+              background: 'transparent', border: 'none', color: t.textDim, fontSize: 12, cursor: 'pointer', padding: 0, marginBottom: 8,
+            }}>💬 댓글 {post.comments}개 보기</button>
+          )}
+          {showComments && comments.length > 0 && (
+            <div style={{ marginBottom: 10 }}>
+              {comments.map(c => (
+                <div key={c.commentId} style={{ marginBottom: 10 }}>
+                  <div style={{ display: 'flex', gap: 8, fontSize: 12 }}>
+                    <div style={{ width: 24, height: 24, borderRadius: '50%', flexShrink: 0, background: `linear-gradient(135deg, ${artist.color1}, ${artist.color2})`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: 8, fontWeight: 800 }}>{(c.writerNickname || '?').slice(0, 2)}</div>
+                    <div style={{ flex: 1 }}>
+                      <span style={{ fontWeight: 600, marginRight: 6 }}>{c.writerNickname}</span>
+                      <span style={{ color: t.text }}>{c.content}</span>
+                      {c.replyCount > 0 && !expandedReplies[c.commentId] && (
+                        <button onClick={() => loadReplies(c.commentId)} style={{ display: 'block', background: 'transparent', border: 'none', color: t.accent, fontSize: 11, cursor: 'pointer', padding: 0, marginTop: 4 }}>답글 {c.replyCount}개 보기</button>
+                      )}
+                      {expandedReplies[c.commentId] && expandedReplies[c.commentId].map(r => (
+                        <div key={r.commentId} style={{ display: 'flex', gap: 6, marginTop: 6, marginLeft: 16, fontSize: 11 }}>
+                          <div style={{ width: 18, height: 18, borderRadius: '50%', flexShrink: 0, background: t.line, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 7, fontWeight: 700, color: t.textDim }}>{(r.writerNickname || '?').slice(0, 2)}</div>
+                          <div><span style={{ fontWeight: 600, marginRight: 4 }}>{r.writerNickname}</span>{r.content}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input type="text" value={commentInput} onChange={e => setCommentInput(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitComment(); } }}
+              placeholder="댓글 달기..." style={{ flex: 1, padding: '8px 12px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.text, fontSize: 12, fontFamily: t.font }}/>
+            <button onClick={submitComment} disabled={commentSubmitting || !commentInput.trim()} style={{
+              padding: '6px 12px', borderRadius: 8, border: 'none', background: t.accent, color: '#fff', fontSize: 11, fontWeight: 600, cursor: 'pointer', opacity: commentSubmitting || !commentInput.trim() ? 0.5 : 1,
+            }}>{commentSubmitting ? '...' : '게시'}</button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -270,6 +270,7 @@ function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive,
   else if (tab === 'live') body = <TabLive t={t} theme={theme} artist={displayArtist} onOpenLive={onOpenLive}/>;
   else if (tab === 'notice') body = <TabNotice t={t} theme={theme} artist={displayArtist}/>;
   else if (tab === 'shop') body = <TabShop t={t} theme={theme} artist={displayArtist}/>;
+  else if (tab === 'admin') body = <TabAdmin t={t} theme={theme} artist={displayArtist}/>;
 
   return (
     <div>
@@ -912,6 +913,14 @@ function TabMedia({ t, theme, artist }) {
   const latest = MEDIA_EXTENDED.filter(m => m.artistId === artist.id).slice(0, 6);
   const membership = MEDIA_EXTENDED.filter(m => m.artistId === artist.id && m.membership).slice(0, 4);
 
+  const [youtubeVideos, setYoutubeVideos] = React.useState([]);
+
+  React.useEffect(() => {
+    window.ConnectfinAPI.api(`/api/media/v1/artists/${artist.id}/youtube-videos`)
+      .then(data => setYoutubeVideos(data.content || []))
+      .catch(err => { console.warn('YouTube videos load failed:', err?.message || err); });
+  }, [artist.id]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
       <div style={{ display: 'flex', gap: 6 }}>
@@ -950,6 +959,32 @@ function TabMedia({ t, theme, artist }) {
           <button style={{ ...moreBtn(t), marginTop: 8 }}>멤버십 가입하기</button>
         </div>
       </Section>
+
+      {youtubeVideos.length > 0 && (
+        <Section t={t} theme={theme}>
+          <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 14 }}>YouTube</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 14 }}>
+            {youtubeVideos.map(v => (
+              <a key={v.id || v.youtubeVideoId} href={v.youtubeUrl} target="_blank" rel="noopener noreferrer"
+                style={{ textDecoration: 'none', color: t.text }}>
+                <div style={{ borderRadius: 10, overflow: 'hidden', border: `1px solid ${t.line}` }}>
+                  {v.thumbnailUrl && (
+                    <img src={v.thumbnailUrl} alt={v.title} style={{ width: '100%', aspectRatio: '16/9', objectFit: 'cover' }}/>
+                  )}
+                  <div style={{ padding: 8 }}>
+                    <div style={{ fontSize: 12, fontWeight: 600, lineHeight: 1.4,
+                      display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden'
+                    }}>{v.title}</div>
+                    <div style={{ fontSize: 10, color: t.textDim, marginTop: 4, fontFamily: t.fontMono }}>
+                      {v.writerDisplayName}
+                    </div>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
+        </Section>
+      )}
     </div>
   );
 }
@@ -1479,6 +1514,263 @@ function FanPostMiniCard({ post, artist, t }) {
           {post.body}
         </div>
         <div style={{ fontSize: 10, color: t.textDim, marginTop: 4 }}>좋아요 {post.likes}</div>
+      </div>
+    </div>
+  );
+}
+
+// ────────── ADMIN (관리자 간이 패널) ──────────
+function TabAdmin({ t, theme, artist }) {
+  // ── 라이브 ──
+  const [liveTitle, setLiveTitle] = React.useState('');
+  const [liveCreating, setLiveCreating] = React.useState(false);
+  const [lives, setLives] = React.useState([]);
+
+  const loadLives = () => {
+    window.ConnectfinAPI.api(`/api/v1/artists/${artist.id}/lives`)
+      .then(data => setLives(Array.isArray(data) ? data.slice(0, 5) : []))
+      .catch(err => { console.warn('Lives load failed:', err?.message || err); });
+  };
+
+  React.useEffect(() => { loadLives(); }, [artist.id]);
+
+  const createLive = async () => {
+    if (!liveTitle.trim() || liveCreating) return;
+    setLiveCreating(true);
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/admin/artists/${artist.id}/lives`, {
+        method: 'POST', body: JSON.stringify({ title: liveTitle.trim(), description: '', thumbnailUrl: '' })
+      });
+      setLiveTitle('');
+      loadLives();
+      alert('라이브 생성 완료!');
+    } catch (err) {
+      alert('라이브 생성 실패: ' + (err.message || '권한이 없습니다'));
+    } finally {
+      setLiveCreating(false);
+    }
+  };
+
+  const startLive = async (liveId) => {
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/admin/artists/${artist.id}/lives/${liveId}/start`, { method: 'PATCH' });
+      loadLives();
+      alert('라이브 시작!');
+    } catch (err) { alert('시작 실패: ' + (err.message || '')); }
+  };
+
+  const endLive = async (liveId) => {
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/admin/artists/${artist.id}/lives/${liveId}/end`, { method: 'PATCH' });
+      loadLives();
+      alert('라이브 종료!');
+    } catch (err) { alert('종료 실패: ' + (err.message || '')); }
+  };
+
+  // ── 래플 ──
+  const [raffleTitle, setRaffleTitle] = React.useState('');
+  const [raffleWinners, setRaffleWinners] = React.useState(3);
+  const [raffleDuration, setRaffleDuration] = React.useState(30);
+  const [raffleCreating, setRaffleCreating] = React.useState(false);
+  const [raffles, setRaffles] = React.useState([]);
+
+  const loadRaffles = () => {
+    window.ConnectfinAPI.api(`/api/v1/artists/${artist.id}/raffles`)
+      .then(data => {
+        const list = Array.isArray(data) ? data : (data?.content || []);
+        setRaffles(list.slice(0, 5));
+      })
+      .catch(err => { console.warn('Raffles load failed:', err?.message || err); });
+  };
+
+  React.useEffect(() => { loadRaffles(); }, [artist.id]);
+
+  const createRaffle = async () => {
+    if (!raffleTitle.trim() || raffleCreating) return;
+    setRaffleCreating(true);
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/admin/artists/${artist.id}/raffles`, {
+        method: 'POST', body: JSON.stringify({
+          title: raffleTitle.trim(),
+          totalWinners: raffleWinners,
+          durationMinutes: raffleDuration,
+          entryCondition: 'ALL',
+          rewardType: 'MEMBERSHIP_EXTENSION'
+        })
+      });
+      setRaffleTitle('');
+      loadRaffles();
+      alert('래플 생성 완료!');
+    } catch (err) {
+      alert('래플 생성 실패: ' + (err.message || '권한이 없습니다'));
+    } finally {
+      setRaffleCreating(false);
+    }
+  };
+
+  const startRaffle = async (raffleId) => {
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/admin/artists/${artist.id}/raffles/${raffleId}/start`, { method: 'PATCH' });
+      loadRaffles();
+      alert('래플 시작!');
+    } catch (err) { alert('시작 실패: ' + (err.message || '')); }
+  };
+
+  // ── DM 일괄 발송 ──
+  const [dmContent, setDmContent] = React.useState('');
+  const [dmSending, setDmSending] = React.useState(false);
+
+  const broadcastDm = async () => {
+    if (!dmContent.trim() || dmSending) return;
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    setDmSending(true);
+    try {
+      // 이미 연결된 stomp 클라이언트가 있으면 connectStomp가 그대로 반환한다.
+      // 미연결 상태면 새 연결을 활성화하지만 즉시 connected가 되지 않으므로 안내한다.
+      const client = window.ConnectfinAPI.connectStomp(() => {});
+      if (!client || !client.connected) {
+        alert('STOMP 연결이 없습니다. 라이브 채팅 화면을 먼저 열어 연결해 주세요.');
+        return;
+      }
+      // 백엔드 @MessageMapping("/dm/broadcast/{artistId}")는 @Payload String을 받으므로 plain text 전송
+      client.publish({
+        destination: `/pub/dm/broadcast/${artist.id}`,
+        body: dmContent.trim(),
+      });
+      setDmContent('');
+      alert('DM 일괄 발송 완료!');
+    } catch (err) {
+      alert('발송 실패: ' + (err.message || ''));
+    } finally {
+      setDmSending(false);
+    }
+  };
+
+  // ── YouTube import ──
+  const [youtubeUrl, setYoutubeUrl] = React.useState('');
+  const [youtubeImporting, setYoutubeImporting] = React.useState(false);
+
+  const importYoutube = async () => {
+    if (!youtubeUrl.trim() || youtubeImporting) return;
+    setYoutubeImporting(true);
+    try {
+      await window.ConnectfinAPI.api(`/api/media/v1/artists/${artist.id}/youtube-videos`, {
+        method: 'POST', body: JSON.stringify({ youtubeUrl: youtubeUrl.trim() })
+      });
+      setYoutubeUrl('');
+      alert('YouTube 영상 등록 완료!');
+    } catch (err) {
+      alert('등록 실패: ' + (err.message || '권한이 없거나 중복된 영상입니다'));
+    } finally {
+      setYoutubeImporting(false);
+    }
+  };
+
+  const inputStyle = {
+    flex: 1, padding: '8px 12px', borderRadius: 8,
+    border: `1px solid ${t.line}`, background: 'transparent',
+    color: t.text, fontSize: 12, fontFamily: t.font,
+  };
+  const adminBtnStyle = (disabled) => ({
+    padding: '6px 14px', borderRadius: 8, border: 'none',
+    background: t.accent, color: '#fff', fontSize: 12, fontWeight: 600,
+    cursor: 'pointer', opacity: disabled ? 0.5 : 1,
+  });
+  const sectionStyle = {
+    padding: 16, marginBottom: 14, borderRadius: 12,
+    border: `1px solid ${t.line}`,
+    background: theme === 'dark' ? 'rgba(20,22,36,0.55)' : t.surface,
+  };
+
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: t.textDim, marginBottom: 16, fontFamily: t.fontMono }}>
+        ARTIST / SUPER_ADMIN 권한 필요 · 권한 없으면 API가 403 반환
+      </div>
+
+      {/* 라이브 관리 */}
+      <div style={sectionStyle}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 12 }}>라이브 관리</div>
+        <div style={{ display: 'flex', gap: 6, marginBottom: 10 }}>
+          <input value={liveTitle} onChange={e => setLiveTitle(e.target.value)}
+            placeholder="라이브 제목" style={inputStyle}/>
+          <button onClick={createLive} disabled={liveCreating || !liveTitle.trim()} style={adminBtnStyle(liveCreating || !liveTitle.trim())}>
+            {liveCreating ? '...' : '생성'}
+          </button>
+        </div>
+        {lives.map(live => {
+          const status = live.liveStatus || live.status;
+          return (
+            <div key={live.liveId || live.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 0', fontSize: 12 }}>
+              <span>{live.title} <span style={{ color: t.textDim, fontFamily: t.fontMono }}>({status})</span></span>
+              <div style={{ display: 'flex', gap: 4 }}>
+                {status === 'SCHEDULED' && (
+                  <button onClick={() => startLive(live.liveId || live.id)} style={{ ...adminBtnStyle(false), padding: '3px 8px', fontSize: 11 }}>시작</button>
+                )}
+                {status === 'LIVE' && (
+                  <button onClick={() => endLive(live.liveId || live.id)} style={{ ...adminBtnStyle(false), padding: '3px 8px', fontSize: 11, background: t.hot || '#E24B4A' }}>종료</button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 래플 관리 */}
+      <div style={sectionStyle}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 12 }}>래플 관리</div>
+        <div style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+          <input value={raffleTitle} onChange={e => setRaffleTitle(e.target.value)}
+            placeholder="래플 제목" style={inputStyle}/>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginBottom: 10, alignItems: 'center' }}>
+          <label style={{ fontSize: 11, color: t.textDim }}>당첨</label>
+          <input type="number" value={raffleWinners} onChange={e => setRaffleWinners(Number(e.target.value))} min={1}
+            style={{ ...inputStyle, flex: 'none', width: 50, textAlign: 'center' }}/>
+          <label style={{ fontSize: 11, color: t.textDim }}>명 ·</label>
+          <label style={{ fontSize: 11, color: t.textDim }}>시간</label>
+          <input type="number" value={raffleDuration} onChange={e => setRaffleDuration(Number(e.target.value))} min={1}
+            style={{ ...inputStyle, flex: 'none', width: 50, textAlign: 'center' }}/>
+          <label style={{ fontSize: 11, color: t.textDim }}>분</label>
+          <button onClick={createRaffle} disabled={raffleCreating || !raffleTitle.trim()} style={adminBtnStyle(raffleCreating || !raffleTitle.trim())}>
+            {raffleCreating ? '...' : '생성'}
+          </button>
+        </div>
+        {raffles.map(r => (
+          <div key={r.raffleId || r.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '6px 0', fontSize: 12 }}>
+            <span>{r.title} <span style={{ color: t.textDim, fontFamily: t.fontMono }}>({r.status})</span></span>
+            {r.status === 'PENDING' && (
+              <button onClick={() => startRaffle(r.raffleId || r.id)} style={{ ...adminBtnStyle(false), padding: '3px 8px', fontSize: 11 }}>시작</button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* DM 일괄 발송 */}
+      <div style={sectionStyle}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 12 }}>DM 일괄 발송</div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input value={dmContent} onChange={e => setDmContent(e.target.value)}
+            placeholder="구독자 전체에게 보낼 메시지" style={inputStyle}
+            onKeyDown={e => { if (e.key === 'Enter') broadcastDm(); }}/>
+          <button onClick={broadcastDm} disabled={dmSending || !dmContent.trim()} style={adminBtnStyle(dmSending || !dmContent.trim())}>
+            {dmSending ? '...' : '발송'}
+          </button>
+        </div>
+        <div style={{ fontSize: 10, color: t.textDim, marginTop: 6 }}>STOMP /pub/dm/broadcast/{artist.id} — 아티스트 멤버만 발송 가능</div>
+      </div>
+
+      {/* YouTube import */}
+      <div style={sectionStyle}>
+        <div style={{ fontWeight: 800, fontSize: 14, marginBottom: 12 }}>YouTube 영상 등록</div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input value={youtubeUrl} onChange={e => setYoutubeUrl(e.target.value)}
+            placeholder="YouTube URL (https://youtube.com/watch?v=...)" style={inputStyle}
+            onKeyDown={e => { if (e.key === 'Enter') importYoutube(); }}/>
+          <button onClick={importYoutube} disabled={youtubeImporting || !youtubeUrl.trim()} style={adminBtnStyle(youtubeImporting || !youtubeUrl.trim())}>
+            {youtubeImporting ? '...' : '등록'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -105,6 +105,25 @@ function NavArtist({ artist, t, onClick }) {
 // ───────── Top bar (profile tabs live here when on artist page) ─────────
 function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile, authUser, onShowLogin, onLogout }) {
   const dark = theme === 'dark';
+  const [jellyBalance, setJellyBalance] = React.useState(null);
+
+  const fetchJelly = React.useCallback(() => {
+    if (!authUser?.id) { setJellyBalance(null); return; }
+    window.ConnectfinAPI.api('/api/payment/v1/jelly/balance', {
+      headers: { 'X-User-Id': String(authUser.id) }
+    })
+      .then(data => setJellyBalance(data.currentBalance))
+      .catch(err => { console.warn('Jelly balance failed:', err?.message || err); });
+  }, [authUser?.id]);
+
+  React.useEffect(() => { fetchJelly(); }, [fetchJelly]);
+
+  React.useEffect(() => {
+    const handler = () => fetchJelly();
+    window.addEventListener('connectfin:jelly-changed', handler);
+    return () => window.removeEventListener('connectfin:jelly-changed', handler);
+  }, [fetchJelly]);
+
   return (
     <header style={{
       height: 56, flexShrink: 0, display: 'flex', alignItems: 'center',
@@ -150,7 +169,9 @@ function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavPr
       )}
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginLeft: 'auto' }}>
-        <span style={{ fontFamily: t.fontMono, fontSize: 11, color: t.textDim }}>142 🍮</span>
+        <span style={{ fontFamily: t.fontMono, fontSize: 11, color: t.textDim }}>
+          {jellyBalance !== null ? jellyBalance : '—'} 🍮
+        </span>
         <span style={{ fontSize: 18, cursor: 'pointer' }}>🔔</span>
         {authUser ? (
           <button onClick={onLogout} style={{
@@ -184,6 +205,53 @@ const PROFILE_TABS = [
 // ───────── Right sidebar ─────────
 function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
   const dark = theme === 'dark';
+  const hasToken = !!window.ConnectfinAPI?.getToken();
+
+  const [membershipStatus, setMembershipStatus] = React.useState(null);
+  const [dmStatus, setDmStatus] = React.useState(null);
+  const [purchasingMembership, setPurchasingMembership] = React.useState(false);
+  const [purchasingDm, setPurchasingDm] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!hasToken || !artist?.id) return;
+    window.ConnectfinAPI.api(`/api/v1/subscriptions/membership/${artist.id}/status`)
+      .then(data => setMembershipStatus(data))
+      .catch(err => { console.warn('Membership status failed:', err?.message || err); });
+    window.ConnectfinAPI.api(`/api/v1/subscriptions/dm/${artist.id}/status`)
+      .then(data => setDmStatus(data))
+      .catch(err => { console.warn('DM status failed:', err?.message || err); });
+  }, [hasToken, artist?.id]);
+
+  const purchaseMembership = async () => {
+    if (purchasingMembership || !hasToken) return;
+    setPurchasingMembership(true);
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/subscriptions/membership/${artist.id}`, { method: 'POST' });
+      setMembershipStatus({ active: true, expiredAt: null });
+      window.dispatchEvent(new CustomEvent('connectfin:jelly-changed'));
+      alert('팬 멤버십 구매 완료!');
+    } catch (err) {
+      alert('구매 실패: ' + (err.message || '젤리가 부족합니다'));
+    } finally {
+      setPurchasingMembership(false);
+    }
+  };
+
+  const purchaseDm = async () => {
+    if (purchasingDm || !hasToken) return;
+    setPurchasingDm(true);
+    try {
+      await window.ConnectfinAPI.api(`/api/v1/subscriptions/dm/${artist.id}`, { method: 'POST' });
+      setDmStatus({ active: true, expiredAt: null });
+      window.dispatchEvent(new CustomEvent('connectfin:jelly-changed'));
+      alert('DM 구독 완료!');
+    } catch (err) {
+      alert('구매 실패: ' + (err.message || '젤리가 부족합니다'));
+    } finally {
+      setPurchasingDm(false);
+    }
+  };
+
   return (
     <aside style={{ width: 320, flexShrink: 0, padding: '20px 20px 20px 0', display: 'flex', flexDirection: 'column', gap: 14 }}>
       {/* Digital membership */}
@@ -198,11 +266,20 @@ function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
         <div style={{ fontSize: 12, color: t.textDim, lineHeight: 1.5, marginBottom: 12 }}>
           디지털 멤버십에 가입하고 다양한 혜택을 즐겨보세요.
         </div>
-        <button onClick={onOpenMembership} style={{
-          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
-          background: t.accent2, color: dark ? '#071014' : '#fff',
-          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
-        }}>디지털 멤버십 가입하기</button>
+        {dmStatus?.active ? (
+          <div style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, textAlign: 'center',
+            background: t.surface, border: `1px solid ${t.line}`,
+            fontWeight: 700, fontSize: 13, color: t.accent2, fontFamily: t.font,
+          }}>✓ DM 구독 중{dmStatus.expiredAt ? ` (~ ${new Date(dmStatus.expiredAt).toLocaleDateString()})` : ''}</div>
+        ) : (
+          <button onClick={purchaseDm} disabled={purchasingDm} style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+            background: t.accent2, color: dark ? '#071014' : '#fff',
+            fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+            opacity: purchasingDm ? 0.5 : 1,
+          }}>{purchasingDm ? '구매 중...' : 'DM 구독하기 (15 Jelly)'}</button>
+        )}
       </div>
 
       {/* Premium membership */}
@@ -217,11 +294,20 @@ function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
         <div style={{ fontSize: 12, color: t.textDim, lineHeight: 1.5, marginBottom: 12 }}>
           지금 멤버십에 가입하고 특별한 혜택을 누려보세요.
         </div>
-        <button onClick={onOpenMembership} style={{
-          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
-          background: t.accent2, color: dark ? '#071014' : '#fff',
-          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
-        }}>멤버십 가입하기</button>
+        {membershipStatus?.active ? (
+          <div style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, textAlign: 'center',
+            background: t.surface, border: `1px solid ${t.line}`,
+            fontWeight: 700, fontSize: 13, color: t.accent, fontFamily: t.font,
+          }}>✓ 멤버십 구독 중{membershipStatus.expiredAt ? ` (~ ${new Date(membershipStatus.expiredAt).toLocaleDateString()})` : ''}</div>
+        ) : (
+          <button onClick={purchaseMembership} disabled={purchasingMembership} style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+            background: t.accent2, color: dark ? '#071014' : '#fff',
+            fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+            opacity: purchasingMembership ? 0.5 : 1,
+          }}>{purchasingMembership ? '구매 중...' : '멤버십 가입하기 (9 Jelly)'}</button>
+        )}
       </div>
 
       {/* DM widget */}
@@ -241,11 +327,20 @@ function DesktopRightSidebar({ t, theme, artist, onOpenDM, onOpenMembership }) {
             }}>지금 뭐해?</div>
           </div>
         </div>
-        <button onClick={onOpenDM} style={{
-          width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
-          background: t.accent2, color: dark ? '#071014' : '#fff',
-          fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
-        }}>DM 시작하기</button>
+        {dmStatus?.active ? (
+          <button onClick={onOpenDM} style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+            background: t.accent2, color: dark ? '#071014' : '#fff',
+            fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+          }}>DM 보내기</button>
+        ) : (
+          <button onClick={purchaseDm} disabled={purchasingDm} style={{
+            width: '100%', padding: '10px 0', borderRadius: 10, border: 'none',
+            background: t.line, color: t.textDim,
+            fontWeight: 800, fontSize: 13, cursor: 'pointer', fontFamily: t.font,
+            opacity: purchasingDm ? 0.5 : 1,
+          }}>{purchasingDm ? '구매 중...' : 'DM 구독 필요 (15 Jelly)'}</button>
+        )}
       </div>
 
       {/* About artist */}

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -200,6 +200,7 @@ const PROFILE_TABS = [
   { k: 'live', label: 'LIVE' },
   { k: 'notice', label: 'Notice' },
   { k: 'shop', label: 'Shop', external: true },
+  { k: 'admin', label: 'Admin' },
 ];
 
 // ───────── Right sidebar ─────────

--- a/src/main/resources/static/components/screens-raffle.jsx
+++ b/src/main/resources/static/components/screens-raffle.jsx
@@ -91,6 +91,19 @@ function RaffleListScreen({ t, onBack, onOpenRaffle }) {
   const [filter, setFilter] = React.useState('all');
   const [raffles, setRaffles] = React.useState(RAFFLES);
 
+  const [activeTab, setActiveTab] = React.useState('list'); // 'list' | 'myEntries'
+  const [myEntries, setMyEntries] = React.useState([]);
+  const [myEntriesLoading, setMyEntriesLoading] = React.useState(false);
+
+  const loadMyEntries = () => {
+    if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    setMyEntriesLoading(true);
+    window.ConnectfinAPI.api('/api/v1/users/me/raffle-entries')
+      .then(data => { setMyEntries(Array.isArray(data) ? data : []); setActiveTab('myEntries'); })
+      .catch(err => { console.warn('My entries failed:', err?.message || err); })
+      .finally(() => setMyEntriesLoading(false));
+  };
+
   React.useEffect(() => {
     // 모든 아티스트의 래플을 한번에 로드
     Promise.all(
@@ -124,6 +137,23 @@ function RaffleListScreen({ t, onBack, onOpenRaffle }) {
         }}>DM+ TIER</div>
       </div>
 
+      {/* Tab chips */}
+      <div style={{ display: 'flex', gap: 8, padding: '0 16px 12px' }}>
+        <button onClick={() => setActiveTab('list')} style={{
+          padding: '6px 14px', borderRadius: 20, fontSize: 12, fontWeight: 600, cursor: 'pointer',
+          border: activeTab === 'list' ? 'none' : `1px solid ${t.line}`,
+          background: activeTab === 'list' ? t.accent : 'transparent',
+          color: activeTab === 'list' ? '#fff' : t.text, fontFamily: t.font,
+        }}>전체 래플</button>
+        <button onClick={loadMyEntries} style={{
+          padding: '6px 14px', borderRadius: 20, fontSize: 12, fontWeight: 600, cursor: 'pointer',
+          border: activeTab === 'myEntries' ? 'none' : `1px solid ${t.line}`,
+          background: activeTab === 'myEntries' ? t.accent : 'transparent',
+          color: activeTab === 'myEntries' ? '#fff' : t.text, fontFamily: t.font,
+        }}>내 응모 이력</button>
+      </div>
+
+      {activeTab === 'list' && (<>
       {/* Hero featured */}
       {(() => {
         const hero = RAFFLES.find(r => r.hot);
@@ -231,6 +261,38 @@ function RaffleListScreen({ t, onBack, onOpenRaffle }) {
         GET /raffles?cursor=...&status=active<br/>
         가중치 계산: base × membership_tier × jelly_spent
       </div>
+      </>)}
+
+      {activeTab === 'myEntries' && (
+        <div style={{ padding: '0 16px' }}>
+          {myEntriesLoading && (
+            <div style={{ textAlign: 'center', color: t.textDim, padding: 20, fontSize: 13 }}>로딩 중...</div>
+          )}
+          {!myEntriesLoading && myEntries.length === 0 && (
+            <div style={{ textAlign: 'center', color: t.textDim, padding: 40, fontSize: 13 }}>응모 이력이 없습니다.</div>
+          )}
+          {!myEntriesLoading && myEntries.map((entry, idx) => (
+            <div key={entry.raffleId ?? idx} style={{
+              padding: 14, marginBottom: 8, borderRadius: 12,
+              border: `1px solid ${t.line}`, background: 'transparent',
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div>
+                  <div style={{ fontWeight: 700, fontSize: 14 }}>{entry.raffleTitle || '래플'}</div>
+                  <div style={{ fontSize: 11, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+                    {entry.enteredAt ? new Date(entry.enteredAt).toLocaleString() : ''}
+                  </div>
+                </div>
+                <div style={{
+                  padding: '4px 10px', borderRadius: 8, fontSize: 11, fontWeight: 700,
+                  background: entry.won ? t.accent : t.line,
+                  color: entry.won ? '#fff' : t.textDim,
+                }}>{entry.won ? '당첨' : '응모 완료'}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -604,15 +604,31 @@ function LoginModal({ t, theme, onLogin, onClose }) {
   const [password, setPassword] = React.useState('');
   const [error, setError] = React.useState('');
   const [loading, setLoading] = React.useState(false);
+  const [mode, setMode] = React.useState('login'); // 'login' | 'signup'
+  const [nickname, setNickname] = React.useState('');
+  const [phone, setPhone] = React.useState('');
+  const [signupSuccess, setSignupSuccess] = React.useState(false);
 
   const submit = async () => {
     if (!email || !password) return;
+    if (mode === 'signup' && (!nickname || !phone)) return;
     setLoading(true);
     setError('');
     try {
-      await onLogin(email, password);
+      if (mode === 'signup') {
+        await window.ConnectfinAPI.api('/api/auth/v1/signup', {
+          method: 'POST',
+          body: JSON.stringify({ email, password, nickname, phoneNumber: phone }),
+        });
+        setSignupSuccess(true);
+        setMode('login');
+        setNickname('');
+        setPhone('');
+      } else {
+        await onLogin(email, password);
+      }
     } catch (err) {
-      setError(err.message || '로그인 실패');
+      setError(err.message || (mode === 'signup' ? '회원가입 실패' : '로그인 실패'));
     } finally {
       setLoading(false);
     }
@@ -635,8 +651,26 @@ function LoginModal({ t, theme, onLogin, onClose }) {
         border: `1px solid ${t.line}`,
         boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
       }}>
-        <div style={{ fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800, marginBottom: 6 }}>로그인</div>
-        <div style={{ fontSize: 13, color: t.textDim, marginBottom: 24 }}>Connectfin 계정으로 로그인하세요</div>
+        <div style={{ display: 'flex', gap: 16, marginBottom: 6 }}>
+          <button onClick={() => { setMode('login'); setError(''); setSignupSuccess(false); }} style={{
+            fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800,
+            background: 'transparent', border: 'none', cursor: 'pointer', padding: 0,
+            color: mode === 'login' ? t.text : t.textDim,
+            borderBottom: mode === 'login' ? `2px solid ${t.accent}` : '2px solid transparent',
+            paddingBottom: 4,
+          }}>로그인</button>
+          <button onClick={() => { setMode('signup'); setError(''); setSignupSuccess(false); }} style={{
+            fontFamily: t.fontDisplay, fontSize: 22, fontWeight: 800,
+            background: 'transparent', border: 'none', cursor: 'pointer', padding: 0,
+            color: mode === 'signup' ? t.text : t.textDim,
+            borderBottom: mode === 'signup' ? `2px solid ${t.accent}` : '2px solid transparent',
+            paddingBottom: 4,
+          }}>회원가입</button>
+        </div>
+        <div style={{ fontSize: 13, color: t.textDim, marginBottom: 24 }}>
+          {signupSuccess && <span style={{ color: '#22c55e' }}>회원가입 완료! 로그인해 주세요. </span>}
+          {!signupSuccess && (mode === 'login' ? 'Connectfin 계정으로 로그인하세요' : '새 계정을 만들어 보세요')}
+        </div>
 
         <input
           type="email" placeholder="이메일" value={email}
@@ -658,21 +692,44 @@ function LoginModal({ t, theme, onLogin, onClose }) {
           }}
         />
 
+        {mode === 'signup' && (
+          <>
+            <input
+              type="text" placeholder="닉네임 (2~50자)" value={nickname}
+              onChange={e => setNickname(e.target.value)} onKeyDown={handleKeyDown}
+              style={{
+                width: '100%', padding: '12px 14px', marginBottom: 10, borderRadius: 10,
+                border: `1px solid ${t.line}`, background: t.surface2 || 'transparent',
+                color: t.text, fontSize: 14, fontFamily: t.font,
+              }}
+            />
+            <input
+              type="tel" placeholder="전화번호 (010-1234-5678)" value={phone}
+              onChange={e => setPhone(e.target.value)} onKeyDown={handleKeyDown}
+              style={{
+                width: '100%', padding: '12px 14px', marginBottom: 16, borderRadius: 10,
+                border: `1px solid ${t.line}`, background: t.surface2 || 'transparent',
+                color: t.text, fontSize: 14, fontFamily: t.font,
+              }}
+            />
+          </>
+        )}
+
         {error && (
           <div style={{ fontSize: 12, color: '#ff6b6b', marginBottom: 12, lineHeight: 1.4 }}>{error}</div>
         )}
 
-        <button onClick={submit} disabled={loading || !email || !password} style={{
+        <button onClick={submit} disabled={loading || !email || !password || (mode === 'signup' && (!nickname || !phone))} style={{
           width: '100%', padding: '13px 0', borderRadius: 12, border: 'none',
           background: (!email || !password) ? (t.line || '#333') : (t.gradient || t.accent),
           color: '#fff', fontSize: 15, fontWeight: 700, cursor: loading ? 'wait' : 'pointer',
           fontFamily: t.font, opacity: loading ? 0.6 : 1,
         }}>
-          {loading ? '로그인 중...' : '로그인'}
+          {loading ? (mode === 'signup' ? '가입 중...' : '로그인 중...') : (mode === 'signup' ? '회원가입' : '로그인')}
         </button>
 
         <div style={{ textAlign: 'center', marginTop: 16, fontSize: 11, color: t.textMuted, fontFamily: t.fontMono }}>
-          POST /api/auth/v1/login
+          {mode === 'login' ? 'POST /api/auth/v1/login' : 'POST /api/auth/v1/signup'}
         </div>
       </div>
     </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -120,6 +120,10 @@ function App() {
     }
   }, []);
 
+  React.useEffect(() => {
+    window.__connectfinAuthUser = authUser;
+  }, [authUser]);
+
   const handleLogout = () => {
     window.ConnectfinAPI.clearToken();
     setAuthUser(null);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -104,12 +104,21 @@ function App() {
         body: JSON.stringify({ email, password }),
       });
       window.ConnectfinAPI.setToken(res.accessToken);
-      setAuthUser({ token: res.accessToken, email });
+      const meData = await window.ConnectfinAPI.api('/api/member/v1/me');
+      setAuthUser({ token: res.accessToken, email, id: meData.id, nickname: meData.nickname });
       setShowLogin(false);
     } catch (err) {
       throw err;
     }
   };
+
+  React.useEffect(() => {
+    if (authUser?.token && !authUser?.id) {
+      window.ConnectfinAPI.api('/api/member/v1/me')
+        .then(data => setAuthUser(prev => ({ ...prev, id: data.id, nickname: data.nickname })))
+        .catch(err => { console.warn('Auto /me failed:', err?.message || err); });
+    }
+  }, []);
 
   const handleLogout = () => {
     window.ConnectfinAPI.clearToken();


### PR DESCRIPTION
## Summary

데스크톱 프로토타입(`index.html` + `components/*.jsx`)의 비어 있던 사용자 액션 흐름을 백엔드 API와 한꺼번에 연결한 묶음 PR. 백엔드 Java는 변경하지 않으며, 프론트 정적 리소스(`src/main/resources/static`)만 수정.

작업 단위는 4개 이슈로 분리해 추적했고, 한 브랜치 위에 4개 커밋으로 누적했다.

| 이슈 | 커밋 | 핵심 변경 |
|---|---|---|
| #146 | `ce63b21` | 회원가입 + FanPost/FanLetter 작성 + 댓글/대댓글 |
| #147 | `bbfc69c` | 내 정보(/me) + 젤리 잔액 + 멤버십/DM 구독 상태 및 구매 |
| #148 | `6d083f2` | 게시글/댓글 삭제, 댓글 좋아요, 내 래플 응모 이력 |
| #149 | `eebb259` | Admin 간이 패널(라이브/래플/DM/YouTube), 미디어 탭 YouTube |

## 주요 설계 포인트

- **`window.__connectfinAuthUser` 동기화 (#148)**: CDN React + 빌드 없는 환경에서 컴포넌트 간 prop 전달이 어려운 한계 때문에, `index.html`의 App에서 `authUser` 변경 시 `window`에 미러링한다. 사용 측은 `?.id` 옵셔널 체이닝 가드 필수.
- **젤리 잔액 즉시 갱신 (#147)**: Topbar와 RightSidebar가 분리돼 있어 직접 결합 없이 `connectfin:jelly-changed` 커스텀 이벤트로 신호. 구독 구매 성공 시 dispatch → Topbar가 listen 후 잔액 refetch.
- **백엔드 정합성 보정 (#149 검토 결과)**:
  - Live 진행 상태 비교: `'ON_AIR'` ❌ → `'LIVE'` (`LiveStatus` enum 실제값) ✅
  - DM broadcast: `JSON.stringify({content:...})` ❌ → plain string (`@Payload String`) ✅
  - STOMP 클라이언트 접근: `window.__connectfinStompClient` ❌ → `ConnectfinAPI.connectStomp()` 재진입 패턴 ✅
  - STOMP API: v6 `client.send` ❌ → v7 `client.publish` ✅
  - YouTube 작성자 필드: `writerStageName` ❌ → `writerDisplayName` ✅
- **MyRaffleEntryResponse DTO 정합성 (#148)**: 실제 필드 `raffleId`, `raffleTitle`, `enteredAt`, `won`만 사용 (지시서 예시의 `raffleName`/`entryId`/`status`는 DTO에 없음).

## Test plan

- [ ] 비로그인 → 모달 "회원가입" 탭 → 가입 성공 후 로그인 탭 자동 전환 + 성공 메시지
- [ ] 로그인 → Topbar 젤리 잔액이 API 값으로 표시 (비로그인 시 `— 🍮`)
- [ ] 새로고침 후에도 토큰만 있으면 `/me`로 `authUser.id` 자동 복원
- [ ] 멤버십/DM 미구독 상태 → 가격 표시 버튼 → 구매 성공 시 "✓ 구독 중" 표시 + Topbar 잔액 즉시 감소
- [ ] 젤리 부족 시 alert
- [ ] TabFan: "✏️ 팬포스트 작성" → 게시 → 목록 새로고침
- [ ] TabFanLetter: "💌 팬레터 보내기" → recipientType + 이미지 → 보내기 (멤버십 미구독 시 에러 alert)
- [ ] FanPostFullCard / ArtistPostCard: 댓글 작성 / 대댓글 펼치기 / 댓글 좋아요 토글 / 본인 댓글 삭제
- [ ] FanPost 본인 글에 "삭제" 버튼 → 목록에서 제거 (latest/hot 양쪽)
- [ ] ArtistPostCard `inline` 모드(대시보드 미리보기)에선 댓글 영역 비표시
- [ ] RaffleListScreen: "전체 래플 / 내 응모 이력" 탭 / 응모 이력 호출
- [ ] PROFILE_TABS에 "Admin" 탭 노출 / TabAdmin 렌더
  - [ ] 라이브 생성 → SCHEDULED → 시작 → LIVE → 종료 → ENDED
  - [ ] 래플 생성 (PENDING) → 시작
  - [ ] DM 일괄 발송 (라이브 화면을 한 번 열어 STOMP 연결 후) — 미연결 시 안내 alert
  - [ ] YouTube URL 등록 → 미디어 탭 YouTube 섹션에 카드 노출
- [ ] 권한 없는 유저가 Admin API 호출 시 403 → alert로 안내
- [ ] `./gradlew compileJava` 성공 (백엔드 무수정)

## Out of scope (의도적으로 미포함)

- 대댓글 **작성** (이번엔 조회만)
- FanLetter `ARTIST_MEMBER` 선택 시 대상 멤버 ID 입력 UX (그룹 전체 기본값으로 단순화)
- 역할 기반 Admin 패널 가시성 분기 (`/me` 응답에 role 미포함, CDN React 환경에서 추가 가시성 분기 비용 큼 → 서버 403 + alert로 처리)

Closes #146
Closes #147
Closes #148
Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)