### PR TITLE
chore/시연용 더미데이터추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,8 @@ RDS_PASSWORD=
 REDIS_HOST=
 REDIS_PORT=6379
 S3_BUCKET_NAME=
+APP_SEED_SHOWCASE_DATA=false
+APP_SEED_SHOWCASE_PASSWORD=demo1234!
 
 
 # Grafana Local Settings (DO NOT USE admin/admin in production)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -154,6 +154,8 @@ jobs:
           S3_BUCKET_NAME=${S3_BUCKET_NAME}
           JWT_SECRET_KEY=${JWT_SECRET_KEY}
           YOUTUBE_DATA_API_KEY=${YOUTUBE_DATA_API_KEY}
+          APP_SEED_SHOWCASE_DATA=true
+          APP_SEED_SHOWCASE_PASSWORD=demo1234!
           EOF
           
           # 3. 업로드 (변수명 오타 주의!)

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/artistpost/repository/ArtistPostRepository.java
@@ -15,6 +15,10 @@ public interface ArtistPostRepository extends JpaRepository<ArtistPost, Long>, A
 
     Optional<ArtistPost> findByIdAndArtistId(Long artistPostId, Long artistId);
 
+    boolean existsByArtistIdAndWriterIdAndContent(Long artistId, Long writerId, String content);
+
+    Optional<ArtistPost> findByArtistIdAndWriterIdAndContent(Long artistId, Long writerId, String content);
+
     /**
      * flush 단계에서 사용되는 원자 update.
      *

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanletter/repository/FanLetterRepository.java
@@ -17,6 +17,19 @@ public interface FanLetterRepository extends JpaRepository<FanLetter, Long>, Fan
     // 다른 아티스트의 팬레터를 잘못 건드리지 않는다.
     Optional<FanLetter> findByIdAndArtistId(Long fanLetterId, Long artistId);
 
+    Optional<FanLetter> findByArtistIdAndWriterIdAndRecipientTypeAndRecipientArtistMemberIsNull(
+            Long artistId,
+            Long writerId,
+            com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType recipientType
+    );
+
+    Optional<FanLetter> findByArtistIdAndWriterIdAndRecipientTypeAndRecipientArtistMemberId(
+            Long artistId,
+            Long writerId,
+            com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType recipientType,
+            Long recipientArtistMemberId
+    );
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             update FanLetter fanLetter

--- a/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
+++ b/src/main/java/com/example/infinite/domain/artistcontent/post/fanpost/repository/FanPostRepository.java
@@ -14,6 +14,10 @@ import java.util.Optional;
 public interface FanPostRepository extends JpaRepository<FanPost, Long>, FanPostRepositoryCustom {
     Optional<FanPost> findByIdAndArtistId(Long fanPostId, Long artistId);
 
+    boolean existsByArtistIdAndWriterIdAndContent(Long artistId, Long writerId, String content);
+
+    Optional<FanPost> findByArtistIdAndWriterIdAndContent(Long artistId, Long writerId, String content);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             update FanPost fanPost

--- a/src/main/java/com/example/infinite/global/bootstrap/DeployShowcaseDataSeeder.java
+++ b/src/main/java/com/example/infinite/global/bootstrap/DeployShowcaseDataSeeder.java
@@ -1,0 +1,808 @@
+package com.example.infinite.global.bootstrap;
+
+import com.example.infinite.domain.artistcontent.comment.entity.Comment;
+import com.example.infinite.domain.artistcontent.comment.repository.CommentRepository;
+import com.example.infinite.domain.artistcontent.follow.entity.Follow;
+import com.example.infinite.domain.artistcontent.follow.repository.FollowRepository;
+import com.example.infinite.domain.artistcontent.interaction.entity.Reaction;
+import com.example.infinite.domain.artistcontent.interaction.enums.ReactionType;
+import com.example.infinite.domain.artistcontent.interaction.repository.InteractionRepository;
+import com.example.infinite.domain.artistcontent.media.entity.Media;
+import com.example.infinite.domain.artistcontent.media.enums.MediaType;
+import com.example.infinite.domain.artistcontent.media.repository.MediaRepository;
+import com.example.infinite.domain.artistcontent.post.artistpost.entity.ArtistPost;
+import com.example.infinite.domain.artistcontent.post.artistpost.repository.ArtistPostRepository;
+import com.example.infinite.domain.artistcontent.post.enums.PostType;
+import com.example.infinite.domain.artistcontent.post.fanletter.entity.FanLetter;
+import com.example.infinite.domain.artistcontent.post.fanletter.enums.FanLetterRecipientType;
+import com.example.infinite.domain.artistcontent.post.fanletter.repository.FanLetterRepository;
+import com.example.infinite.domain.artistcontent.post.fanpost.entity.FanPost;
+import com.example.infinite.domain.artistcontent.post.fanpost.repository.FanPostRepository;
+import com.example.infinite.domain.member.artist.entity.Artist;
+import com.example.infinite.domain.member.artist.entity.ArtistMember;
+import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
+import com.example.infinite.domain.member.artist.repository.ArtistRepository;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.enums.MemberRole;
+import com.example.infinite.domain.member.member.enums.MemberStatus;
+import com.example.infinite.domain.member.member.repository.MemberRepository;
+import com.example.infinite.domain.subscriptionmembership.entity.DmSubscription;
+import com.example.infinite.domain.subscriptionmembership.entity.FanMembership;
+import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
+import com.example.infinite.domain.subscriptionmembership.repository.DmSubscriptionRepository;
+import com.example.infinite.domain.subscriptionmembership.repository.FanMembershipRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.seed", name = "showcase-data", havingValue = "true")
+public class DeployShowcaseDataSeeder implements ApplicationRunner {
+
+    private static final String LOCK_NAME = "deploy-showcase-data-seed-v1";
+
+    private static final String DEFAULT_PASSWORD = "demo1234!";
+
+    private static final List<FanSeed> FAN_SEEDS = List.of(
+            new FanSeed("fan.01@connectfin.demo", "starlit_one", "010-9700-0001"),
+            new FanSeed("fan.02@connectfin.demo", "midnight_loop", "010-9700-0002"),
+            new FanSeed("fan.03@connectfin.demo", "violet_signal", "010-9700-0003"),
+            new FanSeed("fan.04@connectfin.demo", "cloudberry", "010-9700-0004"),
+            new FanSeed("fan.05@connectfin.demo", "aurora_note", "010-9700-0005"),
+            new FanSeed("fan.06@connectfin.demo", "silverframe", "010-9700-0006"),
+            new FanSeed("fan.07@connectfin.demo", "neonharbor", "010-9700-0007"),
+            new FanSeed("fan.08@connectfin.demo", "peachsignal", "010-9700-0008"),
+            new FanSeed("fan.09@connectfin.demo", "moonlitpage", "010-9700-0009"),
+            new FanSeed("fan.10@connectfin.demo", "afterglowfan", "010-9700-0010")
+    );
+
+    private static final List<String> ARTIST_POST_TEMPLATES = List.of(
+            "%s입니다. 오늘 리허설 막 끝났어요. 무대 준비 잘해서 곧 만날게요.",
+            "새 콘텐츠 준비하면서 팬분들 반응 다 보고 있어요. %s 응원 덕분에 더 힘나요.",
+            "녹음본 마지막 체크 중입니다. 오늘은 특히 %s 파트가 마음에 들어요.",
+            "%s 저녁에 사진이랑 짧은 비하인드도 더 올릴게요. 오늘도 잘 부탁해요."
+    );
+
+    private static final List<String> FAN_POST_TEMPLATES = List.of(
+            "%s 사진 뜬 거 보고 하루 종일 이야기 중이에요. 오늘 비주얼 진짜 최고예요.",
+            "%s 라이브 공지 확인했어요. 본방 사수하려고 일정 다 비워뒀습니다.",
+            "%s 파트 계속 반복 재생 중인데 들을수록 더 좋아져요.",
+            "%s 팬미팅 후기 정리하다가 또 감동받았어요. 현장 분위기 최고였습니다.",
+            "%s 굿즈 배송 왔는데 퀄리티 너무 좋아서 바로 글 남겨요.",
+            "%s 오늘도 응원합니다. 다들 같이 스트리밍 달려요."
+    );
+
+    private static final List<String> ARTIST_POST_COMMENT_TEMPLATES = List.of(
+            "오늘 글 올려줘서 고마워요. %s 일정 기대하면서 기다릴게요.",
+            "비하인드 더 풀어주시면 너무 좋을 것 같아요. 항상 응원합니다."
+    );
+
+    private static final List<String> FAN_POST_COMMENT_TEMPLATES = List.of(
+            "저도 같은 생각이에요. 이번 활동 진짜 반응 좋을 것 같아요.",
+            "정보 감사합니다. 같이 달리면 더 재밌을 것 같네요."
+    );
+
+    private static final List<String> REPLY_TEMPLATES = List.of(
+            "맞아요. 저도 그 장면에서 바로 저장했어요.",
+            "같이 기다려봐요. 오늘도 좋은 하루 보내세요."
+    );
+
+    private static final List<ArtistSeed> ARTIST_SEEDS = List.of(
+            new ArtistSeed(
+                    1L,
+                    "LUMEN8",
+                    "lumen8",
+                    "LUMEN8 공식 커뮤니티입니다. 팬포스트, 아티스트포스트, 팬레터, 댓글 동선을 한 번에 시연하기 위한 데이터입니다.",
+                    List.of(
+                            new ArtistMemberSeed("YUNA", "artist.lumen8.yuna@connectfin.demo", "lumen8_yuna", "010-9600-0001"),
+                            new ArtistMemberSeed("RIN", "artist.lumen8.rin@connectfin.demo", "lumen8_rin", "010-9600-0002"),
+                            new ArtistMemberSeed("SORA", "artist.lumen8.sora@connectfin.demo", "lumen8_sora", "010-9600-0003")
+                    )
+            ),
+            new ArtistSeed(
+                    2L,
+                    "Kagero",
+                    "kagero",
+                    "Kagero 공식 커뮤니티입니다. mock 프론트 artistId 2와 맞춰 시연 가능한 데이터를 제공합니다.",
+                    List.of(
+                            new ArtistMemberSeed("REI", "artist.kagero.rei@connectfin.demo", "kagero_rei", "010-9600-0004"),
+                            new ArtistMemberSeed("REN", "artist.kagero.ren@connectfin.demo", "kagero_ren", "010-9600-0005")
+                    )
+            ),
+            new ArtistSeed(
+                    3L,
+                    "NOIR7",
+                    "noir7",
+                    "NOIR7 공식 커뮤니티입니다. 여러 멤버 계정과 게시물을 함께 시연할 수 있도록 구성된 데이터입니다.",
+                    List.of(
+                            new ArtistMemberSeed("KAI", "artist.noir7.kai@connectfin.demo", "noir7_kai", "010-9600-0006"),
+                            new ArtistMemberSeed("JUNO", "artist.noir7.juno@connectfin.demo", "noir7_juno", "010-9600-0007"),
+                            new ArtistMemberSeed("HARU", "artist.noir7.haru@connectfin.demo", "noir7_haru", "010-9600-0008")
+                    )
+            ),
+            new ArtistSeed(
+                    4L,
+                    "hanabi*",
+                    "hanabi-star",
+                    "hanabi* 공식 커뮤니티입니다. 솔로 아티스트 흐름과 팬레터 수신 대상을 함께 확인할 수 있습니다.",
+                    List.of(
+                            new ArtistMemberSeed("hanabi*", "artist.hanabi.main@connectfin.demo", "hanabi_main", "010-9600-0009")
+                    )
+            ),
+            new ArtistSeed(
+                    5L,
+                    "Velvet Static",
+                    "velvet-static",
+                    "Velvet Static 공식 커뮤니티입니다. 밴드형 아티스트 프로필과 커뮤니티 흐름 시연용입니다.",
+                    List.of(
+                            new ArtistMemberSeed("SEUNG", "artist.velvet.seung@connectfin.demo", "velvet_seung", "010-9600-0010"),
+                            new ArtistMemberSeed("JIN", "artist.velvet.jin@connectfin.demo", "velvet_jin", "010-9600-0011")
+                    )
+            ),
+            new ArtistSeed(
+                    6L,
+                    "ORBITAL",
+                    "orbital",
+                    "ORBITAL 공식 커뮤니티입니다. 힙합 크루 스타일 아티스트 테스트를 위한 시연 데이터입니다.",
+                    List.of(
+                            new ArtistMemberSeed("LOW-G", "artist.orbital.lowg@connectfin.demo", "orbital_lowg", "010-9600-0012"),
+                            new ArtistMemberSeed("COSM", "artist.orbital.cosm@connectfin.demo", "orbital_cosm", "010-9600-0013"),
+                            new ArtistMemberSeed("NOVA", "artist.orbital.nova@connectfin.demo", "orbital_nova", "010-9600-0014")
+                    )
+            )
+    );
+
+    private final MemberRepository memberRepository;
+    private final ArtistRepository artistRepository;
+    private final ArtistMemberRepository artistMemberRepository;
+    private final ArtistPostRepository artistPostRepository;
+    private final FanPostRepository fanPostRepository;
+    private final FanLetterRepository fanLetterRepository;
+    private final CommentRepository commentRepository;
+    private final InteractionRepository interactionRepository;
+    private final FollowRepository followRepository;
+    private final FanMembershipRepository fanMembershipRepository;
+    private final DmSubscriptionRepository dmSubscriptionRepository;
+    private final MediaRepository mediaRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Value("${app.seed.showcase-password:" + DEFAULT_PASSWORD + "}")
+    private String showcasePassword;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (!acquireLock()) {
+            log.info("배포 시연 데이터 시드 잠금을 획득하지 못해 이번 인스턴스는 건너뜁니다.");
+            return;
+        }
+
+        try {
+            List<Member> fanMembers = ensureFanMembers();
+
+            for (ArtistSeed artistSeed : ARTIST_SEEDS) {
+                Artist artist = ensureArtist(artistSeed);
+                List<ArtistMember> artistMembers = ensureArtistMembers(artist, artistSeed.members());
+
+                ensureFanSubscriptions(artist, fanMembers);
+                ensureDmSubscriptions(artist, fanMembers);
+                ensureFollows(fanMembers, artistMembers.get(0));
+
+                List<ArtistPost> artistPosts = seedArtistPosts(artist, artistMembers);
+                List<FanPost> fanPosts = seedFanPosts(artist, artistMembers, fanMembers);
+                List<FanLetter> fanLetters = seedFanLetters(artist, artistMembers, fanMembers);
+
+                seedArtistPostComments(artist, artistMembers, fanMembers, artistPosts);
+                seedFanPostComments(artist, artistMembers, fanMembers, fanPosts);
+
+                seedArtistPostLikes(fanMembers, artistPosts);
+                seedFanPostLikes(artistMembers, fanMembers, fanPosts);
+                seedFanLetterLikes(artistMembers, fanMembers, fanLetters);
+            }
+
+            log.info(
+                    "배포 시연 데이터 시드 완료: artists={}, artistMembers={}, fans={}",
+                    ARTIST_SEEDS.size(),
+                    ARTIST_SEEDS.stream().mapToInt(seed -> seed.members().size()).sum(),
+                    FAN_SEEDS.size()
+            );
+        } finally {
+            releaseLock();
+        }
+    }
+
+    private List<Member> ensureFanMembers() {
+        List<Member> fanMembers = new ArrayList<>();
+        for (int index = 0; index < FAN_SEEDS.size(); index++) {
+            FanSeed fanSeed = FAN_SEEDS.get(index);
+            fanMembers.add(ensureMember(
+                    fanSeed.email(),
+                    fanSeed.nickname(),
+                    fanSeed.phoneNumber(),
+                    MemberRole.MEMBER,
+                    profileImageUrl("fan", fanSeed.nickname()),
+                    coverImageUrl("fan", fanSeed.nickname())
+            ));
+        }
+        return fanMembers;
+    }
+
+    private Artist ensureArtist(ArtistSeed seed) {
+        Artist artistById = artistRepository.findById(seed.id()).orElse(null);
+        Artist artistBySlug = artistRepository.findBySlug(seed.slug()).orElse(null);
+
+        if (artistById != null) {
+            if (artistBySlug != null && !artistBySlug.getId().equals(artistById.getId())) {
+                log.warn(
+                        "artistId={} 는 이미 다른 slug={} 로 존재하고 slug={} 는 다른 id={} 에 연결되어 있습니다. id 기준으로만 갱신합니다.",
+                        seed.id(),
+                        artistById.getSlug(),
+                        seed.slug(),
+                        artistBySlug.getId()
+                );
+                artistById.updateProfile(
+                        seed.name(),
+                        artistById.getSlug(),
+                        profileImageUrl("artist", seed.slug()),
+                        coverImageUrl("artist", seed.slug()),
+                        seed.intro()
+                );
+                return artistById;
+            }
+
+            artistById.updateProfile(
+                    seed.name(),
+                    seed.slug(),
+                    profileImageUrl("artist", seed.slug()),
+                    coverImageUrl("artist", seed.slug()),
+                    seed.intro()
+            );
+            return artistById;
+        }
+
+        if (artistBySlug != null) {
+            log.warn(
+                    "artist slug={} 가 이미 id={} 로 존재합니다. 프론트 mock artistId={} 와 불일치할 수 있습니다.",
+                    seed.slug(),
+                    artistBySlug.getId(),
+                    seed.id()
+            );
+            artistBySlug.updateProfile(
+                    seed.name(),
+                    seed.slug(),
+                    profileImageUrl("artist", seed.slug()),
+                    coverImageUrl("artist", seed.slug()),
+                    seed.intro()
+            );
+            return artistBySlug;
+        }
+
+        insertArtistWithFixedId(seed);
+        return artistRepository.findById(seed.id())
+                .orElseThrow(() -> new IllegalStateException("시드 아티스트 생성 후 조회에 실패했습니다. id=" + seed.id()));
+    }
+
+    private List<ArtistMember> ensureArtistMembers(Artist artist, List<ArtistMemberSeed> seeds) {
+        List<ArtistMember> artistMembers = new ArrayList<>();
+
+        for (int index = 0; index < seeds.size(); index++) {
+            ArtistMemberSeed seed = seeds.get(index);
+            int sortOrder = index + 1;
+            Member member = ensureMember(
+                    seed.email(),
+                    seed.nickname(),
+                    seed.phoneNumber(),
+                    MemberRole.ARTIST,
+                    profileImageUrl("artist-member", seed.nickname()),
+                    coverImageUrl("artist-member", seed.nickname())
+            );
+
+            ArtistMember artistMember = artistMemberRepository.findByArtistIdAndMemberId(artist.getId(), member.getId())
+                    .map(existing -> {
+                        existing.updateProfile(
+                                seed.stageName(),
+                                profileImageUrl("artist-member", seed.nickname()),
+                                MemberStatus.ACTIVE,
+                                sortOrder
+                        );
+                        return existing;
+                    })
+                    .orElseGet(() -> artistMemberRepository.save(ArtistMember.create(
+                            artist,
+                            member,
+                            seed.stageName(),
+                            profileImageUrl("artist-member", seed.nickname()),
+                            sortOrder
+                    )));
+
+            artistMembers.add(artistMember);
+        }
+
+        return artistMembers;
+    }
+
+    private Member ensureMember(
+            String email,
+            String nickname,
+            String phoneNumber,
+            MemberRole role,
+            String profileImageUrl,
+            String coverImageUrl
+    ) {
+        return memberRepository.findByEmail(email)
+                .map(existing -> {
+                    if (existing.getRole() != role) {
+                        existing.changeRole(role);
+                    }
+                    if (existing.getStatus() != MemberStatus.ACTIVE) {
+                        existing.changeStatus(MemberStatus.ACTIVE);
+                    }
+                    if (!passwordEncoder.matches(showcasePassword, existing.getPassword())) {
+                        existing.changePassword(passwordEncoder.encode(showcasePassword));
+                    }
+                    existing.updateProfile(nickname, phoneNumber, profileImageUrl, coverImageUrl);
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    Member member = Member.createNewMember(
+                            email,
+                            passwordEncoder.encode(showcasePassword),
+                            nickname,
+                            phoneNumber
+                    );
+                    member.changeRole(role);
+                    member.changeStatus(MemberStatus.ACTIVE);
+                    member.updateProfile(nickname, phoneNumber, profileImageUrl, coverImageUrl);
+                    return memberRepository.save(member);
+                });
+    }
+
+    private void ensureFanSubscriptions(Artist artist, List<Member> fanMembers) {
+        LocalDateTime now = LocalDateTime.now();
+        for (Member fanMember : fanMembers) {
+            boolean activeMembership = fanMembershipRepository
+                    .findByUserIdAndArtistIdAndStatus(fanMember.getId(), artist.getId(), SubscriptionStatus.ACTIVE)
+                    .filter(FanMembership::isActive)
+                    .isPresent();
+
+            if (activeMembership) {
+                continue;
+            }
+
+            fanMembershipRepository.save(FanMembership.builder()
+                    .userId(fanMember.getId())
+                    .artistId(artist.getId())
+                    .startedAt(now.minusDays(5))
+                    .expiredAt(now.plusDays(45))
+                    .jellyAmount(9)
+                    .build());
+        }
+    }
+
+    private void ensureDmSubscriptions(Artist artist, List<Member> fanMembers) {
+        LocalDateTime now = LocalDateTime.now();
+        for (int index = 0; index < Math.min(4, fanMembers.size()); index++) {
+            Member fanMember = fanMembers.get(index);
+            boolean activeSubscription = dmSubscriptionRepository
+                    .findByUserIdAndArtistIdAndStatus(fanMember.getId(), artist.getId(), SubscriptionStatus.ACTIVE)
+                    .filter(DmSubscription::isActive)
+                    .isPresent();
+
+            if (activeSubscription) {
+                continue;
+            }
+
+            dmSubscriptionRepository.save(DmSubscription.builder()
+                    .userId(fanMember.getId())
+                    .artistId(artist.getId())
+                    .startedAt(now.minusDays(3))
+                    .expiredAt(now.plusDays(30))
+                    .jellyAmount(15)
+                    .build());
+        }
+    }
+
+    private void ensureFollows(List<Member> fanMembers, ArtistMember primaryArtistMember) {
+        for (Member fanMember : fanMembers) {
+            if (followRepository.findByFollowerMemberIdAndTargetArtistMemberId(
+                    fanMember.getId(),
+                    primaryArtistMember.getId()
+            ).isPresent()) {
+                continue;
+            }
+
+            followRepository.save(Follow.create(fanMember, primaryArtistMember));
+        }
+    }
+
+    private List<ArtistPost> seedArtistPosts(Artist artist, List<ArtistMember> artistMembers) {
+        List<ArtistPost> posts = new ArrayList<>();
+
+        for (int index = 0; index < ARTIST_POST_TEMPLATES.size(); index++) {
+            ArtistMember writer = artistMembers.get(index % artistMembers.size());
+            String content = buildArtistPostContent(artist.getName(), writer.getStageName(), index);
+
+            ArtistPost post = artistPostRepository.findByArtistIdAndWriterIdAndContent(artist.getId(), writer.getMember().getId(), content)
+                    .orElseGet(() -> artistPostRepository.save(ArtistPost.create(artist, writer.getMember(), content)));
+            posts.add(post);
+        }
+
+        return posts;
+    }
+
+    private List<FanPost> seedFanPosts(Artist artist, List<ArtistMember> artistMembers, List<Member> fanMembers) {
+        List<FanPost> posts = new ArrayList<>();
+        String primaryStageName = artistMembers.get(0).getStageName();
+
+        for (int index = 0; index < FAN_POST_TEMPLATES.size(); index++) {
+            Member writer = fanMembers.get((int) ((artist.getId() + index) % fanMembers.size()));
+            String content = buildFanPostContent(artist.getName(), primaryStageName, index);
+
+            FanPost post = fanPostRepository.findByArtistIdAndWriterIdAndContent(artist.getId(), writer.getId(), content)
+                    .orElseGet(() -> fanPostRepository.save(FanPost.create(artist, writer, content)));
+            posts.add(post);
+        }
+
+        return posts;
+    }
+
+    private List<FanLetter> seedFanLetters(Artist artist, List<ArtistMember> artistMembers, List<Member> fanMembers) {
+        List<FanLetter> letters = new ArrayList<>();
+
+        for (int index = 0; index < 4; index++) {
+            Member writer = fanMembers.get((int) ((artist.getId() + index + 2) % fanMembers.size()));
+            FanLetterRecipientType recipientType = index < 2 ? FanLetterRecipientType.ARTIST : FanLetterRecipientType.ARTIST_MEMBER;
+            ArtistMember recipientArtistMember = recipientType == FanLetterRecipientType.ARTIST
+                    ? null
+                    : artistMembers.get(index % artistMembers.size());
+
+            FanLetter fanLetter = findExistingFanLetter(artist.getId(), writer.getId(), recipientType, recipientArtistMember)
+                    .orElseGet(() -> fanLetterRepository.save(FanLetter.create(
+                            artist,
+                            writer,
+                            recipientType,
+                            recipientArtistMember
+                    )));
+
+            ensureFanLetterImage(artist, writer, fanLetter, recipientType, recipientArtistMember, index);
+            letters.add(fanLetter);
+        }
+
+        return letters;
+    }
+
+    private Optional<FanLetter> findExistingFanLetter(
+            Long artistId,
+            Long writerId,
+            FanLetterRecipientType recipientType,
+            ArtistMember recipientArtistMember
+    ) {
+        if (recipientArtistMember == null) {
+            return fanLetterRepository.findByArtistIdAndWriterIdAndRecipientTypeAndRecipientArtistMemberIsNull(
+                    artistId,
+                    writerId,
+                    recipientType
+            );
+        }
+
+        return fanLetterRepository.findByArtistIdAndWriterIdAndRecipientTypeAndRecipientArtistMemberId(
+                artistId,
+                writerId,
+                recipientType,
+                recipientArtistMember.getId()
+        );
+    }
+
+    private void ensureFanLetterImage(
+            Artist artist,
+            Member writer,
+            FanLetter fanLetter,
+            FanLetterRecipientType recipientType,
+            ArtistMember recipientArtistMember,
+            int index
+    ) {
+        if (!mediaRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(PostType.FAN_LETTER, fanLetter.getId()).isEmpty()) {
+            return;
+        }
+
+        String recipientKey = recipientArtistMember == null ? "artist" : recipientArtistMember.getStageName().toLowerCase();
+        String imageUrl = "https://picsum.photos/seed/showcase-letter-" + artist.getId() + "-" + writer.getId() + "-" + recipientKey + "-" + index + "/900/1200";
+
+        mediaRepository.save(Media.create(
+                PostType.FAN_LETTER,
+                fanLetter.getId(),
+                MediaType.IMAGE,
+                "showcase/fan-letter/" + artist.getId() + "/" + fanLetter.getId() + "/" + recipientKey + ".jpg",
+                imageUrl,
+                imageUrl,
+                "showcase-letter-" + artist.getId() + "-" + writer.getId() + "-" + index + ".jpg",
+                "image/jpeg",
+                250_000L,
+                0
+        ));
+    }
+
+    private void seedArtistPostComments(
+            Artist artist,
+            List<ArtistMember> artistMembers,
+            List<Member> fanMembers,
+            List<ArtistPost> artistPosts
+    ) {
+        for (int index = 0; index < artistPosts.size(); index++) {
+            ArtistPost artistPost = artistPosts.get(index);
+            Member rootWriter = fanMembers.get(index % fanMembers.size());
+            Member secondWriter = fanMembers.get((index + 1) % fanMembers.size());
+            Member replyWriter = artistMembers.get(index % artistMembers.size()).getMember();
+
+            Comment rootOne = ensureComment(
+                    PostType.ARTIST_POST,
+                    artistPost.getId(),
+                    rootWriter,
+                    String.format(ARTIST_POST_COMMENT_TEMPLATES.get(0), artist.getName()),
+                    null,
+                    "showcase-artist-post-" + artistPost.getId() + "-root-1",
+                    artistPost::changeCommentCountBy
+            );
+            ensureComment(
+                    PostType.ARTIST_POST,
+                    artistPost.getId(),
+                    secondWriter,
+                    ARTIST_POST_COMMENT_TEMPLATES.get(1),
+                    null,
+                    "showcase-artist-post-" + artistPost.getId() + "-root-2",
+                    artistPost::changeCommentCountBy
+            );
+            ensureComment(
+                    PostType.ARTIST_POST,
+                    artistPost.getId(),
+                    replyWriter,
+                    REPLY_TEMPLATES.get(index % REPLY_TEMPLATES.size()),
+                    rootOne,
+                    "showcase-artist-post-" + artistPost.getId() + "-reply-1",
+                    artistPost::changeCommentCountBy
+            );
+        }
+    }
+
+    private void seedFanPostComments(
+            Artist artist,
+            List<ArtistMember> artistMembers,
+            List<Member> fanMembers,
+            List<FanPost> fanPosts
+    ) {
+        for (int index = 0; index < fanPosts.size(); index++) {
+            FanPost fanPost = fanPosts.get(index);
+            Member rootWriter = fanMembers.get((index + 2) % fanMembers.size());
+            Member secondWriter = fanMembers.get((index + 3) % fanMembers.size());
+            Member replyWriter = artistMembers.get(index % artistMembers.size()).getMember();
+
+            Comment rootOne = ensureComment(
+                    PostType.FAN_POST,
+                    fanPost.getId(),
+                    rootWriter,
+                    FAN_POST_COMMENT_TEMPLATES.get(0),
+                    null,
+                    "showcase-fan-post-" + fanPost.getId() + "-root-1",
+                    fanPost::changeCommentCountBy
+            );
+            ensureComment(
+                    PostType.FAN_POST,
+                    fanPost.getId(),
+                    secondWriter,
+                    FAN_POST_COMMENT_TEMPLATES.get(1),
+                    null,
+                    "showcase-fan-post-" + fanPost.getId() + "-root-2",
+                    fanPost::changeCommentCountBy
+            );
+            ensureComment(
+                    PostType.FAN_POST,
+                    fanPost.getId(),
+                    replyWriter,
+                    REPLY_TEMPLATES.get((index + 1) % REPLY_TEMPLATES.size()),
+                    rootOne,
+                    "showcase-fan-post-" + fanPost.getId() + "-reply-1",
+                    fanPost::changeCommentCountBy
+            );
+        }
+    }
+
+    private Comment ensureComment(
+            PostType targetType,
+            Long targetId,
+            Member writer,
+            String content,
+            Comment parent,
+            String commandRequestId,
+            java.util.function.IntConsumer commentCountChanger
+    ) {
+        return commentRepository.findByCommandRequestId(commandRequestId)
+                .orElseGet(() -> {
+                    Comment comment = commentRepository.save(Comment.create(
+                            targetType,
+                            targetId,
+                            writer,
+                            content,
+                            parent,
+                            commandRequestId
+                    ));
+                    commentCountChanger.accept(1);
+                    return comment;
+                });
+    }
+
+    private void seedArtistPostLikes(List<Member> fanMembers, List<ArtistPost> artistPosts) {
+        for (int index = 0; index < artistPosts.size(); index++) {
+            ArtistPost artistPost = artistPosts.get(index);
+            int likeTarget = index < 12 ? 5 : 3;
+            for (int likeIndex = 0; likeIndex < likeTarget; likeIndex++) {
+                Member actor = fanMembers.get((index + likeIndex) % fanMembers.size());
+                ensureLike(PostType.ARTIST_POST, artistPost.getId(), actor, () -> artistPost.changeLikeCountBy(1));
+            }
+        }
+    }
+
+    private void seedFanPostLikes(List<ArtistMember> artistMembers, List<Member> fanMembers, List<FanPost> fanPosts) {
+        for (int index = 0; index < fanPosts.size(); index++) {
+            FanPost fanPost = fanPosts.get(index);
+            int likeTarget = index < 2 ? 6 : index < 4 ? 5 : 3;
+
+            for (int likeIndex = 0; likeIndex < likeTarget; likeIndex++) {
+                Member actor = fanMembers.get((index + likeIndex) % fanMembers.size());
+                ensureLike(PostType.FAN_POST, fanPost.getId(), actor, () -> fanPost.changeLikeCountBy(1));
+            }
+
+            Member artistActor = artistMembers.get(index % artistMembers.size()).getMember();
+            ensureLike(PostType.FAN_POST, fanPost.getId(), artistActor, () -> fanPost.changeLikeCountBy(1));
+        }
+    }
+
+    private void seedFanLetterLikes(List<ArtistMember> artistMembers, List<Member> fanMembers, List<FanLetter> fanLetters) {
+        for (int index = 0; index < fanLetters.size(); index++) {
+            FanLetter fanLetter = fanLetters.get(index);
+
+            for (int likeIndex = 0; likeIndex < 5; likeIndex++) {
+                Member actor = fanMembers.get((index + likeIndex) % fanMembers.size());
+                ensureLike(PostType.FAN_LETTER, fanLetter.getId(), actor, () -> fanLetter.changeLikeCountBy(1));
+            }
+
+            Member artistActor = artistMembers.get(index % artistMembers.size()).getMember();
+            ensureLike(PostType.FAN_LETTER, fanLetter.getId(), artistActor, () -> fanLetter.changeLikeCountBy(1));
+        }
+    }
+
+    private void ensureLike(PostType targetType, Long targetId, Member actor, Runnable onCreated) {
+        if (interactionRepository.existsByTargetTypeAndTargetIdAndMemberIdAndReactionType(
+                targetType,
+                targetId,
+                actor.getId(),
+                ReactionType.LIKE
+        )) {
+            return;
+        }
+
+        interactionRepository.save(Reaction.create(targetType, targetId, actor.getId(), ReactionType.LIKE));
+        onCreated.run();
+    }
+
+    private String buildArtistPostContent(String artistName, String stageName, int index) {
+        return switch (index) {
+            case 0 -> String.format(ARTIST_POST_TEMPLATES.get(0), stageName);
+            case 1 -> String.format(ARTIST_POST_TEMPLATES.get(1), artistName);
+            case 2 -> String.format(ARTIST_POST_TEMPLATES.get(2), stageName);
+            default -> String.format(ARTIST_POST_TEMPLATES.get(3), artistName);
+        };
+    }
+
+    private String buildFanPostContent(String artistName, String primaryStageName, int index) {
+        return switch (index) {
+            case 0 -> String.format(FAN_POST_TEMPLATES.get(0), artistName);
+            case 1 -> String.format(FAN_POST_TEMPLATES.get(1), artistName);
+            case 2 -> String.format(FAN_POST_TEMPLATES.get(2), primaryStageName);
+            case 3 -> String.format(FAN_POST_TEMPLATES.get(3), artistName);
+            case 4 -> String.format(FAN_POST_TEMPLATES.get(4), artistName);
+            default -> String.format(FAN_POST_TEMPLATES.get(5), artistName);
+        };
+    }
+
+    private void insertArtistWithFixedId(ArtistSeed seed) {
+        entityManager.createNativeQuery("""
+                insert into artists (
+                    id,
+                    name,
+                    slug,
+                    profile_image_url,
+                    cover_image_url,
+                    intro,
+                    status,
+                    created_at,
+                    updated_at,
+                    deleted_at
+                ) values (
+                    :id,
+                    :name,
+                    :slug,
+                    :profileImageUrl,
+                    :coverImageUrl,
+                    :intro,
+                    'ACTIVE',
+                    current_timestamp,
+                    current_timestamp,
+                    null
+                )
+                """)
+                .setParameter("id", seed.id())
+                .setParameter("name", seed.name())
+                .setParameter("slug", seed.slug())
+                .setParameter("profileImageUrl", profileImageUrl("artist", seed.slug()))
+                .setParameter("coverImageUrl", coverImageUrl("artist", seed.slug()))
+                .setParameter("intro", seed.intro())
+                .executeUpdate();
+    }
+
+    private boolean acquireLock() {
+        Number result = (Number) entityManager.createNativeQuery("select get_lock(:lockName, 5)")
+                .setParameter("lockName", LOCK_NAME)
+                .getSingleResult();
+        return result != null && result.intValue() == 1;
+    }
+
+    private void releaseLock() {
+        entityManager.createNativeQuery("select release_lock(:lockName)")
+                .setParameter("lockName", LOCK_NAME)
+                .getSingleResult();
+    }
+
+    private String profileImageUrl(String prefix, String seedKey) {
+        return "https://picsum.photos/seed/" + prefix + "-" + seedKey + "/600/600";
+    }
+
+    private String coverImageUrl(String prefix, String seedKey) {
+        return "https://picsum.photos/seed/" + prefix + "-" + seedKey + "-cover/1440/720";
+    }
+
+    private record ArtistSeed(
+            Long id,
+            String name,
+            String slug,
+            String intro,
+            List<ArtistMemberSeed> members
+    ) {
+    }
+
+    private record ArtistMemberSeed(
+            String stageName,
+            String email,
+            String nickname,
+            String phoneNumber
+    ) {
+    }
+
+    private record FanSeed(
+            String email,
+            String nickname,
+            String phoneNumber
+    ) {
+    }
+}

--- a/src/main/java/com/example/infinite/global/bootstrap/LocalDemoDataSeeder.java
+++ b/src/main/java/com/example/infinite/global/bootstrap/LocalDemoDataSeeder.java
@@ -1,0 +1,378 @@
+package com.example.infinite.global.bootstrap;
+
+import com.example.infinite.domain.artistcontent.media.entity.ArtistYoutubeVideo;
+import com.example.infinite.domain.artistcontent.media.repository.ArtistYoutubeVideoRepository;
+import com.example.infinite.domain.member.artist.entity.Artist;
+import com.example.infinite.domain.member.artist.entity.ArtistMember;
+import com.example.infinite.domain.member.artist.repository.ArtistMemberRepository;
+import com.example.infinite.domain.member.artist.repository.ArtistRepository;
+import com.example.infinite.domain.member.artist.service.ArtistSearchKeywordService;
+import com.example.infinite.domain.member.member.entity.Member;
+import com.example.infinite.domain.member.member.enums.MemberRole;
+import com.example.infinite.domain.member.member.repository.MemberRepository;
+import com.example.infinite.domain.realtimelive.entity.RealtimeLive;
+import com.example.infinite.domain.realtimelive.enums.LiveStatus;
+import com.example.infinite.domain.realtimelive.repository.RealtimeLiveRepository;
+import com.example.infinite.domain.subscriptionmembership.entity.FanMembership;
+import com.example.infinite.domain.subscriptionmembership.enums.SubscriptionStatus;
+import com.example.infinite.domain.subscriptionmembership.repository.FanMembershipRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 로컬 프론트 확인용 더미 데이터 시드.
+ *
+ * 목표:
+ * - 아티스트 검색 결과가 비지 않게 기본 아티스트를 채운다.
+ * - YouTube 탭에서 바로 보이도록 아티스트당 6개 카드를 넣는다.
+ * - LIVE Replay 탭에서 보이도록 REPLAY_READY VOD를 아티스트당 3개 넣는다.
+ * - 로그인 테스트를 위해 팬 계정 1개와 아티스트 멤버 계정을 같이 만든다.
+ *
+ * 운영/배포 환경에서는 절대 돌지 않도록 local profile + property 두 겹으로 막는다.
+ */
+@Slf4j
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.seed", name = "demo-data", havingValue = "true", matchIfMissing = true)
+public class LocalDemoDataSeeder implements ApplicationRunner {
+
+    private static final String DEMO_PASSWORD = "demo1234!";
+
+    private static final List<ArtistSeed> ARTISTS = List.of(
+            new ArtistSeed("bts", "BTS", "Jin", "Global pop group demo artist"),
+            new ArtistSeed("blackpink", "BLACKPINK", "Jennie", "Performance-focused demo artist"),
+            new ArtistSeed("newjeans", "NewJeans", "Minji", "Fast-moving fandom demo artist"),
+            new ArtistSeed("ive", "IVE", "Wonyoung", "Bright concept demo artist"),
+            new ArtistSeed("aespa", "aespa", "Karina", "Digital concept demo artist"),
+            new ArtistSeed("seventeen", "SEVENTEEN", "S.Coups", "Large member-count demo artist")
+    );
+
+    private static final List<YoutubeSeed> YOUTUBE_SEEDS = List.of(
+            new YoutubeSeed("dQw4w9WgXcQ", "Performance Clip 01", 213),
+            new YoutubeSeed("3JZ_D3ELwOQ", "Performance Clip 02", 246),
+            new YoutubeSeed("kJQP7kiw5Fk", "Performance Clip 03", 281),
+            new YoutubeSeed("fLexgOxsZu0", "Performance Clip 04", 234),
+            new YoutubeSeed("9bZkp7q19f0", "Performance Clip 05", 252),
+            new YoutubeSeed("L_jWHffIx5E", "Performance Clip 06", 242)
+    );
+
+    private static final List<ReplaySeed> REPLAY_SEEDS = List.of(
+            new ReplaySeed(
+                    "https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                    "Replay 01",
+                    96,
+                    3
+            ),
+            new ReplaySeed(
+                    "https://storage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+                    "Replay 02",
+                    74,
+                    8
+            ),
+            new ReplaySeed(
+                    "https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4",
+                    "Replay 03",
+                    58,
+                    14
+            )
+    );
+
+    private final MemberRepository memberRepository;
+    private final ArtistRepository artistRepository;
+    private final ArtistMemberRepository artistMemberRepository;
+    private final ArtistYoutubeVideoRepository artistYoutubeVideoRepository;
+    private final RealtimeLiveRepository realtimeLiveRepository;
+    private final FanMembershipRepository fanMembershipRepository;
+    private final ArtistSearchKeywordService artistSearchKeywordService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        Member fanDemoMember = ensureFanDemoMember();
+        ensureSuperAdminDemoMember();
+
+        for (int artistIndex = 0; artistIndex < ARTISTS.size(); artistIndex++) {
+            ArtistSeed artistSeed = ARTISTS.get(artistIndex);
+            Member member = ensureArtistMemberUser(artistSeed, artistIndex);
+            Artist artist = ensureArtist(artistSeed, artistIndex);
+            ArtistMember artistMember = ensureArtistMember(artist, member, artistSeed, artistIndex);
+
+            seedYoutubeVideos(artist, artistMember, artistIndex);
+            seedReplayVod(artist, artistMember, artistIndex);
+            seedPopularKeyword(artistSeed, artistIndex);
+            seedFanDemoMembership(fanDemoMember, artist);
+        }
+
+        log.info("로컬 더미데이터 시드 점검 완료: artists={}, youtubePerArtist=6, vodPerArtist=3",
+                ARTISTS.size());
+    }
+
+    private Member ensureFanDemoMember() {
+        String email = "fan.demo@infinite.local";
+        return memberRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    Member fan = Member.createNewMember(
+                            email,
+                            passwordEncoder.encode(DEMO_PASSWORD),
+                            "fan_demo",
+                            "010-9000-0001"
+                    );
+                    fan.updateProfile(
+                            "fan_demo",
+                            "010-9000-0001",
+                            "https://picsum.photos/seed/infinite-fan-profile/480/480",
+                            "https://picsum.photos/seed/infinite-fan-cover/1440/720"
+                    );
+                    return memberRepository.save(fan);
+                });
+    }
+
+    private void ensureSuperAdminDemoMember() {
+        String email = "admin.demo@infinite.local";
+        memberRepository.findByEmail(email)
+                .map(existing -> {
+                    // 예전에 일반 계정으로 만든 로컬 admin demo도 재시드 시 SUPER_ADMIN으로 교정한다.
+                    if (existing.getRole() != MemberRole.SUPER_ADMIN) {
+                        existing.changeRole(MemberRole.SUPER_ADMIN);
+                    }
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    Member admin = Member.createNewMember(
+                            email,
+                            passwordEncoder.encode(DEMO_PASSWORD),
+                            "super_admin",
+                            "010-9000-0002"
+                    );
+                    admin.changeRole(MemberRole.SUPER_ADMIN);
+                    admin.updateProfile(
+                            "super_admin",
+                            "010-9000-0002",
+                            "https://picsum.photos/seed/infinite-super-admin-profile/480/480",
+                            "https://picsum.photos/seed/infinite-super-admin-cover/1440/720"
+                    );
+                    return memberRepository.save(admin);
+                });
+    }
+
+    private Member ensureArtistMemberUser(ArtistSeed seed, int index) {
+        String email = seed.slug() + ".host@infinite.local";
+        return memberRepository.findByEmail(email)
+                .map(existing -> {
+                    // 예전에 MEMBER 권한으로 생성된 로컬 더미 계정도 재시드 시 ARTIST로 교정한다.
+                    if (existing.getRole() != MemberRole.ARTIST) {
+                        existing.changeRole(MemberRole.ARTIST);
+                    }
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    Member member = Member.createNewMember(
+                            email,
+                            passwordEncoder.encode(DEMO_PASSWORD),
+                            seed.stageName().toLowerCase().replace(" ", "_"),
+                            String.format("010-9100-%04d", index + 1)
+                    );
+                    member.changeRole(MemberRole.ARTIST);
+                    member.updateProfile(
+                            seed.stageName().toLowerCase().replace(" ", "_"),
+                            String.format("010-9100-%04d", index + 1),
+                            artistMemberImage(seed.slug()),
+                            artistCoverImage(seed.slug())
+                    );
+                    return memberRepository.save(member);
+                });
+    }
+
+    private Artist ensureArtist(ArtistSeed seed, int index) {
+        return artistRepository.findBySlug(seed.slug())
+                .orElseGet(() -> artistRepository.save(Artist.create(
+                        seed.name(),
+                        seed.slug(),
+                        artistProfileImage(seed.slug()),
+                        artistCoverImage(seed.slug()),
+                        seed.intro() + " #" + (index + 1)
+                )));
+    }
+
+    private ArtistMember ensureArtistMember(Artist artist, Member member, ArtistSeed seed, int index) {
+        return artistMemberRepository.findByArtistIdAndMemberId(artist.getId(), member.getId())
+                .orElseGet(() -> artistMemberRepository.save(ArtistMember.create(
+                        artist,
+                        member,
+                        seed.stageName(),
+                        artistMemberImage(seed.slug()),
+                        index + 1
+                )));
+    }
+
+    private void seedYoutubeVideos(Artist artist, ArtistMember artistMember, int artistIndex) {
+        if (artistYoutubeVideoRepository.countByArtistId(artist.getId()) >= YOUTUBE_SEEDS.size()) {
+            return;
+        }
+
+        for (int videoIndex = 0; videoIndex < YOUTUBE_SEEDS.size(); videoIndex++) {
+            YoutubeSeed youtubeSeed = YOUTUBE_SEEDS.get(videoIndex);
+            if (artistYoutubeVideoRepository.existsByArtistIdAndYoutubeVideoId(artist.getId(), youtubeSeed.videoId())) {
+                continue;
+            }
+
+            LocalDateTime publishedAt = LocalDateTime.now()
+                    .minusDays((long) artistIndex * 5 + videoIndex + 2)
+                    .withHour(20)
+                    .withMinute(0)
+                    .withSecond(0)
+                    .withNano(0);
+
+            artistYoutubeVideoRepository.save(ArtistYoutubeVideo.create(
+                    artist.getId(),
+                    artistMember.getMember().getId(),
+                    artistMember.getStageName(),
+                    artistMember.getProfileImageUrl(),
+                    youtubeSeed.videoId(),
+                    "https://www.youtube.com/watch?v=" + youtubeSeed.videoId(),
+                    artist.getName() + " " + youtubeSeed.titleSuffix(),
+                    "https://i.ytimg.com/vi/" + youtubeSeed.videoId() + "/hqdefault.jpg",
+                    youtubeSeed.durationSeconds(),
+                    publishedAt
+            ));
+        }
+    }
+
+    private void seedReplayVod(Artist artist, ArtistMember artistMember, int artistIndex) {
+        if (realtimeLiveRepository.countByArtistIdAndLiveStatus(artist.getId(), LiveStatus.REPLAY_READY) >= REPLAY_SEEDS.size()) {
+            return;
+        }
+
+        for (int replayIndex = 0; replayIndex < REPLAY_SEEDS.size(); replayIndex++) {
+            ReplaySeed replaySeed = REPLAY_SEEDS.get(replayIndex);
+
+            RealtimeLive live = realtimeLiveRepository.save(RealtimeLive.builder()
+                    .artistId(artist.getId())
+                    .hostMemberId(artistMember.getMember().getId())
+                    .hostDisplayName(artistMember.getStageName())
+                    .hostProfileImageUrl(artistMember.getProfileImageUrl())
+                    .title(artist.getName() + " LIVE " + replaySeed.titleSuffix())
+                    .description(artist.getName() + " replay demo content")
+                    .thumbnailUrl(replayThumbnail(artist.getSlug(), replayIndex))
+                    .build());
+
+            LocalDateTime startedAt = LocalDateTime.now()
+                    .minusDays((long) artistIndex * 4 + replaySeed.publishedDaysAgo())
+                    .withHour(20)
+                    .withMinute(0)
+                    .withSecond(0)
+                    .withNano(0);
+            LocalDateTime endedAt = startedAt.plusMinutes(replaySeed.durationMinutes());
+            LocalDateTime replayPublishedAt = endedAt.plusHours(6);
+
+            live.start();
+            live.end();
+            live.markReplayReady(replaySeed.replayUrl());
+
+            setField(live, "startedAt", startedAt);
+            setField(live, "endedAt", endedAt);
+            setField(live, "replayPublishedAt", replayPublishedAt);
+
+            realtimeLiveRepository.save(live);
+        }
+    }
+
+    private void seedPopularKeyword(ArtistSeed seed, int artistIndex) {
+        int weight = 12 - artistIndex;
+        for (int i = 0; i < weight; i++) {
+            artistSearchKeywordService.recordSearchKeyword(
+                    "seed-user-" + seed.slug() + "-" + i,
+                    seed.name()
+            );
+        }
+    }
+
+    private void seedFanDemoMembership(Member fanDemoMember, Artist artist) {
+        LocalDateTime now = LocalDateTime.now();
+
+        boolean hasActiveMembership = fanMembershipRepository
+                .findByUserIdAndStatusAndExpiredAtAfterOrderByIdDesc(
+                        fanDemoMember.getId(),
+                        SubscriptionStatus.ACTIVE,
+                        now
+                )
+                .stream()
+                .anyMatch(membership -> artist.getId().equals(membership.getArtistId()));
+
+        if (hasActiveMembership) {
+            return;
+        }
+
+        // 로컬 fan.demo 계정은 Fan Letter 시연이 바로 가능해야 해서
+        // 모든 데모 아티스트에 대해 유효한 팬 멤버십을 기본 지급한다.
+        fanMembershipRepository.save(FanMembership.builder()
+                .userId(fanDemoMember.getId())
+                .artistId(artist.getId())
+                .startedAt(now.minusDays(3))
+                .expiredAt(now.plusDays(30))
+                .jellyAmount(9)
+                .build());
+    }
+
+    private static String artistProfileImage(String slug) {
+        return "https://picsum.photos/seed/artist-profile-" + slug + "/600/600";
+    }
+
+    private static String artistMemberImage(String slug) {
+        return "https://picsum.photos/seed/artist-member-" + slug + "/480/480";
+    }
+
+    private static String artistCoverImage(String slug) {
+        return "https://picsum.photos/seed/artist-cover-" + slug + "/1440/720";
+    }
+
+    private static String replayThumbnail(String slug, int index) {
+        return "https://picsum.photos/seed/replay-" + slug + "-" + index + "/1280/720";
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("더미데이터 필드 세팅 실패: " + fieldName, e);
+        }
+    }
+
+    private record ArtistSeed(
+            String slug,
+            String name,
+            String stageName,
+            String intro
+    ) {
+    }
+
+    private record YoutubeSeed(
+            String videoId,
+            String titleSuffix,
+            long durationSeconds
+    ) {
+    }
+
+    private record ReplaySeed(
+            String replayUrl,
+            String titleSuffix,
+            int durationMinutes,
+            int publishedDaysAgo
+    ) {
+    }
+}


### PR DESCRIPTION
작업 배경

프론트/시연 환경에서 아티스트 페이지, 메인 홈, 팬포스트, 팬레터, 댓글, 좋아요, 팔로우, 구독 동선을 한 번에 확인할 수 있도록
배포 환경 전용 쇼케이스 데이터 시더를 추가했습니다.

기존에는 배포 후 수동으로 데이터를 만들어야 해서

아티스트 상세/홈 대시보드
아티스트포스트 / 팬포스트 / 팬레터
댓글 / 좋아요 / 팔로우
팬십 / DM 구독

같은 핵심 흐름을 바로 시연하기 어려웠는데,
이번 PR에서는 이를 자동으로 채워주는 방향으로 정리했습니다.

주요 변경 사항
1. 배포용 쇼케이스 데이터 시더 추가
DeployShowcaseDataSeeder 추가
prod 프로필에서만 동작
app.seed.showcase-data=true 일 때만 실행
ApplicationRunner 기반으로 앱 기동 시점에 시드 수행
2. 시연용 계정/도메인 데이터 자동 생성

아래 데이터를 한 번에 구성하도록 추가했습니다.

팬 계정 10개
아티스트 6개
아티스트 멤버 다수
팬십 구독 / DM 구독
특정 아티스트 멤버 대상 follow
아티스트포스트
팬포스트
팬레터
댓글 / 대댓글
좋아요(reaction)
3. mock 프론트와 맞춘 아티스트 고정 데이터 구성
시드 아티스트에 고정 ID를 부여해
프론트 mock에서 기대하는 artistId와 최대한 맞춰 시연 가능한 형태로 정리
특히 artistId 2 등 mock 기준과 연결되는 데이터 설명/로그 추가
4. 시드 중복 실행 방지
LOCK_NAME = deploy-showcase-data-seed-v1
시드 실행 전 잠금 획득
이미 다른 인스턴스가 수행 중이면 현재 인스턴스는 건너뛰도록 처리
멀티 인스턴스/재배포 시 중복 데이터 폭증을 방지하는 방향
5. 재실행 시 idempotent 보강용 repository 메서드 추가

시더가 같은 게시글/팬레터를 중복 생성하지 않도록
조회 메서드를 repository에 추가했습니다.

ArtistPostRepository
existsByArtistIdAndWriterIdAndContent
findByArtistIdAndWriterIdAndContent
FanPostRepository
existsByArtistIdAndWriterIdAndContent
findByArtistIdAndWriterIdAndContent
FanLetterRepository
아티스트 전체 수신 / 특정 아티스트 멤버 수신을 구분하는 조회 메서드 추가
6. 환경변수 및 배포 워크플로우 반영
.env.example
APP_SEED_SHOWCASE_DATA=false
APP_SEED_SHOWCASE_PASSWORD=demo1234!
추가
GitHub Actions 배포 워크플로우
APP_SEED_SHOWCASE_DATA=true
APP_SEED_SHOWCASE_PASSWORD=demo1234!
주입 추가
기대 효과
배포 후 별도 수동 작업 없이 시연 가능한 기본 데이터 확보
프론트/백엔드 연동 확인 속도 개선
아티스트 홈/메인 홈/포스트/팬레터/댓글/좋아요/팔로우/구독 흐름을 한 번에 검증 가능
재배포 시에도 쇼케이스 데이터가 무한히 중복되지 않도록 최소한의 안전장치 확보
리뷰 포인트
prod + app.seed.showcase-data=true 조건에서만 시더가 동작하는지
시드 락이 실제 멀티 인스턴스 상황에서 중복 실행을 막는지
고정 artistId 정책이 기존 데이터와 충돌할 가능성은 없는지
repository 조회 메서드 기준으로 게시글/팬레터가 재실행 시 중복 생성되지 않는지
GitHub Actions에서 쇼케이스 시드 환경변수가 의도대로 주입되는지
테스트 체크리스트