### PR TITLE
Feat: 데스크톱 ARTIST 동기화 + Admin 생성 UI + Raffle 진입점

### DIFF
--- a/src/main/resources/static/components/api-client.jsx
+++ b/src/main/resources/static/components/api-client.jsx
@@ -54,14 +54,32 @@ const ConnectfinAPI = (() => {
     // 204 No Content
     if (response.status === 204) return null;
 
-    const json = await response.json();
+    // 응답을 텍스트로 먼저 읽고 → JSON 파싱 시도
+    // (JSON이 아니거나 깨진 경우 raw 텍스트를 에러 메시지에 포함시켜 디버깅 용이)
+    const rawText = await response.text();
+    let json;
+    try {
+      json = rawText ? JSON.parse(rawText) : null;
+    } catch (parseErr) {
+      console.error(`[ConnectfinAPI] JSON parse failed for ${path}:`, {
+        status: response.status,
+        contentType: response.headers.get('content-type'),
+        rawText: rawText.slice(0, 500),
+      });
+      const err = new Error(
+        `서버 응답을 JSON으로 파싱할 수 없습니다 (HTTP ${response.status}): ${rawText.slice(0, 200)}`
+      );
+      err.status = response.status;
+      err.rawText = rawText;
+      throw err;
+    }
 
     // 에러 응답 (4xx, 5xx)
     if (!response.ok && response.status !== 202) {
-      const errMsg = json.error?.message || json.message || `HTTP ${response.status}`;
+      const errMsg = json?.error?.message || json?.message || `HTTP ${response.status}`;
       const err = new Error(errMsg);
       err.status = response.status;
-      err.code = json.error?.code;
+      err.code = json?.error?.code;
       err.response = json;
       throw err;
     }
@@ -285,8 +303,83 @@ const ConnectfinAPI = (() => {
     sendDm,
     unsubscribe,
     disconnectStomp,
+    // Artist store sync
+    loadArtists,
   };
 })();
+
+// ──────────────────────────────────────────────────────────────
+// 백엔드 ArtistSearchResponse → 프론트 ARTISTS 항목 변환
+// (이름·이미지만 백엔드 값으로 덮고, 색·장르 같은 visual prop은 mock 값을 보존)
+// ──────────────────────────────────────────────────────────────
+function mergeArtistFromBackend(backend, existing) {
+  return {
+    // 기본 visual mock (없으면 deterministic 색상 생성)
+    color1: existing?.color1 || hslFromId(backend.id, 60),
+    color2: existing?.color2 || hslFromId(backend.id, 80),
+    genre: existing?.genre || 'ARTIST',
+    members: existing?.members || 1,
+    live: existing?.live || false,
+    viewers: existing?.viewers || 0,
+    followers: existing?.followers || '—',
+    stage: existing?.stage || backend.name,
+    // 백엔드 우선 필드
+    id: backend.id,
+    name: backend.name,
+    slug: backend.slug,
+    profileImageUrl: backend.profileImageUrl,
+    fromBackend: true,
+  };
+}
+
+function hslFromId(id, lightness = 60) {
+  const hue = (Number(id) * 47) % 360;
+  return `hsl(${hue}, 70%, ${lightness}%)`;
+}
+
+// 백엔드의 모든 아티스트를 가져와 window.ARTISTS에 머지한다.
+// - 이미 있는 mock 아티스트는 visual prop을 보존
+// - 백엔드에만 있는 신규 아티스트는 새로 push
+// - mock에만 있고 백엔드에 없는 아티스트는 dev 모드에서 살려둠 (백엔드 미구동 시 화면 보존)
+async function loadArtists() {
+  try {
+    // v3 검색을 keyword 없이 호출 — 전체 아티스트 페이징
+    let allBackend = [];
+    let page = 1;
+    while (page <= 5) { // 안전장치: 최대 50개
+      const res = await ConnectfinAPI.api(`/api/member/v3/artists/search?page=${page}`);
+      const list = res?.content || [];
+      if (list.length === 0) break;
+      allBackend = allBackend.concat(list);
+      if (!res.hasNext) break;
+      page += 1;
+    }
+    if (!Array.isArray(window.ARTISTS)) return;
+
+    // 머지: 백엔드 id 기준
+    const merged = [];
+    const seenIds = new Set();
+    for (const b of allBackend) {
+      const existing = window.ARTISTS.find(a => a.id === b.id);
+      merged.push(mergeArtistFromBackend(b, existing));
+      seenIds.add(b.id);
+    }
+    // 백엔드에 없는 mock은 뒤에 보존 (오프라인 데모 호환)
+    for (const a of window.ARTISTS) {
+      if (!seenIds.has(a.id)) merged.push(a);
+    }
+
+    // 배열 mutate (다른 모듈이 같은 참조를 들고 있을 수 있으므로)
+    window.ARTISTS.length = 0;
+    window.ARTISTS.push(...merged);
+
+    // 갱신 알림
+    window.dispatchEvent(new CustomEvent('connectfin:artists-changed', { detail: merged }));
+    console.log(`[Connectfin] ARTISTS 동기화: 백엔드 ${allBackend.length} + mock 보존 ${merged.length - allBackend.length} = ${merged.length}`);
+  } catch (err) {
+    console.warn('[Connectfin] loadArtists 실패 (mock으로 동작):', err?.message || err);
+  }
+}
 
 // 전역 노출 — 다른 JSX 컴포넌트에서 window.ConnectfinAPI.api(...) 로 접근
 Object.assign(window, { ConnectfinAPI });

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -245,11 +245,29 @@ function ArtistCoverBanner({ artist, t, theme }) {
 // Main desktop profile router
 function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive, onOpenDM, onOpenMembership }) {
   const [artistDetail, setArtistDetail] = React.useState(null);
+  const [activeLive, setActiveLive] = React.useState(null);
 
   React.useEffect(() => {
     window.ConnectfinAPI.api(`/api/member/v2/artists/${artist.id}`)
       .then(data => setArtistDetail(data))
       .catch(err => { console.warn('API fallback to mock:', err?.message || err); });
+  }, [artist.id]);
+
+  // 진행 중인 라이브 폴링 (10초마다) — 어드민이 시작/종료 시 반영
+  React.useEffect(() => {
+    let cancelled = false;
+    const fetchLive = () => {
+      window.ConnectfinAPI.api(`/api/v1/artists/${artist.id}/lives`)
+        .then(data => {
+          if (cancelled) return;
+          const live = (Array.isArray(data) ? data : []).find(l => (l.liveStatus || l.status) === 'LIVE');
+          setActiveLive(live || null);
+        })
+        .catch(() => {});
+    };
+    fetchLive();
+    const id = setInterval(fetchLive, 10000);
+    return () => { cancelled = true; clearInterval(id); };
   }, [artist.id]);
 
   const displayArtist = artistDetail ? {
@@ -274,6 +292,24 @@ function DesktopArtistProfile({ t, theme, artist, tab, onNavProfile, onOpenLive,
 
   return (
     <div>
+      {activeLive && (
+        <button onClick={() => onOpenLive(artist.id)} style={{
+          width: '100%', display: 'flex', alignItems: 'center', gap: 14,
+          padding: '12px 28px', border: 'none', cursor: 'pointer', textAlign: 'left',
+          background: t.liveGradient || 'linear-gradient(90deg, #FF2D55, #FF6B9F)',
+          color: '#fff', fontFamily: t.font,
+        }}>
+          <span style={{
+            width: 8, height: 8, borderRadius: '50%', background: '#fff',
+            animation: 'connectfin-pulse 1.2s ease-in-out infinite', flexShrink: 0,
+          }}/>
+          <span style={{ fontWeight: 800, fontSize: 11, letterSpacing: 1.2, fontFamily: t.fontMono }}>LIVE NOW</span>
+          <span style={{ fontWeight: 700, fontSize: 14, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {activeLive.title || `${artist.name} 라이브 진행 중`}
+          </span>
+          <span style={{ fontSize: 12, opacity: 0.95, fontWeight: 700 }}>지금 입장 →</span>
+        </button>
+      )}
       <ArtistCoverBanner artist={displayArtist} t={t} theme={theme}/>
       <div style={{ display: 'flex', maxWidth: 1320, margin: '0 auto', padding: '20px 24px 60px', gap: 24 }}>
         <div style={{ flex: 1, minWidth: 0 }}>{body}</div>
@@ -1650,6 +1686,53 @@ function TabAdmin({ t, theme, artist }) {
   const [youtubeUrl, setYoutubeUrl] = React.useState('');
   const [youtubeImporting, setYoutubeImporting] = React.useState(false);
 
+  // ── 신규 아티스트 생성 ──
+  const [newArtist, setNewArtist] = React.useState({
+    name: '', slug: '', stageName: '', intro: '',
+    profileImageUrl: '', coverImageUrl: '',
+  });
+  const [creatingArtist, setCreatingArtist] = React.useState(false);
+
+  const createArtist = async () => {
+    const a = newArtist;
+    if (!a.name.trim() || !a.slug.trim() || !a.stageName.trim() || creatingArtist) return;
+    setCreatingArtist(true);
+    try {
+      const res = await window.ConnectfinAPI.api('/api/member/v1/artists', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: a.name.trim(),
+          slug: a.slug.trim(),
+          stageName: a.stageName.trim(),
+          profileImageUrl: a.profileImageUrl.trim() || 'https://cdn.connectfin.com/default-profile.jpg',
+          coverImageUrl: a.coverImageUrl.trim() || 'https://cdn.connectfin.com/default-cover.jpg',
+          intro: a.intro.trim() || '소개 준비중',
+        }),
+      });
+      // 생성된 아티스트를 ARTISTS에 즉시 머지 + 갱신 알림
+      const id = res?.id || res?.artistId;
+      if (id && Array.isArray(window.ARTISTS)) {
+        const hue = (id * 47) % 360;
+        window.ARTISTS.push({
+          id, name: a.name.trim(), slug: a.slug.trim(),
+          stage: a.stageName.trim(), genre: 'NEW · ARTIST',
+          color1: `hsl(${hue}, 70%, 60%)`, color2: `hsl(${hue}, 70%, 80%)`,
+          members: 1, live: false, viewers: 0, followers: '0',
+          profileImageUrl: a.profileImageUrl.trim(), fromBackend: true,
+        });
+        window.dispatchEvent(new CustomEvent('connectfin:artists-changed'));
+      }
+      // 또한 백엔드에서 다시 풀로드 (정규화된 데이터 확보)
+      window.ConnectfinAPI.loadArtists();
+      setNewArtist({ name: '', slug: '', stageName: '', intro: '', profileImageUrl: '', coverImageUrl: '' });
+      alert(`아티스트 생성 완료! ID=${id}\n좌측 네비/검색에서 즉시 확인 가능`);
+    } catch (err) {
+      alert('생성 실패: ' + (err.message || ''));
+    } finally {
+      setCreatingArtist(false);
+    }
+  };
+
   const importYoutube = async () => {
     if (!youtubeUrl.trim() || youtubeImporting) return;
     setYoutubeImporting(true);
@@ -1769,6 +1852,43 @@ function TabAdmin({ t, theme, artist }) {
             onKeyDown={e => { if (e.key === 'Enter') importYoutube(); }}/>
           <button onClick={importYoutube} disabled={youtubeImporting || !youtubeUrl.trim()} style={adminBtnStyle(youtubeImporting || !youtubeUrl.trim())}>
             {youtubeImporting ? '...' : '등록'}
+          </button>
+        </div>
+      </div>
+
+      {/* ── 신규 아티스트 생성 ── */}
+      <div style={{ padding: 16, background: t.surface2, borderRadius: 12, border: `1px solid ${t.line}`, marginTop: 14 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 4 }}>
+          <div style={{ fontWeight: 800, fontSize: 14 }}>신규 아티스트 생성</div>
+          <div style={{ fontSize: 10, fontFamily: t.fontMono, color: t.textMuted }}>POST /api/member/v1/artists</div>
+        </div>
+        <div style={{ fontSize: 11, color: t.textDim, marginBottom: 12 }}>
+          생성 즉시 좌측 네비, 검색, 라이브 스피어에 반영됩니다 · SUPER_ADMIN 권한 필요
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 6 }}>
+          <input value={newArtist.name} onChange={e => setNewArtist(p => ({ ...p, name: e.target.value }))}
+            placeholder="이름 (예: NEXUS9)" style={inputStyle}/>
+          <input value={newArtist.slug} onChange={e => setNewArtist(p => ({ ...p, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))}
+            placeholder="슬러그 (예: nexus9, 영문/숫자/-)" style={{ ...inputStyle, fontFamily: t.fontMono }}/>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 6, marginBottom: 6 }}>
+          <input value={newArtist.stageName} onChange={e => setNewArtist(p => ({ ...p, stageName: e.target.value }))}
+            placeholder="활동명 (예: 넥서스나인)" style={inputStyle}/>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 6 }}>
+          <input value={newArtist.profileImageUrl} onChange={e => setNewArtist(p => ({ ...p, profileImageUrl: e.target.value }))}
+            placeholder="프로필 이미지 URL (선택)" style={{ ...inputStyle, fontFamily: t.fontMono, fontSize: 11 }}/>
+          <input value={newArtist.coverImageUrl} onChange={e => setNewArtist(p => ({ ...p, coverImageUrl: e.target.value }))}
+            placeholder="커버 이미지 URL (선택)" style={{ ...inputStyle, fontFamily: t.fontMono, fontSize: 11 }}/>
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input value={newArtist.intro} onChange={e => setNewArtist(p => ({ ...p, intro: e.target.value }))}
+            placeholder="소개 (선택)" style={inputStyle}/>
+          <button
+            onClick={createArtist}
+            disabled={creatingArtist || !newArtist.name.trim() || !newArtist.slug.trim() || !newArtist.stageName.trim()}
+            style={adminBtnStyle(creatingArtist || !newArtist.name.trim() || !newArtist.slug.trim() || !newArtist.stageName.trim())}>
+            {creatingArtist ? '...' : '생성'}
           </button>
         </div>
       </div>

--- a/src/main/resources/static/components/desktop-raffle.jsx
+++ b/src/main/resources/static/components/desktop-raffle.jsx
@@ -1,0 +1,41 @@
+// Connectfin — Desktop Raffle entry wrapper
+// 데스크톱에 래플 진입점이 없어 임시로 모바일 컴포넌트를 중앙 정렬 컬럼에 재사용한다.
+// 데스크톱 네이티브 그리드 디자인은 후속 이슈에서 별도 구현.
+
+function DesktopRaffleScreen({ t, theme, onArtistOpen }) {
+  const [view, setView] = React.useState('list'); // 'list' | 'detail'
+  const [raffleId, setRaffleId] = React.useState(null);
+
+  return (
+    <div style={{
+      position: 'relative',
+      width: '100%',
+      maxWidth: 520,
+      margin: '0 auto',
+      height: 'calc(100vh - 56px)',
+      overflow: 'hidden',
+      background: t.bg,
+      borderLeft: `1px solid ${t.line}`,
+      borderRight: `1px solid ${t.line}`,
+    }}>
+      {view === 'list' && (
+        <RaffleListScreen
+          t={t}
+          onBack={() => {}}
+          onOpenRaffle={(id) => { setRaffleId(id); setView('detail'); }}
+        />
+      )}
+      {view === 'detail' && raffleId != null && (
+        <RaffleDetailScreen
+          t={t}
+          theme={theme}
+          raffleId={raffleId}
+          onBack={() => setView('list')}
+          onEnter={() => setView('list')}
+        />
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, { DesktopRaffleScreen });

--- a/src/main/resources/static/components/desktop-shell.jsx
+++ b/src/main/resources/static/components/desktop-shell.jsx
@@ -8,7 +8,7 @@ function DesktopShell({ t, theme, children, activeArtist, onNavGlobal, globalVie
     }}>
       <DesktopLeftNav t={t} theme={theme} globalView={globalView} onNavGlobal={onNavGlobal} onArtistOpen={onArtistOpen}/>
       <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
-        <DesktopTopbar t={t} theme={theme} activeArtist={activeArtist} globalView={globalView} profileTab={profileTab} onNavProfile={onNavProfile} authUser={authUser} onShowLogin={onShowLogin} onLogout={onLogout}/>
+        <DesktopTopbar t={t} theme={theme} activeArtist={activeArtist} globalView={globalView} profileTab={profileTab} onNavProfile={onNavProfile} onNavGlobal={onNavGlobal} authUser={authUser} onShowLogin={onShowLogin} onLogout={onLogout}/>
         <div style={{ flex: 1, minWidth: 0 }}>
           {children}
         </div>
@@ -26,13 +26,18 @@ function DesktopLeftNav({ t, theme, globalView, onNavGlobal, onArtistOpen }) {
       padding: '18px 16px', position: 'sticky', top: 0, height: '100vh',
       overflowY: 'auto', background: dark ? 'rgba(10,11,16,0.5)' : 'rgba(255,255,255,0.5)',
     }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '4px 8px 18px' }}>
+      <button onClick={() => onNavGlobal('home')} aria-label="홈으로" style={{
+        display: 'flex', alignItems: 'center', gap: 10, padding: '4px 8px 18px',
+        background: 'transparent', border: 'none', cursor: 'pointer', textAlign: 'left',
+        width: '100%', color: t.text,
+      }}>
         <Infinity8 size={26} color={t.accent} color2={t.accent2} stroke={8}/>
         <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 18, letterSpacing: -0.4 }}>Connectfin</div>
-      </div>
+      </button>
 
       <NavItem t={t} icon="⌂" label="홈" active={globalView === 'home'} onClick={() => onNavGlobal('home')}/>
       <NavItem t={t} icon="✉" label="DM" active={globalView === 'dm'} onClick={() => onNavGlobal('dm')}/>
+      <NavItem t={t} icon="🎰" label="Raffle" active={globalView === 'raffle'} onClick={() => onNavGlobal('raffle')}/>
       <NavItem t={t} icon="⋯" label="더보기" />
 
       <NavSection t={t} label="내 커뮤니티"/>
@@ -103,7 +108,7 @@ function NavArtist({ artist, t, onClick }) {
 }
 
 // ───────── Top bar (profile tabs live here when on artist page) ─────────
-function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile, authUser, onShowLogin, onLogout }) {
+function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavProfile, onNavGlobal, authUser, onShowLogin, onLogout }) {
   const dark = theme === 'dark';
   const [jellyBalance, setJellyBalance] = React.useState(null);
 
@@ -162,8 +167,15 @@ function DesktopTopbar({ t, theme, activeArtist, globalView, profileTab, onNavPr
         </>
       ) : (
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 16 }}>
+          {globalView === 'live' && (
+            <button onClick={() => onNavGlobal && onNavGlobal('home')} aria-label="뒤로" style={{
+              width: 36, height: 36, borderRadius: 10, border: `1px solid ${t.line}`,
+              background: 'transparent', color: t.text, fontSize: 16, cursor: 'pointer',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>←</button>
+          )}
           <div style={{ fontFamily: t.fontDisplay, fontSize: 17, fontWeight: 800 }}>
-            {globalView === 'home' ? '홈' : globalView === 'jelly' ? 'Jelly Shop' : globalView === 'shop' ? 'Shop' : globalView === 'dm' ? 'DM' : globalView === 'live' ? 'LIVE' : ''}
+            {globalView === 'home' ? '홈' : globalView === 'jelly' ? 'Jelly Shop' : globalView === 'shop' ? 'Shop' : globalView === 'dm' ? 'DM' : globalView === 'live' ? 'LIVE' : globalView === 'raffle' ? 'Raffle' : ''}
           </div>
         </div>
       )}
@@ -449,7 +461,21 @@ function ArtistSearchSection({ t, theme, onArtistOpen }) {
           {results.length === 0 ? (
             <div style={{ padding: '8px 10px', fontSize: 12, color: t.textDim }}>검색 결과가 없습니다</div>
           ) : results.map(a => (
-            <button key={a.id} onClick={() => { onArtistOpen(a.id); setShowSearch(false); setQuery(''); setResults(null); }} style={{
+            <button key={a.id} onClick={() => {
+              // ARTISTS에 없는 백엔드 결과면 즉시 머지 → 프로필이 빈 화면이 되는 것을 방지
+              if (Array.isArray(window.ARTISTS) && !window.ARTISTS.some(x => x.id === a.id)) {
+                const hue = (a.id * 47) % 360;
+                window.ARTISTS.push({
+                  id: a.id, name: a.name, slug: a.slug,
+                  stage: a.name, genre: 'ARTIST',
+                  color1: `hsl(${hue}, 70%, 60%)`, color2: `hsl(${hue}, 70%, 80%)`,
+                  members: 1, live: false, viewers: 0, followers: '—',
+                  profileImageUrl: a.profileImageUrl, fromBackend: true,
+                });
+                window.dispatchEvent(new CustomEvent('connectfin:artists-changed'));
+              }
+              onArtistOpen(a.id); setShowSearch(false); setQuery(''); setResults(null);
+            }} style={{
               display: 'flex', alignItems: 'center', gap: 10, width: '100%', textAlign: 'left',
               padding: '8px 10px', borderRadius: 8,
               background: 'transparent', border: 'none', cursor: 'pointer', color: t.text,

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -63,21 +63,30 @@
 <script type="text/babel" src="components/desktop-profile.jsx"></script>
 <script type="text/babel" src="components/desktop-global.jsx"></script>
 <script type="text/babel" src="components/desktop-dm.jsx"></script>
+<script type="text/babel" src="components/desktop-raffle.jsx"></script>
 
 <script type="text/babel" data-presets="react">
 const TWEAKS = /*EDITMODE-BEGIN*/{
   "theme": "dark",
   "liveOn": true,
   "simSpeed": 0.5,
-  "viewMode": "mobile",
+  "viewMode": "desktop",
   "accentHue": 150,
-  "desktopView": false
+  "desktopView": true
 }/*EDITMODE-END*/;
 
 function App() {
   const [tweaks, setTweaks] = React.useState(() => {
-    try { return { ...TWEAKS, ...(JSON.parse(localStorage.getItem('connectfin_tweaks') || '{}')) }; }
-    catch { return TWEAKS; }
+    try {
+      const stored = JSON.parse(localStorage.getItem('connectfin_tweaks') || '{}');
+      // v2 마이그레이션: 데스크톱이 기본 — 한 번만 stored.viewMode 비움
+      if (!localStorage.getItem('connectfin_tweaks_v2')) {
+        delete stored.viewMode;
+        delete stored.desktopView;
+        localStorage.setItem('connectfin_tweaks_v2', '1');
+      }
+      return { ...TWEAKS, ...stored };
+    } catch { return TWEAKS; }
   });
   const [showTweaks, setShowTweaks] = React.useState(false);
 
@@ -118,6 +127,18 @@ function App() {
         .then(data => setAuthUser(prev => ({ ...prev, id: data.id, nickname: data.nickname })))
         .catch(err => { console.warn('Auto /me failed:', err?.message || err); });
     }
+  }, []);
+
+  // ── ARTISTS 동기화 ──
+  // 부팅 시 백엔드의 모든 아티스트를 가져와 window.ARTISTS와 머지.
+  // 이후 다른 컴포넌트(어드민 생성/검색 등)가 'connectfin:artists-changed' 이벤트를 발생시키면
+  // 같은 콜백이 다시 트리거되어 화면이 갱신된다.
+  const [artistsVersion, setArtistsVersion] = React.useState(0);
+  React.useEffect(() => {
+    window.ConnectfinAPI.loadArtists().then(() => setArtistsVersion(v => v + 1));
+    const handler = () => setArtistsVersion(v => v + 1);
+    window.addEventListener('connectfin:artists-changed', handler);
+    return () => window.removeEventListener('connectfin:artists-changed', handler);
   }, []);
 
   React.useEffect(() => {
@@ -186,8 +207,9 @@ function App() {
     else if (globalView === 'artist') body = <DesktopArtistProfile t={t} theme={tweaks.theme} artist={artist} tab={profileTab} onNavProfile={setProfileTab} onOpenLive={goLive} onOpenDM={openDM} onOpenMembership={openMembership}/>;
     else if (globalView === 'jelly') body = <DesktopJellyShop t={t} theme={tweaks.theme}/>;
     else if (globalView === 'shop') body = <DesktopShop t={t} theme={tweaks.theme}/>;
-    else if (globalView === 'live') body = <DesktopLiveViewer t={t} theme={tweaks.theme} artistId={artistId} speed={tweaks.simSpeed} liveOn={tweaks.liveOn} onExit={() => setGlobalView('artist')}/>;
+    else if (globalView === 'live') body = <DesktopLiveViewer t={t} theme={tweaks.theme} artistId={artistId} speed={tweaks.simSpeed} liveOn={tweaks.liveOn} onExit={() => setGlobalView('home')} onSwitchLive={goLive}/>;
     else if (globalView === 'dm') body = <DesktopDMScreen t={t} theme={tweaks.theme} onExit={() => setGlobalView('home')}/>;
+    else if (globalView === 'raffle') body = <DesktopRaffleScreen t={t} theme={tweaks.theme} onArtistOpen={openArtist}/>;
 
     return (
       <>
@@ -416,14 +438,29 @@ function HiddenTweaksTrigger({ show, onShow, t }) {
 }
 
 // ───────── Desktop Live Viewer (uses same layout as artist) ─────────
-function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
+function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit, onSwitchLive }) {
   const a = ARTISTS.find(x => x.id === artistId) || ARTISTS[0];
   const [messages, setMessages] = React.useState(() => LIVE_SEEDS.map((s, i) => ({ ...s, id: i, t: s.t || 'fan' })));
   const [viewers, setViewers] = React.useState(a.viewers || 58_000);
   const [input, setInput] = React.useState('');
   const [hearts, setHearts] = React.useState([]);
+  const [otherLives, setOtherLives] = React.useState([]);
   const nextId = React.useRef(100);
   const listRef = React.useRef(null);
+
+  // 다른 라이브 목록 로드 — 전 아티스트 대상
+  React.useEffect(() => {
+    Promise.all(
+      ARTISTS.map(ar =>
+        window.ConnectfinAPI.api(`/api/v1/artists/${ar.id}/lives`)
+          .then(data => (data || [])
+            .filter(l => l.liveStatus === 'LIVE' && ar.id !== artistId)
+            .map(l => ({ ...l, artistId: ar.id, artistName: ar.name, color1: ar.color1, color2: ar.color2 }))
+          )
+          .catch(() => [])
+      )
+    ).then(results => setOtherLives(results.flat()));
+  }, [artistId]);
 
   React.useEffect(() => {
     if (!liveOn) return;
@@ -449,7 +486,7 @@ function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
   };
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: '1fr 380px', height: 'calc(100vh - 56px)' }}>
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 360px 280px', height: 'calc(100vh - 56px)' }}>
       <div style={{ position: 'relative', overflow: 'hidden', background: '#000' }}>
         <div style={{
           position: 'absolute', inset: 0,
@@ -494,7 +531,7 @@ function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
             <div style={{ position: 'absolute', inset: 0, width: '100%', background: t.liveGradient, borderRadius: 2 }}/>
           </div>
           <span style={{ fontFamily: t.fontMono, fontSize: 11 }}>LIVE</span>
-          <button onClick={onExit} style={{ padding: '4px 10px', borderRadius: 6, border: `1px solid rgba(255,255,255,0.3)`, background: 'transparent', color: '#fff', fontSize: 11, cursor: 'pointer', fontFamily: t.fontMono }}>← 프로필</button>
+          <button onClick={onExit} style={{ padding: '4px 10px', borderRadius: 6, border: `1px solid rgba(255,255,255,0.3)`, background: 'rgba(0,0,0,0.4)', color: '#fff', fontSize: 11, cursor: 'pointer', fontFamily: t.fontMono, fontWeight: 700 }}>← 나가기</button>
         </div>
       </div>
 
@@ -544,6 +581,74 @@ function DesktopLiveViewer({ t, theme, artistId, speed, liveOn, onExit }) {
           <input value={input} onChange={e => setInput(e.target.value)} onKeyDown={e => e.key === 'Enter' && send()} placeholder="채팅 · Enter로 전송"
             style={{ flex: 1, padding: '10px 14px', borderRadius: 20, border: `1px solid ${t.line}`, background: theme === 'dark' ? '#12141C' : '#fff', color: t.text, fontSize: 13 }}/>
           <button onClick={send} style={{ padding: '0 16px', borderRadius: 20, border: 'none', background: t.gradient, color: '#fff', fontWeight: 800, fontSize: 13, cursor: 'pointer' }}>SEND</button>
+        </div>
+      </div>
+
+      {/* ───── 우측 라이브 목록 패널 ───── */}
+      <div style={{
+        display: 'flex', flexDirection: 'column',
+        borderLeft: `1px solid ${t.line}`,
+        background: theme === 'dark' ? '#080A12' : t.surface2 || t.surface,
+        color: t.text, overflowY: 'auto',
+      }}>
+        <div style={{ padding: '14px 16px 10px', borderBottom: `1px solid ${t.line}`, position: 'sticky', top: 0, background: 'inherit', zIndex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: t.hot, animation: 'connectfin-pulse 1.2s ease-in-out infinite' }}/>
+            <div style={{ fontFamily: t.fontDisplay, fontWeight: 800, fontSize: 14 }}>다른 LIVE</div>
+            <div style={{ marginLeft: 'auto', fontFamily: t.fontMono, fontSize: 10, color: t.textDim }}>{otherLives.length}개</div>
+          </div>
+          <div style={{ fontSize: 10, color: t.textMuted, fontFamily: t.fontMono, marginTop: 4, letterSpacing: 0.3 }}>
+            GET /artists/&#123;id&#125;/lives
+          </div>
+        </div>
+
+        <div style={{ padding: 10, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {otherLives.length === 0 && (
+            <div style={{
+              padding: '24px 12px', textAlign: 'center', fontSize: 12,
+              color: t.textDim, fontFamily: t.fontMono, lineHeight: 1.6,
+            }}>
+              현재 진행 중인<br/>다른 라이브가 없어요
+            </div>
+          )}
+          {otherLives.map(live => (
+            <button key={live.id} onClick={() => onSwitchLive && onSwitchLive(live.artistId)} style={{
+              textAlign: 'left', padding: 0, border: `1px solid ${t.line}`,
+              borderRadius: 10, overflow: 'hidden', cursor: 'pointer',
+              background: 'transparent', color: t.text,
+            }}
+              onMouseEnter={e => e.currentTarget.style.borderColor = t.accent}
+              onMouseLeave={e => e.currentTarget.style.borderColor = t.line}
+            >
+              <div style={{
+                position: 'relative', height: 90,
+                background: `repeating-linear-gradient(30deg, ${live.color1} 0 18px, ${live.color2} 18px 36px)`,
+              }}>
+                <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, transparent 50%, rgba(0,0,0,0.7))' }}/>
+                <div style={{
+                  position: 'absolute', top: 6, left: 6,
+                  padding: '2px 6px', borderRadius: 4, background: t.liveGradient,
+                  fontSize: 9, fontWeight: 800, color: '#fff', letterSpacing: 0.4,
+                  display: 'flex', alignItems: 'center', gap: 4,
+                }}>
+                  <span style={{ width: 4, height: 4, borderRadius: '50%', background: '#fff' }}/>
+                  LIVE
+                </div>
+                <div style={{
+                  position: 'absolute', bottom: 6, left: 8, right: 8,
+                  fontSize: 11, fontWeight: 700, color: '#fff',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  textShadow: '0 1px 4px rgba(0,0,0,0.6)',
+                }}>{live.title || '라이브 방송'}</div>
+              </div>
+              <div style={{ padding: '8px 10px' }}>
+                <div style={{ fontSize: 12, fontWeight: 700 }}>{live.artistName}</div>
+                <div style={{ fontSize: 10, color: t.textDim, fontFamily: t.fontMono, marginTop: 2 }}>
+                  @{live.hostDisplayName || live.artistName?.toLowerCase()}
+                </div>
+              </div>
+            </button>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 부팅 시 백엔드 아티스트 풀로드 → `window.ARTISTS` 머지 + `connectfin:artists-changed` 이벤트로 검색/네비/프로필 자동 갱신
- Admin 탭에 `POST /api/member/v1/artists` 폼 추가, 생성 즉시 좌측 네비/검색 반영
- LIVE UX 개선(다른 LIVE 패널, ← 뒤로, 프로필 상단 LIVE NOW 배너) + 데스크톱 Raffle 진입점 추가(임시 래퍼)
- `ConnectfinAPI.api` JSON 파싱 실패 시 raw 본문 노출, 외부 트래커 스크립트 `lc.getunicorn.org` 주입분 제거

## 변경 파일
| 파일 | 변경 |
|---|---|
| `static/index.html` | 데스크톱 기본화(v2 마이그레이션), `loadArtists()` 부팅 호출, LIVE 뷰어 3컬럼 + 다른 LIVE 패널, raffle 라우팅, 트래커 스크립트 제거 |
| `static/components/api-client.jsx` | `loadArtists()`/`mergeArtistFromBackend()` 추가, JSON 파싱 에러 핸들링 강화 |
| `static/components/desktop-shell.jsx` | 로고 → 홈 버튼, 🎰 Raffle 네비 항목, 검색 결과 → ARTISTS 즉시 머지 |
| `static/components/desktop-profile.jsx` | LIVE NOW 배너(10초 폴링), Admin 신규 아티스트 생성 폼 |
| `static/components/desktop-raffle.jsx` (신규) | 모바일 `RaffleListScreen`/`RaffleDetailScreen`을 데스크톱 폭 컬럼으로 래핑 |

## 결정 사항 / 알아둘 점
- **데스크톱 Raffle 디자인**: 이번 PR은 진입점 확보가 목적이라 모바일 컴포넌트 재사용으로 처리. 데스크톱 네이티브 그리드 레이아웃은 후속 이슈로 분리.
- **외부 스크립트 제거**: 원본 대체 코드에 `//lc.getunicorn.org/...` 트래커가 포함되어 있어 머지 전 제거. 앱 어디서도 참조하지 않으므로 동작 영향 없음.
- **Admin 폼은 SUPER_ADMIN 권한 필요**: 백엔드 가드는 그대로, UI는 권한 없는 사용자가 호출하면 403으로 fail.

## Test plan
- [ ] 데스크톱 모드 부팅 시 좌측 네비에 백엔드의 모든 아티스트가 보이는지 확인 (콘솔에 `[Connectfin] ARTISTS 동기화` 로그)
- [ ] Admin 탭에서 새 아티스트 생성 → 새로고침 없이 좌측 네비/검색에 즉시 등장하는지
- [ ] 좌측 네비 🎰 Raffle → 목록 → 카드 클릭 → 상세 → ← 뒤로 흐름 동작
- [ ] LIVE 진행 중인 아티스트 프로필 진입 시 상단 "LIVE NOW" 핫 배너 표시, 클릭 시 LIVE 뷰어 진입
- [ ] LIVE 뷰어 우측 "다른 LIVE" 패널에서 카드 클릭 시 해당 라이브로 전환
- [ ] 백엔드가 비정상 JSON 응답을 줄 때 콘솔에 `JSON parse failed` 로그 + raw 본문 노출 확인
- [ ] 검색에서 mock에 없는 신규 백엔드 아티스트 클릭 시 빈 프로필 없이 정상 진입

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)