### PR TITLE
fix/펜레터 에러, 리뷰봇 보안수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,10 @@ RDS_PASSWORD=
 REDIS_HOST=
 REDIS_PORT=6379
 S3_BUCKET_NAME=
+# showcase 시드는 격리된 시연 환경에서만 켠다.
+# 비밀번호는 소스에 넣지 말고 배포 시 secret 으로 주입한다.
 APP_SEED_SHOWCASE_DATA=false
-APP_SEED_SHOWCASE_PASSWORD=demo1234!
+APP_SEED_SHOWCASE_PASSWORD=
 
 
 # Grafana Local Settings (DO NOT USE admin/admin in production)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,6 +138,8 @@ jobs:
           S3_BUCKET_NAME: ${{ vars.S3_BUCKET_NAME }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
           YOUTUBE_DATA_API_KEY: ${{ secrets.YOUTUBE_DATA_API_KEY }}
+          APP_SEED_SHOWCASE_DATA: ${{ vars.APP_SEED_SHOWCASE_DATA }}
+          APP_SEED_SHOWCASE_PASSWORD: ${{ secrets.APP_SEED_SHOWCASE_PASSWORD }}
         run: |
           # 2. 여기서는 실제 .env 값을 만들어야 하므로 quoted heredoc(<<'EOF')를 쓰면 안 된다.
           #    quoted heredoc은 ${JWT_SECRET_KEY} 같은 변수를 literal 문자열로 남겨
@@ -154,8 +156,8 @@ jobs:
           S3_BUCKET_NAME=${S3_BUCKET_NAME}
           JWT_SECRET_KEY=${JWT_SECRET_KEY}
           YOUTUBE_DATA_API_KEY=${YOUTUBE_DATA_API_KEY}
-          APP_SEED_SHOWCASE_DATA=true
-          APP_SEED_SHOWCASE_PASSWORD=demo1234!
+          APP_SEED_SHOWCASE_DATA=${APP_SEED_SHOWCASE_DATA}
+          APP_SEED_SHOWCASE_PASSWORD=${APP_SEED_SHOWCASE_PASSWORD}
           EOF
           
           # 3. 업로드 (변수명 오타 주의!)

--- a/src/main/java/com/example/infinite/global/bootstrap/DeployShowcaseDataSeeder.java
+++ b/src/main/java/com/example/infinite/global/bootstrap/DeployShowcaseDataSeeder.java
@@ -60,8 +60,6 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
 
     private static final String LOCK_NAME = "deploy-showcase-data-seed-v1";
 
-    private static final String DEFAULT_PASSWORD = "demo1234!";
-
     private static final List<FanSeed> FAN_SEEDS = List.of(
             new FanSeed("fan.01@connectfin.demo", "starlit_one", "010-9700-0001"),
             new FanSeed("fan.02@connectfin.demo", "midnight_loop", "010-9700-0002"),
@@ -188,12 +186,17 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Value("${app.seed.showcase-password:" + DEFAULT_PASSWORD + "}")
+    @Value("${app.seed.showcase-password:}")
     private String showcasePassword;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
+        if (showcasePassword == null || showcasePassword.isBlank()) {
+            log.warn("app.seed.showcase-data=true 이지만 app.seed.showcase-password 가 비어 있어 시연 데이터 시드를 건너뜁니다.");
+            return;
+        }
+
         if (!acquireLock()) {
             log.info("배포 시연 데이터 시드 잠금을 획득하지 못해 이번 인스턴스는 건너뜁니다.");
             return;
@@ -201,10 +204,21 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
 
         try {
             List<Member> fanMembers = ensureFanMembers();
+            int seededArtistCount = 0;
+            int seededArtistMemberCount = 0;
+            int skippedArtistCount = 0;
 
             for (ArtistSeed artistSeed : ARTIST_SEEDS) {
-                Artist artist = ensureArtist(artistSeed);
+                Optional<Artist> artistOptional = ensureArtist(artistSeed);
+                if (artistOptional.isEmpty()) {
+                    skippedArtistCount++;
+                    continue;
+                }
+
+                Artist artist = artistOptional.get();
                 List<ArtistMember> artistMembers = ensureArtistMembers(artist, artistSeed.members());
+                seededArtistCount++;
+                seededArtistMemberCount += artistMembers.size();
 
                 ensureFanSubscriptions(artist, fanMembers);
                 ensureDmSubscriptions(artist, fanMembers);
@@ -223,9 +237,10 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
             }
 
             log.info(
-                    "배포 시연 데이터 시드 완료: artists={}, artistMembers={}, fans={}",
-                    ARTIST_SEEDS.size(),
-                    ARTIST_SEEDS.stream().mapToInt(seed -> seed.members().size()).sum(),
+                    "배포 시연 데이터 시드 완료: artistsSeeded={}, artistsSkipped={}, artistMembersSeeded={}, fans={}",
+                    seededArtistCount,
+                    skippedArtistCount,
+                    seededArtistMemberCount,
                     FAN_SEEDS.size()
             );
         } finally {
@@ -249,29 +264,31 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
         return fanMembers;
     }
 
-    private Artist ensureArtist(ArtistSeed seed) {
+    private Optional<Artist> ensureArtist(ArtistSeed seed) {
         Artist artistById = artistRepository.findById(seed.id()).orElse(null);
         Artist artistBySlug = artistRepository.findBySlug(seed.slug()).orElse(null);
 
-        if (artistById != null) {
-            if (artistBySlug != null && !artistBySlug.getId().equals(artistById.getId())) {
-                log.warn(
-                        "artistId={} 는 이미 다른 slug={} 로 존재하고 slug={} 는 다른 id={} 에 연결되어 있습니다. id 기준으로만 갱신합니다.",
-                        seed.id(),
-                        artistById.getSlug(),
-                        seed.slug(),
-                        artistBySlug.getId()
-                );
-                artistById.updateProfile(
-                        seed.name(),
-                        artistById.getSlug(),
-                        profileImageUrl("artist", seed.slug()),
-                        coverImageUrl("artist", seed.slug()),
-                        seed.intro()
-                );
-                return artistById;
-            }
+        if (artistById != null && !seed.slug().equals(artistById.getSlug())) {
+            log.warn(
+                    "artistId={} 는 이미 slug={} 에 연결되어 있어 showcase slug={} 로 덮어쓰지 않습니다. 이 아티스트 시드는 건너뜁니다.",
+                    seed.id(),
+                    artistById.getSlug(),
+                    seed.slug()
+            );
+            return Optional.empty();
+        }
 
+        if (artistBySlug != null && !artistBySlug.getId().equals(seed.id())) {
+            log.warn(
+                    "showcase slug={} 는 이미 artistId={} 에 연결되어 있어 고정 artistId={} 로 시드하지 않습니다. 이 아티스트 시드는 건너뜁니다.",
+                    seed.slug(),
+                    artistBySlug.getId(),
+                    seed.id()
+            );
+            return Optional.empty();
+        }
+
+        if (artistById != null) {
             artistById.updateProfile(
                     seed.name(),
                     seed.slug(),
@@ -279,16 +296,10 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
                     coverImageUrl("artist", seed.slug()),
                     seed.intro()
             );
-            return artistById;
+            return Optional.of(artistById);
         }
 
         if (artistBySlug != null) {
-            log.warn(
-                    "artist slug={} 가 이미 id={} 로 존재합니다. 프론트 mock artistId={} 와 불일치할 수 있습니다.",
-                    seed.slug(),
-                    artistBySlug.getId(),
-                    seed.id()
-            );
             artistBySlug.updateProfile(
                     seed.name(),
                     seed.slug(),
@@ -296,12 +307,12 @@ public class DeployShowcaseDataSeeder implements ApplicationRunner {
                     coverImageUrl("artist", seed.slug()),
                     seed.intro()
             );
-            return artistBySlug;
+            return Optional.of(artistBySlug);
         }
 
         insertArtistWithFixedId(seed);
-        return artistRepository.findById(seed.id())
-                .orElseThrow(() -> new IllegalStateException("시드 아티스트 생성 후 조회에 실패했습니다. id=" + seed.id()));
+        return Optional.of(artistRepository.findById(seed.id())
+                .orElseThrow(() -> new IllegalStateException("시드 아티스트 생성 후 조회에 실패했습니다. id=" + seed.id())));
     }
 
     private List<ArtistMember> ensureArtistMembers(Artist artist, List<ArtistMemberSeed> seeds) {

--- a/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/infinite/global/error/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.example.infinite.domain.dm.error.DmException;
 import com.example.infinite.domain.member.artist.error.ArtistException;
 import com.example.infinite.domain.member.member.error.MemberErrorCode;
 import com.example.infinite.domain.member.member.error.MemberException;
+import com.example.infinite.domain.artistcontent.post.error.ArtistContentErrorCode;
 import com.example.infinite.domain.artistcontent.post.error.ArtistContentException;
 import com.example.infinite.domain.raffle.error.RaffleException;
 import com.example.infinite.domain.realtimelive.error.LiveException;
@@ -22,6 +23,8 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 import java.time.LocalDateTime;
 
@@ -80,6 +83,43 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.fail(buildErrorResponse(ErrorCode.INVALID_INPUT_VALUE, errorMessage, request.getRequestURI())));
+    }
+
+    /**
+     * multipart 업로드가 스프링 레벨 최대 크기를 넘긴 경우를 명시적으로 처리한다.
+     * 그렇지 않으면 팬레터/미디어 업로드에서 500 일반 에러로 보여 원인 파악이 어려워진다.
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(
+            MaxUploadSizeExceededException e,
+            HttpServletRequest request
+    ) {
+        log.warn("MaxUploadSizeExceededException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ArtistContentErrorCode.MEDIA_SIZE_EXCEEDED.getStatus())
+                .body(ApiResponse.fail(buildErrorResponse(
+                        ArtistContentErrorCode.MEDIA_SIZE_EXCEEDED,
+                        ArtistContentErrorCode.MEDIA_SIZE_EXCEEDED.getMessage(),
+                        request.getRequestURI()
+                )));
+    }
+
+    /**
+     * boundary 누락 등 multipart 파싱 실패를 400으로 돌려 프론트가 일반 500으로 오해하지 않게 한다.
+     */
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMultipartException(
+            MultipartException e,
+            HttpServletRequest request
+    ) {
+        log.warn("MultipartException : {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(buildErrorResponse(
+                        ErrorCode.INVALID_INPUT_VALUE,
+                        "파일 업로드 요청 형식이 올바르지 않습니다.",
+                        request.getRequestURI()
+                )));
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: demo
   config:
     import: optional:classpath:application-local.yml
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 120MB
 
   data:
     redis:

--- a/src/main/resources/static/components/api-client.jsx
+++ b/src/main/resources/static/components/api-client.jsx
@@ -94,7 +94,10 @@ const ConnectfinAPI = (() => {
 
     if (response.status === 204) return null;
 
-    const json = await response.json();
+    const contentType = response.headers.get('content-type') || '';
+    const json = contentType.includes('application/json')
+      ? await response.json()
+      : { message: (await response.text()).trim() };
 
     if (!response.ok) {
       const errMsg = json.error?.message || json.message || `HTTP ${response.status}`;

--- a/src/main/resources/static/components/desktop-profile.jsx
+++ b/src/main/resources/static/components/desktop-profile.jsx
@@ -614,24 +614,56 @@ function TabFanLetter({ t, theme, artist }) {
   const [showLetterForm, setShowLetterForm] = React.useState(false);
   const [letterSubmitting, setLetterSubmitting] = React.useState(false);
   const [letterRecipientType, setLetterRecipientType] = React.useState('ARTIST');
+  const [letterRecipientArtistMemberId, setLetterRecipientArtistMemberId] = React.useState(null);
   const [letterImage, setLetterImage] = React.useState(null);
+
+  React.useEffect(() => {
+    const artistMembers = (artist.artistMembers || []).slice().sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
+    if (letterRecipientType !== 'ARTIST_MEMBER') {
+      if (letterRecipientArtistMemberId != null) {
+        setLetterRecipientArtistMemberId(null);
+      }
+      return;
+    }
+    if (artistMembers.length === 0) {
+      if (letterRecipientArtistMemberId != null) {
+        setLetterRecipientArtistMemberId(null);
+      }
+      return;
+    }
+    const hasCurrent = artistMembers.some(member => String(member.artistMemberId) === String(letterRecipientArtistMemberId));
+    if (!hasCurrent) {
+      setLetterRecipientArtistMemberId(artistMembers[0].artistMemberId);
+    }
+  }, [artist.artistMembers, letterRecipientArtistMemberId, letterRecipientType]);
 
   const submitFanLetter = async () => {
     if (letterSubmitting) return;
     if (!window.ConnectfinAPI.getToken()) { alert('로그인이 필요합니다.'); return; }
+    if (!letterImage) { alert('팬레터는 이미지를 한 장 선택해야 합니다.'); return; }
+    if (letterRecipientType === 'ARTIST_MEMBER' && !letterRecipientArtistMemberId) {
+      alert('받는 아티스트 멤버를 선택해 주세요.');
+      return;
+    }
     setLetterSubmitting(true);
     try {
       const formData = new FormData();
       formData.append('recipientType', letterRecipientType);
-      if (letterImage) formData.append('image', letterImage);
+      if (letterRecipientType === 'ARTIST_MEMBER') {
+        formData.append('recipientArtistMemberId', String(letterRecipientArtistMemberId));
+      }
+      formData.append('image', letterImage);
       await window.ConnectfinAPI.apiMultipart(`/api/post/v1/artists/${artist.id}/fan-letters`, formData);
       setLetterImage(null);
+      setLetterRecipientType('ARTIST');
+      setLetterRecipientArtistMemberId(null);
       setShowLetterForm(false);
       window.ConnectfinAPI.api(`/api/post/v1/artists/${artist.id}/fan-letters`)
         .then(data => { setLetters(data.content.map(mapFanLetterListItem)); setHasNext(data.hasNext); setNextCursor(data.nextCursor); })
         .catch(err => { console.warn('Refresh failed:', err?.message || err); });
     } catch (err) {
-      alert('작성 실패: ' + (err.message || '멤버십 구독이 필요합니다'));
+      const debugSuffix = [err?.code, err?.status].filter(Boolean).join(' / ');
+      alert('작성 실패: ' + (err.message || '멤버십 구독이 필요합니다') + (debugSuffix ? ` (${debugSuffix})` : ''));
     } finally {
       setLetterSubmitting(false);
     }
@@ -728,14 +760,46 @@ function TabFanLetter({ t, theme, artist }) {
               }}>{rt === 'ARTIST' ? '그룹 전체' : '멤버 지정'}</button>
             ))}
           </div>
+          {letterRecipientType === 'ARTIST_MEMBER' && (
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ fontSize: 12, color: t.textDim, marginBottom: 8 }}>받는 멤버</div>
+              <select
+                value={letterRecipientArtistMemberId || ''}
+                onChange={e => setLetterRecipientArtistMemberId(e.target.value ? Number(e.target.value) : null)}
+                disabled={!artist.artistMembers || artist.artistMembers.length === 0}
+                style={{
+                  width: '100%',
+                  padding: '10px 12px',
+                  borderRadius: 8,
+                  border: `1px solid ${t.line}`,
+                  background: 'transparent',
+                  color: t.text,
+                  fontSize: 12,
+                  fontFamily: t.font,
+                }}
+              >
+                {(!artist.artistMembers || artist.artistMembers.length === 0) && (
+                  <option value="">선택 가능한 멤버가 없습니다</option>
+                )}
+                {(artist.artistMembers || [])
+                  .slice()
+                  .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+                  .map(member => (
+                    <option key={member.artistMemberId} value={member.artistMemberId}>
+                      {member.stageName}
+                    </option>
+                  ))}
+              </select>
+            </div>
+          )}
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', borderRadius: 8, border: `1px dashed ${t.line}`, cursor: 'pointer', fontSize: 12, color: t.textDim, marginBottom: 12 }}>
-            📷 {letterImage ? letterImage.name : '이미지 선택 (선택사항)'}
+            📷 {letterImage ? letterImage.name : '이미지 선택 (필수)'}
             <input type="file" accept="image/*" onChange={e => setLetterImage(e.target.files[0] || null)} style={{ display: 'none' }}/>
           </label>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <span style={{ fontSize: 10, color: t.textDim }}>팬 멤버십 구독자만 작성 가능</span>
+            <span style={{ fontSize: 10, color: t.textDim }}>팬 멤버십 구독자만 작성 가능 · 팬레터는 이미지 1장 필수</span>
             <div style={{ display: 'flex', gap: 6 }}>
-              <button onClick={() => { setShowLetterForm(false); setLetterImage(null); }} style={{ padding: '6px 14px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.textDim, fontSize: 12, cursor: 'pointer' }}>취소</button>
+              <button onClick={() => { setShowLetterForm(false); setLetterImage(null); setLetterRecipientType('ARTIST'); setLetterRecipientArtistMemberId(null); }} style={{ padding: '6px 14px', borderRadius: 8, border: `1px solid ${t.line}`, background: 'transparent', color: t.textDim, fontSize: 12, cursor: 'pointer' }}>취소</button>
               <button onClick={submitFanLetter} disabled={letterSubmitting} style={{ padding: '6px 14px', borderRadius: 8, border: 'none', background: t.accent, color: '#fff', fontSize: 12, fontWeight: 600, cursor: 'pointer', opacity: letterSubmitting ? 0.5 : 1 }}>{letterSubmitting ? '전송 중...' : '보내기'}</button>
             </div>
           </div>


### PR DESCRIPTION
## 작업 배경
이번 PR은 시연/배포 환경과 팬레터 업로드 플로우에서 드러난 문제를 정리하는 데 초점을 맞췄습니다.

특히
- showcase 시드 비밀번호가 예시/워크플로우에 하드코딩되어 있던 부분
- 고정 artistId/slug 시드가 기존 데이터와 충돌할 수 있던 부분
- multipart 업로드 실패가 프론트에서 일반 500처럼 보이던 부분
- 팬레터 작성 UI가 실제 백엔드 제약과 완전히 맞지 않던 부분
을 함께 보강했습니다.

## 주요 변경 사항

### 1. showcase 시드 비밀번호 하드코딩 제거
- `.env.example`에서 `APP_SEED_SHOWCASE_PASSWORD` 기본값 제거
- showcase 시드는 격리된 시연 환경에서만 켜도록 주석 보강
- GitHub Actions 배포 워크플로우에서
  - `APP_SEED_SHOWCASE_DATA`는 vars
  - `APP_SEED_SHOWCASE_PASSWORD`는 secrets
  로 주입하도록 수정
- 워크플로우 내부 `.env` 생성 시 더 이상 `true / demo1234!`를 하드코딩하지 않음

### 2. showcase 시더 안전성 보강
- `DeployShowcaseDataSeeder`에서 showcase password 기본 fallback 제거
- `app.seed.showcase-data=true`이지만 `app.seed.showcase-password`가 비어 있으면
  시드를 실행하지 않고 skip 하도록 변경
- `ensureArtist()` 반환 타입을 `Optional<Artist>`로 변경
- 아래 케이스에서는 해당 artist 시드를 skip 하도록 수정
  - 같은 고정 artistId에 이미 다른 slug가 연결된 경우
  - 같은 showcase slug가 이미 다른 artistId에 연결된 경우
- 시드 완료 로그도
  - seeded artist 수
  - skipped artist 수
  - seeded artist member 수
  기준으로 더 명확히 출력

### 3. multipart 업로드 에러 처리 명확화
- `GlobalExceptionHandler`
  - `MaxUploadSizeExceededException` 처리 추가
    - `ArtistContentErrorCode.MEDIA_SIZE_EXCEEDED`로 응답
  - `MultipartException` 처리 추가
    - boundary 누락/형식 오류 등을 400으로 반환
- `application.yml`
  - `spring.servlet.multipart.max-file-size=100MB`
  - `spring.servlet.multipart.max-request-size=120MB`
  설정 추가

### 4. 프론트 API 클라이언트 에러 파싱 보강
- `api-client.jsx`
- 응답 `content-type`이 `application/json`이 아닐 경우
  `response.text()` fallback으로 에러 메시지를 읽도록 수정
- multipart 오류/텍스트 응답이 와도 프론트에서 메시지를 안전하게 표시 가능

### 5. 팬레터 작성 UI를 백엔드 계약에 맞게 수정
- `desktop-profile.jsx`
- 팬레터 작성 시 이미지 선택을 필수로 변경
- 수신 타입이 `ARTIST_MEMBER`일 경우
  - `recipientArtistMemberId` 선택 UI 추가
  - 선택값이 없으면 제출 차단
- artist member 목록은 `sortOrder` 기준으로 정렬
- 멤버 지정 모드로 바꾸면 첫 멤버를 자동 선택
- 제출 시 `recipientArtistMemberId`를 `FormData`에 함께 전송
- 제출 성공 후
  - recipientType
  - recipientArtistMemberId
  - image
  상태 초기화
- 실패 alert에 `code/status` 디버그 suffix를 함께 표시
- 안내 문구도
  - `이미지 선택 (필수)`
  - `팬레터는 이미지 1장 필수`
  로 변경

## 기대 효과
- 시연 환경에서 showcase seed 비밀번호를 안전하게 주입할 수 있음
- 기존 artist 데이터와 충돌하는 showcase 시드가 전체를 망치지 않고 안전하게 skip 됨
- 파일 크기 초과 / multipart 형식 오류를 프론트에서 원인 있는 에러로 인지 가능
- 팬레터 작성 UI와 백엔드 제약이 맞춰져 업로드 실패/누락 케이스 감소

## 리뷰 포인트
- `APP_SEED_SHOWCASE_PASSWORD`가 비어 있으면 시드가 실제로 skip 되는지
- 기존 데이터와 artistId/slug가 충돌할 때 의도대로 skip 되는지
- multipart 에러가 500이 아니라 의미 있는 4xx/도메인 에러로 내려가는지
- 팬레터 작성 시
  - 이미지 미선택
  - 멤버 지정인데 recipient 미선택
  케이스가 프론트에서 먼저 잘 차단되는지
- non-JSON 에러 응답에서도 프론트 alert 메시지가 정상 노출되는지
